### PR TITLE
Add `ParamSpec` annotation to `term()` helper, `EventMode` type

### DIFF
--- a/src/mjlab/managers/event_manager.py
+++ b/src/mjlab/managers/event_manager.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-import torch
 from typing import TYPE_CHECKING
-from prettytable import PrettyTable
-from mjlab.managers.manager_base import ManagerBase
-from mjlab.managers.manager_term_config import EventTermCfg
 
+import torch
+from mjlab.managers.manager_base import ManagerBase
+from mjlab.managers.manager_term_config import EventMode, EventTermCfg
 from mjlab.utils.dataclasses import get_terms
+from prettytable import PrettyTable
 
 if TYPE_CHECKING:
   from mjlab.envs.manager_based_env import ManagerBasedEnv
@@ -16,9 +16,9 @@ class EventManager(ManagerBase):
   _env: ManagerBasedEnv
 
   def __init__(self, cfg: object, env: ManagerBasedEnv):
-    self._mode_term_names: dict[str, list[str]] = dict()
-    self._mode_term_cfgs: dict[str, list[EventTermCfg]] = dict()
-    self._mode_class_term_cfgs: dict[str, list[EventTermCfg]] = dict()
+    self._mode_term_names: dict[EventMode, list[str]] = dict()
+    self._mode_term_cfgs: dict[EventMode, list[EventTermCfg]] = dict()
+    self._mode_class_term_cfgs: dict[EventMode, list[EventTermCfg]] = dict()
 
     super().__init__(cfg=cfg, env=env)
 
@@ -46,11 +46,11 @@ class EventManager(ManagerBase):
   # Properties.
 
   @property
-  def active_terms(self) -> dict[str, list[str]]:
+  def active_terms(self) -> dict[EventMode, list[str]]:
     return self._mode_term_names
 
   @property
-  def available_modes(self) -> list[str]:
+  def available_modes(self) -> list[EventMode]:
     return list(self._mode_term_names.keys())
 
   # Methods.
@@ -75,7 +75,7 @@ class EventManager(ManagerBase):
 
   def apply(
     self,
-    mode: str,
+    mode: EventMode,
     env_ids: torch.Tensor | slice | None = None,
     dt: float | None = None,
     global_env_step_count: int | None = None,

--- a/src/mjlab/managers/manager_base.py
+++ b/src/mjlab/managers/manager_base.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 import abc
-from typing import TYPE_CHECKING, Any, Sequence
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any
 
 import torch
-
 from mjlab.managers.scene_entity_config import SceneEntityCfg
 
 if TYPE_CHECKING:
@@ -63,7 +63,7 @@ class ManagerBase(abc.ABC):
 
   @property
   @abc.abstractmethod
-  def active_terms(self) -> list[str] | dict[str, list[str]]:
+  def active_terms(self) -> list[str] | dict[Any, list[str]]:
     raise NotImplementedError
 
   # Methods.

--- a/src/mjlab/managers/manager_term_config.py
+++ b/src/mjlab/managers/manager_term_config.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Callable, ParamSpec, Type, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, Literal, ParamSpec, TypeVar
 
 import torch
 
@@ -66,11 +66,14 @@ class CurriculumTermCfg(ManagerTermBaseCfg):
 ##
 
 
+EventMode = Literal["startup", "reset", "interval"]
+
+
 @dataclass(kw_only=True)
 class EventTermCfg(ManagerTermBaseCfg):
   """Configuration for an event term."""
 
-  mode: str
+  mode: EventMode
   interval_range_s: tuple[float, float] | None = None
   is_global_time: bool = False
   min_step_count_between_reset: int = 0


### PR DESCRIPTION
<img width="919" height="399" alt="image" src="https://github.com/user-attachments/assets/94c53899-1bd3-4221-82a7-9e45b0b31b19" />

----

Missing args now raise errors:

<img width="919" height="399" alt="image" src="https://github.com/user-attachments/assets/d875a6fa-d094-4e49-ab26-99d762296a2a" />

----

LSP completions work too:

<img width="919" height="399" alt="image" src="https://github.com/user-attachments/assets/eda73700-8425-43e0-94bc-d15f45df6ac6" />
