### PR TITLE
Adds mjlab.tasks import for env registration

### DIFF
--- a/scripts/velocity/rl/play.py
+++ b/scripts/velocity/rl/play.py
@@ -9,6 +9,7 @@ import torch
 import tyro
 from rsl_rl.runners import OnPolicyRunner
 
+import mjlab.tasks  # noqa: F401
 from mjlab.rl import RslRlVecEnvWrapper
 from mjlab.third_party.isaaclab.isaaclab_tasks.utils.parse_cfg import (
   load_cfg_from_registry,

--- a/scripts/velocity/rl/train.py
+++ b/scripts/velocity/rl/train.py
@@ -10,6 +10,7 @@ import torch
 import tyro
 from rsl_rl.runners import OnPolicyRunner
 
+import mjlab.tasks  # noqa: F401
 from mjlab.rl import RslRlVecEnvWrapper
 from mjlab.third_party.isaaclab.isaaclab_tasks.utils.parse_cfg import (
   load_cfg_from_registry,


### PR DESCRIPTION
While trying to run this command `uv run --extra rl scripts/velocity/rl/train.py --task Velocity-Flat-Unitree-Go1-v0`, I ran into the following error:

```
spring@pal-springbasestation:~/mjlab$ uv run --extra rl scripts/velocity/rl/train.py --task Velocity-Flat-Unitree-Go1-v0
Traceback (most recent call last):
  File "/home/spring/mjlab/scripts/velocity/rl/train.py", line 104, in <module>
    tyro.cli(main)
    ~~~~~~~~^^^^^^
  File "/home/spring/mjlab/.venv/lib/python3.13/site-packages/tyro/_cli.py", line 230, in cli
    return run_with_args_from_cli()
  File "/home/spring/mjlab/scripts/velocity/rl/train.py", line 39, in main
    env_cfg = load_cfg_from_registry(task, "env_cfg_entry_point")
  File "/home/spring/mjlab/src/mjlab/third_party/isaaclab/isaaclab_tasks/utils/parse_cfg.py", line 54, in load_cfg_from_registry
    cfg_entry_point = gym.spec(task_name.split(":")[-1]).kwargs.get(entry_point_key)
                      ~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/spring/mjlab/.venv/lib/python3.13/site-packages/gymnasium/envs/registration.py", line 1000, in spec
    _check_version_exists(ns, name, version)
    ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "/home/spring/mjlab/.venv/lib/python3.13/site-packages/gymnasium/envs/registration.py", line 392, in _check_version_exists
    _check_name_exists(ns, name)
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/home/spring/mjlab/.venv/lib/python3.13/site-packages/gymnasium/envs/registration.py", line 369, in _check_name_exists
    raise error.NameNotFound(
        f"Environment `{name}` doesn't exist{namespace_msg}.{suggestion_msg}"
    )
gymnasium.error.NameNotFound: Environment `Velocity-Flat-Unitree-Go1` doesn't exist.
```

The issue was caused by mjlab.tasks not being imported, so I added it to both the RL play and train scripts. I think it may have been removed by pre-commit, so I added # noqa: F401 to ensure it is kept.
