### PR TITLE
Cleanup tracking task.

### DIFF
--- a/src/mjlab/tasks/tracking/config/g1/flat_env_cfg.py
+++ b/src/mjlab/tasks/tracking/config/g1/flat_env_cfg.py
@@ -28,18 +28,32 @@ class G1FlatEnvCfg(TrackingEnvCfg):
       "right_wrist_yaw_link",
     ]
 
+    self.events.foot_friction.params["asset_cfg"].geom_names = [
+      r"^(left|right)_foot[1-7]_collision$"
+    ]
+    self.events.base_com.params["asset_cfg"].body_names = "torso_link"
+
+    self.terminations.ee_body_pos.params["body_names"] = [
+      "left_ankle_roll_link",
+      "right_ankle_roll_link",
+      "left_wrist_yaw_link",
+      "right_wrist_yaw_link",
+    ]
+
+    self.viewer.body_name = "torso_link"
+
 
 @dataclass
 class G1FlatEnvCfg_PLAY(G1FlatEnvCfg):
   def __post_init__(self):
     super().__post_init__()
 
-    self.observations.policy.enable_corruption = False
-
-    self.events.push_robot = None
-
+    # Disable RSI randomization.
     self.commands.motion.pose_range = {}
     self.commands.motion.velocity_range = {}
+
+    # Always start from beginning of motion.
     self.commands.motion.start_from_beginning = True
 
-    self.episode_length_s = int(1e9)  # effectively infinite episode length
+    # Effectively infinite episode length.
+    self.episode_length_s = int(1e9)

--- a/src/mjlab/tasks/tracking/config/g1/rl_cfg.py
+++ b/src/mjlab/tasks/tracking/config/g1/rl_cfg.py
@@ -35,7 +35,7 @@ class G1FlatPPORunnerCfg(RslRlOnPolicyRunnerCfg):
       max_grad_norm=1.0,
     )
   )
-  experiment_name: str = field(default="g1_tracking")
-  save_interval: int = field(default=500)
-  num_steps_per_env: int = field(default=24)
-  max_iterations: int = field(default=10_000)
+  experiment_name: str = "g1_tracking"
+  save_interval: int = 500
+  num_steps_per_env: int = 24
+  max_iterations: int = 10_000

--- a/src/mjlab/tasks/tracking/tracking_env_cfg.py
+++ b/src/mjlab/tasks/tracking/tracking_env_cfg.py
@@ -40,7 +40,7 @@ SCENE_CFG = SceneCfg(
 VIEWER_CONFIG = ViewerConfig(
   origin_type=ViewerConfig.OriginType.ASSET_BODY,
   asset_name="robot",
-  body_name="torso_link",
+  body_name="",  # Override in robot specific cfg.
   distance=3.0,
   elevation=-5.0,
   azimuth=90.0,
@@ -64,7 +64,7 @@ class CommandsCfg:
     },
     velocity_range=VELOCITY_RANGE,
     joint_position_range=(-0.1, 0.1),
-    # Placeholders.
+    # Override in robot specific cfg.
     motion_file="",
     reference_body="",
     body_names=[],
@@ -159,7 +159,7 @@ class EventCfg:
     mode="startup",
     func=mdp.randomize_field,
     params={
-      "asset_cfg": SceneEntityCfg("robot", body_names="torso_link"),
+      "asset_cfg": SceneEntityCfg("robot", body_names=[]),  # Override in robot cfg.
       "operation": "add",
       "field": "body_ipos",
       "ranges": {
@@ -185,9 +185,7 @@ class EventCfg:
     mode="startup",
     func=mdp.randomize_field,
     params={
-      "asset_cfg": SceneEntityCfg(
-        "robot", geom_names=[r"^(left|right)_foot[1-7]_collision$"]
-      ),
+      "asset_cfg": SceneEntityCfg("robot", geom_names=[]),  # Override in robot cfg.
       "operation": "abs",
       "field": "geom_friction",
       "ranges": (0.3, 1.2),
@@ -279,19 +277,9 @@ class TerminationsCfg:
     params={
       "command_name": "motion",
       "threshold": 0.25,
-      "body_names": [
-        "left_ankle_roll_link",
-        "right_ankle_roll_link",
-        "left_wrist_yaw_link",
-        "right_wrist_yaw_link",
-      ],
+      "body_names": [],  # Override in robot cfg.
     },
   )
-
-
-@dataclass
-class CurriculumCfg:
-  pass
 
 
 SIM_CFG = SimulationCfg(
@@ -314,8 +302,7 @@ class TrackingEnvCfg(ManagerBasedRlEnvCfg):
   rewards: RewardCfg = field(default_factory=RewardCfg)
   terminations: TerminationsCfg = field(default_factory=TerminationsCfg)
   events: EventCfg = field(default_factory=EventCfg)
-  curriculum: CurriculumCfg = field(default_factory=CurriculumCfg)
   sim: SimulationCfg = field(default_factory=lambda: SIM_CFG)
   viewer: ViewerConfig = field(default_factory=lambda: VIEWER_CONFIG)
-  decimation: int = 4
+  decimation: int = 4  # 50 Hz control frequency.
   episode_length_s: float = 10.0


### PR DESCRIPTION
* Curriculum is now optional, so remove it.
* Move G1 specific things (e.g., body and geom names) to g1 config.
* Remove unnecessary `field(default)` for `int` and `float`.
* Tested with cartwheel motion, see [wandb run](https://wandb.ai/gcbc_researchers/mjlab_alpha/runs/jqbk2e08/overview).