### PR TITLE
Add Apache 2.0 license headers to Python files in `src/mjlab`.

### DIFF
--- a/src/mjlab/__init__.py
+++ b/src/mjlab/__init__.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 from pathlib import Path
 

--- a/src/mjlab/asset_zoo/__init__.py
+++ b/src/mjlab/asset_zoo/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/src/mjlab/asset_zoo/robots/__init__.py
+++ b/src/mjlab/asset_zoo/robots/__init__.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from mjlab.asset_zoo.robots.unitree_g1.g1_constants import G1_ROBOT_CFG
 from mjlab.asset_zoo.robots.unitree_go1.go1_constants import GO1_ROBOT_CFG
 

--- a/src/mjlab/asset_zoo/robots/unitree_g1/__init__.py
+++ b/src/mjlab/asset_zoo/robots/unitree_g1/__init__.py
@@ -1,1 +1,15 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Unitree G1 humanoid."""

--- a/src/mjlab/asset_zoo/robots/unitree_g1/g1_constants.py
+++ b/src/mjlab/asset_zoo/robots/unitree_g1/g1_constants.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Unitree G1 constants."""
 
 from pathlib import Path

--- a/src/mjlab/asset_zoo/robots/unitree_go1/__init__.py
+++ b/src/mjlab/asset_zoo/robots/unitree_go1/__init__.py
@@ -1,1 +1,15 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Unitree Go1 quadruped."""

--- a/src/mjlab/asset_zoo/robots/unitree_go1/go1_constants.py
+++ b/src/mjlab/asset_zoo/robots/unitree_go1/go1_constants.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Unitree Go1 constants."""
 
 from pathlib import Path

--- a/src/mjlab/entity/__init__.py
+++ b/src/mjlab/entity/__init__.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from mjlab.entity.data import EntityData
 from mjlab.entity.entity import (
   Entity,

--- a/src/mjlab/entity/data.py
+++ b/src/mjlab/entity/data.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/src/mjlab/entity/entity.py
+++ b/src/mjlab/entity/entity.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field

--- a/src/mjlab/envs/__init__.py
+++ b/src/mjlab/envs/__init__.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from mjlab.envs.manager_based_env import ManagerBasedEnv, ManagerBasedEnvCfg
 from mjlab.envs.manager_based_rl_env import ManagerBasedRlEnv, ManagerBasedRlEnvCfg
 from mjlab.envs.types import VecEnvObs, VecEnvStepReturn

--- a/src/mjlab/envs/manager_based_env.py
+++ b/src/mjlab/envs/manager_based_env.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from dataclasses import dataclass, field
 from typing import Any
 

--- a/src/mjlab/envs/manager_based_rl_env.py
+++ b/src/mjlab/envs/manager_based_rl_env.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import math
 from dataclasses import dataclass
 from typing import Any

--- a/src/mjlab/envs/mdp/__init__.py
+++ b/src/mjlab/envs/mdp/__init__.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from .actions import *  # noqa: F403
 from .events import *  # noqa: F403
 from .observations import *  # noqa: F403

--- a/src/mjlab/envs/mdp/actions/__init__.py
+++ b/src/mjlab/envs/mdp/actions/__init__.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from mjlab.envs.mdp.actions.actions_config import JointActionCfg, JointPositionActionCfg
 from mjlab.envs.mdp.actions.joint_actions import JointPositionAction
 

--- a/src/mjlab/envs/mdp/actions/actions_config.py
+++ b/src/mjlab/envs/mdp/actions/actions_config.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from dataclasses import dataclass
 
 from mjlab.envs.mdp.actions import joint_actions

--- a/src/mjlab/envs/mdp/actions/joint_actions.py
+++ b/src/mjlab/envs/mdp/actions/joint_actions.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/src/mjlab/envs/mdp/events.py
+++ b/src/mjlab/envs/mdp/events.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Useful methods for MDP events."""
 
 from __future__ import annotations

--- a/src/mjlab/envs/mdp/observations.py
+++ b/src/mjlab/envs/mdp/observations.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Useful methods for MDP observations."""
 
 from __future__ import annotations

--- a/src/mjlab/envs/mdp/rewards.py
+++ b/src/mjlab/envs/mdp/rewards.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Useful methods for MPD rewards."""
 
 from __future__ import annotations

--- a/src/mjlab/envs/mdp/terminations.py
+++ b/src/mjlab/envs/mdp/terminations.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Useful methods for MPD terminations."""
 
 from __future__ import annotations

--- a/src/mjlab/envs/types.py
+++ b/src/mjlab/envs/types.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import Dict
 
 import torch

--- a/src/mjlab/managers/__init__.py
+++ b/src/mjlab/managers/__init__.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Environment managers."""
 
 from mjlab.managers.command_manager import (

--- a/src/mjlab/managers/action_manager.py
+++ b/src/mjlab/managers/action_manager.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Action manager for processing actions sent to the environment."""
 
 from __future__ import annotations

--- a/src/mjlab/managers/command_manager.py
+++ b/src/mjlab/managers/command_manager.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Command manager for generating and updating commands."""
 
 from __future__ import annotations

--- a/src/mjlab/managers/curriculum_manager.py
+++ b/src/mjlab/managers/curriculum_manager.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Curriculum manager for updating environment quantities subject to a training curriculum."""
 
 from __future__ import annotations

--- a/src/mjlab/managers/event_manager.py
+++ b/src/mjlab/managers/event_manager.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Event manager for orchestrating operations based on different simulation events."""
 
 from __future__ import annotations

--- a/src/mjlab/managers/manager_base.py
+++ b/src/mjlab/managers/manager_base.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import annotations
 
 import abc

--- a/src/mjlab/managers/manager_term_config.py
+++ b/src/mjlab/managers/manager_term_config.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field

--- a/src/mjlab/managers/observation_manager.py
+++ b/src/mjlab/managers/observation_manager.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Observation manager for computing observations."""
 
 from typing import Sequence

--- a/src/mjlab/managers/reward_manager.py
+++ b/src/mjlab/managers/reward_manager.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Reward manager for computing reward signals."""
 
 from __future__ import annotations

--- a/src/mjlab/managers/scene_entity_config.py
+++ b/src/mjlab/managers/scene_entity_config.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from dataclasses import dataclass, field
 
 from mjlab.entity import Entity

--- a/src/mjlab/managers/termination_manager.py
+++ b/src/mjlab/managers/termination_manager.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Termination manager for computing done signals."""
 
 from __future__ import annotations

--- a/src/mjlab/rl/__init__.py
+++ b/src/mjlab/rl/__init__.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from mjlab.rl.config import (
   RslRlBaseRunnerCfg,
   RslRlOnPolicyRunnerCfg,

--- a/src/mjlab/rl/config.py
+++ b/src/mjlab/rl/config.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """RSL-RL configuration."""
 
 from dataclasses import dataclass, field

--- a/src/mjlab/rl/vecenv_wrapper.py
+++ b/src/mjlab/rl/vecenv_wrapper.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import Any, cast
 
 import gymnasium as gym

--- a/src/mjlab/scene/__init__.py
+++ b/src/mjlab/scene/__init__.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from mjlab.scene.scene import Scene, SceneCfg
 
 __all__ = ["Scene", "SceneCfg"]

--- a/src/mjlab/scene/scene.py
+++ b/src/mjlab/scene/scene.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any

--- a/src/mjlab/scripts/csv_to_npz.py
+++ b/src/mjlab/scripts/csv_to_npz.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import Any
 
 import numpy as np

--- a/src/mjlab/scripts/demo.py
+++ b/src/mjlab/scripts/demo.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Script to run a tracking demo with a pretrained policy.
 
 This demo downloads a pretrained checkpoint and motion file from cloud storage

--- a/src/mjlab/scripts/gcs.py
+++ b/src/mjlab/scripts/gcs.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import hashlib
 import tempfile
 from pathlib import Path

--- a/src/mjlab/scripts/list_envs.py
+++ b/src/mjlab/scripts/list_envs.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Script to list MJLab environments."""
 
 import gymnasium as gym

--- a/src/mjlab/scripts/play.py
+++ b/src/mjlab/scripts/play.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Script to play RL agent with RSL-RL."""
 
 from dataclasses import asdict

--- a/src/mjlab/scripts/train.py
+++ b/src/mjlab/scripts/train.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Script to train RL agent with RSL-RL."""
 
 import os

--- a/src/mjlab/sim/__init__.py
+++ b/src/mjlab/sim/__init__.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from mjlab.sim.sim import MujocoCfg, RenderCfg, Simulation, SimulationCfg
 from mjlab.sim.sim_data import TorchArray, WarpBridge
 

--- a/src/mjlab/sim/randomization.py
+++ b/src/mjlab/sim/randomization.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import Any, List
 
 import mujoco_warp as mjwarp

--- a/src/mjlab/sim/sim.py
+++ b/src/mjlab/sim/sim.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Literal, cast
 

--- a/src/mjlab/sim/sim_data.py
+++ b/src/mjlab/sim/sim_data.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Bridge for seamless PyTorch-Warp interoperability with zero-copy memory sharing.
 
 Provides automatic wrapping of Warp arrays as PyTorch-compatible objects while

--- a/src/mjlab/tasks/__init__.py
+++ b/src/mjlab/tasks/__init__.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from mjlab.third_party.isaaclab.isaaclab_tasks.utils.importer import import_packages
 
 _BLACKLIST_PKGS = ["utils", ".mdp"]

--- a/src/mjlab/tasks/tracking/__init__.py
+++ b/src/mjlab/tasks/tracking/__init__.py
@@ -1,1 +1,15 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Motion imitation environments for legged robots."""

--- a/src/mjlab/tasks/tracking/config/__init__.py
+++ b/src/mjlab/tasks/tracking/config/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/src/mjlab/tasks/tracking/config/g1/__init__.py
+++ b/src/mjlab/tasks/tracking/config/g1/__init__.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import gymnasium as gym
 
 gym.register(

--- a/src/mjlab/tasks/tracking/config/g1/flat_env_cfg.py
+++ b/src/mjlab/tasks/tracking/config/g1/flat_env_cfg.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from dataclasses import dataclass, replace
 
 from mjlab.asset_zoo.robots.unitree_g1.g1_constants import G1_ACTION_SCALE, G1_ROBOT_CFG

--- a/src/mjlab/tasks/tracking/config/g1/rl_cfg.py
+++ b/src/mjlab/tasks/tracking/config/g1/rl_cfg.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from dataclasses import dataclass, field
 
 from mjlab.rl import (

--- a/src/mjlab/tasks/tracking/mdp/__init__.py
+++ b/src/mjlab/tasks/tracking/mdp/__init__.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from mjlab.envs.mdp import *  # noqa: F401, F403
 
 from .commands import *  # noqa: F403

--- a/src/mjlab/tasks/tracking/mdp/commands.py
+++ b/src/mjlab/tasks/tracking/mdp/commands.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import annotations
 
 import copy

--- a/src/mjlab/tasks/tracking/mdp/observations.py
+++ b/src/mjlab/tasks/tracking/mdp/observations.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, cast

--- a/src/mjlab/tasks/tracking/mdp/rewards.py
+++ b/src/mjlab/tasks/tracking/mdp/rewards.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional, cast

--- a/src/mjlab/tasks/tracking/mdp/terminations.py
+++ b/src/mjlab/tasks/tracking/mdp/terminations.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional, cast

--- a/src/mjlab/tasks/tracking/rl/__init__.py
+++ b/src/mjlab/tasks/tracking/rl/__init__.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from mjlab.tasks.tracking.rl.runner import MotionTrackingOnPolicyRunner
 
 __all__ = ["MotionTrackingOnPolicyRunner"]

--- a/src/mjlab/tasks/tracking/rl/exporter.py
+++ b/src/mjlab/tasks/tracking/rl/exporter.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 from typing import cast
 

--- a/src/mjlab/tasks/tracking/rl/runner.py
+++ b/src/mjlab/tasks/tracking/rl/runner.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 
 import wandb

--- a/src/mjlab/tasks/tracking/tracking_env_cfg.py
+++ b/src/mjlab/tasks/tracking/tracking_env_cfg.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Motion mimic task configuration.
 
 This module defines the base configuration for motion mimic tasks.

--- a/src/mjlab/tasks/velocity/__init__.py
+++ b/src/mjlab/tasks/velocity/__init__.py
@@ -1,1 +1,15 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Velocity tracking environments for legged robots."""

--- a/src/mjlab/tasks/velocity/config/__init__.py
+++ b/src/mjlab/tasks/velocity/config/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/src/mjlab/tasks/velocity/config/g1/__init__.py
+++ b/src/mjlab/tasks/velocity/config/g1/__init__.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import gymnasium as gym
 
 gym.register(

--- a/src/mjlab/tasks/velocity/config/g1/flat_env_cfg.py
+++ b/src/mjlab/tasks/velocity/config/g1/flat_env_cfg.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from dataclasses import dataclass
 
 from mjlab.tasks.velocity.config.g1.rough_env_cfg import (

--- a/src/mjlab/tasks/velocity/config/g1/rl_cfg.py
+++ b/src/mjlab/tasks/velocity/config/g1/rl_cfg.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from dataclasses import dataclass, field
 
 from mjlab.rl import (

--- a/src/mjlab/tasks/velocity/config/g1/rough_env_cfg.py
+++ b/src/mjlab/tasks/velocity/config/g1/rough_env_cfg.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from dataclasses import dataclass, replace
 
 from mjlab.asset_zoo.robots.unitree_g1.g1_constants import (

--- a/src/mjlab/tasks/velocity/config/go1/__init__.py
+++ b/src/mjlab/tasks/velocity/config/go1/__init__.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import gymnasium as gym
 
 gym.register(

--- a/src/mjlab/tasks/velocity/config/go1/flat_env_cfg.py
+++ b/src/mjlab/tasks/velocity/config/go1/flat_env_cfg.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from dataclasses import dataclass
 
 from mjlab.tasks.velocity.config.go1.rough_env_cfg import (

--- a/src/mjlab/tasks/velocity/config/go1/rl_cfg.py
+++ b/src/mjlab/tasks/velocity/config/go1/rl_cfg.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from dataclasses import dataclass, field
 
 from mjlab.rl import (

--- a/src/mjlab/tasks/velocity/config/go1/rough_env_cfg.py
+++ b/src/mjlab/tasks/velocity/config/go1/rough_env_cfg.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from dataclasses import dataclass, replace
 
 from mjlab.asset_zoo.robots.unitree_go1.go1_constants import (

--- a/src/mjlab/tasks/velocity/mdp/__init__.py
+++ b/src/mjlab/tasks/velocity/mdp/__init__.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from mjlab.envs.mdp import *  # noqa: F401, F403
 
 from .curriculums import *  # noqa: F403

--- a/src/mjlab/tasks/velocity/mdp/curriculums.py
+++ b/src/mjlab/tasks/velocity/mdp/curriculums.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, TypedDict, cast

--- a/src/mjlab/tasks/velocity/mdp/rewards.py
+++ b/src/mjlab/tasks/velocity/mdp/rewards.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/src/mjlab/tasks/velocity/mdp/velocity_command.py
+++ b/src/mjlab/tasks/velocity/mdp/velocity_command.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field

--- a/src/mjlab/tasks/velocity/rl/__init__.py
+++ b/src/mjlab/tasks/velocity/rl/__init__.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from mjlab.tasks.velocity.rl.exporter import (
   attach_onnx_metadata,
   export_velocity_policy_as_onnx,

--- a/src/mjlab/tasks/velocity/rl/exporter.py
+++ b/src/mjlab/tasks/velocity/rl/exporter.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 
 import onnx

--- a/src/mjlab/tasks/velocity/rl/runner.py
+++ b/src/mjlab/tasks/velocity/rl/runner.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 
 import wandb

--- a/src/mjlab/tasks/velocity/velocity_env_cfg.py
+++ b/src/mjlab/tasks/velocity/velocity_env_cfg.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Velocity tracking task configuration.
 
 This module defines the base configuration for velocity tracking tasks.

--- a/src/mjlab/terrains/__init__.py
+++ b/src/mjlab/terrains/__init__.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from mjlab.terrains.heightfield_terrains import (
   HfPyramidSlopedTerrainCfg,
   HfRandomUniformTerrainCfg,

--- a/src/mjlab/terrains/config.py
+++ b/src/mjlab/terrains/config.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import mujoco
 
 import mjlab.terrains as terrain_gen

--- a/src/mjlab/terrains/heightfield_terrains.py
+++ b/src/mjlab/terrains/heightfield_terrains.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Terrains composed of heightfields.
 
 This module provides terrain generation functionality using heightfields,

--- a/src/mjlab/terrains/primitive_terrains.py
+++ b/src/mjlab/terrains/primitive_terrains.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Terrains composed of primitive geometries.
 
 This module provides terrain generation functionality using primitive geometries,

--- a/src/mjlab/terrains/terrain_generator.py
+++ b/src/mjlab/terrains/terrain_generator.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import annotations
 
 import abc

--- a/src/mjlab/terrains/terrain_importer.py
+++ b/src/mjlab/terrains/terrain_importer.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/src/mjlab/terrains/utils.py
+++ b/src/mjlab/terrains/utils.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Utility functions for terrain generation.
 
 References:

--- a/src/mjlab/third_party/__init__.py
+++ b/src/mjlab/third_party/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/src/mjlab/utils/__init__.py
+++ b/src/mjlab/utils/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/src/mjlab/utils/actuator.py
+++ b/src/mjlab/utils/actuator.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Electric actuator utilities."""
 
 import math

--- a/src/mjlab/utils/color.py
+++ b/src/mjlab/utils/color.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Color manipulation utilities for RGB/HSV conversions and transformations."""
 
 from typing import NamedTuple, Tuple

--- a/src/mjlab/utils/dataclasses.py
+++ b/src/mjlab/utils/dataclasses.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from dataclasses import fields, is_dataclass
 from typing import Any, Dict, Type
 

--- a/src/mjlab/utils/logging.py
+++ b/src/mjlab/utils/logging.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Logging utilities for colored terminal output."""
 
 import sys

--- a/src/mjlab/utils/mujoco.py
+++ b/src/mjlab/utils/mujoco.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import mujoco
 
 

--- a/src/mjlab/utils/noise/__init__.py
+++ b/src/mjlab/utils/noise/__init__.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from mjlab.utils.noise.noise_cfg import (
   ConstantNoiseCfg,
   GaussianNoiseCfg,

--- a/src/mjlab/utils/noise/noise_cfg.py
+++ b/src/mjlab/utils/noise/noise_cfg.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import annotations
 
 import abc

--- a/src/mjlab/utils/noise/noise_model.py
+++ b/src/mjlab/utils/noise/noise_model.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/src/mjlab/utils/os.py
+++ b/src/mjlab/utils/os.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import re
 from pathlib import Path
 from typing import Any, Dict, Union

--- a/src/mjlab/utils/random.py
+++ b/src/mjlab/utils/random.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 import random
 

--- a/src/mjlab/utils/spec.py
+++ b/src/mjlab/utils/spec.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """MjSpec utils."""
 
 import mujoco

--- a/src/mjlab/utils/spec_config.py
+++ b/src/mjlab/utils/spec_config.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Literal

--- a/src/mjlab/utils/string.py
+++ b/src/mjlab/utils/string.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import re
 from typing import Any, Dict, List, Pattern, Tuple
 

--- a/src/mjlab/utils/torch.py
+++ b/src/mjlab/utils/torch.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import torch
 
 

--- a/src/mjlab/viewer/__init__.py
+++ b/src/mjlab/viewer/__init__.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """MJLab viewer module for environment visualization."""
 
 from mjlab.viewer.base import BaseViewer, EnvProtocol, PolicyProtocol, VerbosityLevel

--- a/src/mjlab/viewer/base.py
+++ b/src/mjlab/viewer/base.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Base class for environment viewers."""
 
 from __future__ import annotations

--- a/src/mjlab/viewer/keys.py
+++ b/src/mjlab/viewer/keys.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Key codes for input handling."""
 
 KEY_UNKNOWN = -1

--- a/src/mjlab/viewer/native.py
+++ b/src/mjlab/viewer/native.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Environment viewer built on MuJoCo's passive viewer."""
 
 from __future__ import annotations

--- a/src/mjlab/viewer/viewer_config.py
+++ b/src/mjlab/viewer/viewer_config.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import enum
 from dataclasses import dataclass
 

--- a/src/mjlab/viewer/viser.py
+++ b/src/mjlab/viewer/viser.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Mjlab viewer based on Viser.
 
 Adapted from an MJX visualizer by Chung Min Kim: https://github.com/chungmin99/

--- a/src/mjlab/viewer/viser_conversions.py
+++ b/src/mjlab/viewer/viser_conversions.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Convert MuJoCo mesh data to trimesh format with texture support."""
 
 import mujoco

--- a/src/mjlab/viewer/viser_reward_plotter.py
+++ b/src/mjlab/viewer/viser_reward_plotter.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The MjLab Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Reward plotting functionality for Viser viewer."""
 
 from collections import deque


### PR DESCRIPTION
I used `addlicense` with the following command:

```bash
addlicense -c "The MjLab Developers" -l apache \
    -ignore third_party/** -ignore typings/** \
    src/mjlab/**/*.py
```