### PR TITLE
Update runner.py, fix path handling in runner.py for Windows compatibility

### DIFF
--- a/src/mjlab/tasks/velocity/rl/runner.py
+++ b/src/mjlab/tasks/velocity/rl/runner.py
@@ -18,7 +18,7 @@ class VelocityOnPolicyRunner(OnPolicyRunner):
     super().save(path, infos)
     if self.logger_type in ["wandb"]:
       policy_path = path.split("model")[0]
-      filename = policy_path.split("/")[-2] + ".onnx"
+      filename = os.path.basename(os.path.dirname(policy_path)) + ".onnx"
       if self.alg.policy.actor_obs_normalization:
         normalizer = self.alg.policy.actor_obs_normalizer
       else:


### PR DESCRIPTION
The code previously used `split("/")` which breaks on Windows  because of backslashes in file paths. 
This patch uses `os.path` for cross-platform compatibility.