### PR TITLE
Fix YAML serialization for configs with torch tensors.

### DIFF
--- a/src/mjlab/utils/os.py
+++ b/src/mjlab/utils/os.py
@@ -82,11 +82,6 @@ def _to_yaml_friendly(x: Any) -> Any:
 def dump_yaml(filename: Path, data: Dict, sort_keys: bool = False) -> None:
   """Write a human-readable YAML file.
 
-  - Appends ".yaml" if no suffix is provided.
-  - Recursively converts NumPy arrays, Torch tensors, and dataclass instances
-    into plain Python types (lists/scalars/dicts) before dumping.
-  - Uses yaml.safe_dump to avoid PyYAML’s opaque binary/object tags.
-
   Args:
     filename: Destination path (".yaml" added if missing).
     data: Mapping to serialize.

--- a/tests/test_os.py
+++ b/tests/test_os.py
@@ -20,7 +20,6 @@ def test_dump_yaml_torch_scalars(tmp_path):
   dump_yaml(out, data)
   text = out.read_text(encoding="utf-8")
 
-  # Must not have binary tags.
   assert "!!binary" not in text
   assert "42.5" in text
   assert "100" in text
@@ -66,10 +65,8 @@ def test_dump_yaml_velocity_env_config(tmp_path):
 
   text = out.read_text(encoding="utf-8")
 
-  # Critical: no binary or python object tags.
   assert "!!binary" not in text, "Config should not contain binary data"
   assert "!!python" not in text, "Config should not contain Python object tags"
 
-  # Verify it's valid YAML and can be loaded.
   loaded = yaml.safe_load(text)
   assert isinstance(loaded, dict)

--- a/tests/test_os.py
+++ b/tests/test_os.py
@@ -1,0 +1,75 @@
+from dataclasses import asdict, dataclass
+
+import torch
+import yaml
+
+from mjlab.tasks.velocity.velocity_env_cfg import LocomotionVelocityEnvCfg
+from mjlab.utils.os import dump_yaml
+
+
+def test_dump_yaml_torch_scalars(tmp_path):
+  """Torch scalar tensors should serialize as numbers, not binary."""
+  out = tmp_path / "scalars.yaml"
+
+  data = {
+    "float_scalar": torch.tensor(42.5),
+    "int_scalar": torch.tensor(100),
+    "zero_dim": torch.tensor(3.14),
+  }
+
+  dump_yaml(out, data)
+  text = out.read_text(encoding="utf-8")
+
+  # Must not have binary tags.
+  assert "!!binary" not in text
+  assert "42.5" in text
+  assert "100" in text
+
+  loaded = yaml.safe_load(text)
+  assert loaded["float_scalar"] == 42.5
+  assert loaded["int_scalar"] == 100
+  assert abs(loaded["zero_dim"] - 3.14) < 0.01  # Tolerance for float32 precision.
+
+
+def test_dump_yaml_nested_dataclasses(tmp_path):
+  """Nested dataclasses should serialize cleanly."""
+
+  @dataclass
+  class RewardScales:
+    tracking: float = 1.0
+    action_rate: float = -0.01
+
+  @dataclass
+  class Config:
+    rewards: RewardScales
+    max_steps: int = 1000
+
+  cfg = Config(rewards=RewardScales())
+  out = tmp_path / "nested.yaml"
+
+  dump_yaml(out, asdict(cfg))
+  text = out.read_text(encoding="utf-8")
+
+  assert "!!python" not in text
+  loaded = yaml.safe_load(text)
+  assert loaded["rewards"]["tracking"] == 1.0
+  assert loaded["rewards"]["action_rate"] == -0.01
+
+
+def test_dump_yaml_velocity_env_config(tmp_path):
+  """Test that LocomotionVelocityEnvCfg serializes without binary tags."""
+  env_cfg = LocomotionVelocityEnvCfg()
+  env_cfg_dict = asdict(env_cfg)
+
+  out = tmp_path / "params" / "env.yaml"
+  dump_yaml(out, env_cfg_dict)
+
+  text = out.read_text(encoding="utf-8")
+
+  # Critical: no binary or python object tags.
+  assert "!!binary" not in text, "Config should not contain binary data"
+  assert "!!python" not in text, "Config should not contain Python object tags"
+
+  # Verify it's valid YAML and can be loaded.
+  loaded = yaml.safe_load(text)
+  assert isinstance(loaded, dict)


### PR DESCRIPTION
Config dumping was generating binary tags when certain config elements contained torch tensors (e.g. pose reward in velocity task).

This PR:
- Updates `to_yaml` to handle torch scalars properly
- Adds a fallback to `str()` for objects that can't be serialized (enums, slices, functions, etc.)
- Added tests for torch tensors, dataclasses, and `LocomotionVelocityEnvCfg`

YAML configs are now human-readable with no `!!binary` or `!!python` tags.