### PR TITLE
Replace usage of `quat_rotate_inverse` with `quat_apply_inverse`

### DIFF
--- a/src/mjlab/third_party/isaaclab/isaaclab/utils/math.py
+++ b/src/mjlab/third_party/isaaclab/isaaclab/utils/math.py
@@ -817,8 +817,8 @@ def rigid_body_twist_transform(
         - The transformed linear velocity in frame 1. Shape is (N, 3).
         - The transformed angular velocity in frame 1. Shape is (N, 3).
     """
-    w1 = quat_rotate_inverse(q01, w0)
-    v1 = quat_rotate_inverse(q01, v0 + torch.cross(w0, t01, dim=-1))
+    w1 = quat_apply_inverse(q01, w0)
+    v1 = quat_apply_inverse(q01, v0 + torch.cross(w0, t01, dim=-1))
     return v1, w1
 
 


### PR DESCRIPTION
The `quat_rotate_inverse` function isn't implemented in [thirdparty/isaaclab/isaaclab/utils.math.py](https://github.com/mujocolab/mjlab/blob/main/src/mjlab/third_party/isaaclab/isaaclab/utils/math.py) but it is called by the [rigid_body_twist_transform](https://github.com/mujocolab/mjlab/blob/f0b4c4233eb11ba19ade5732aeabd77de953a103/src/mjlab/third_party/isaaclab/isaaclab/utils/math.py#L820-L821) function. 

Since public IsaacLab plans to deprecate `quat_rotate_inverse` in favor of `quat_apply_inverse` ([Ref](https://github.com/isaac-sim/IsaacLab/blob/b7004f44361a442e226142a1e2d297e4c572a29f/source/isaaclab/isaaclab/utils/math.py#L717-L720)) anyway,  this PR replaces the usage of `quat_rotate_inverse` with `quat_apply_inverse` in the `rigid_body_twist_transform` function.