### PR TITLE
Unifies arguments between play and train scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ MUJOCO_GL=egl uv run train Mjlab-Velocity-Flat-Unitree-G1 --env.scene.num-envs 4
 Evaluate a policy while training (fetches latest checkpoint from Weights & Biases):
 
 ```bash
-uv run play --task Mjlab-Velocity-Flat-Unitree-G1-Play --wandb-run-path your-org/mjlab/run-id
+uv run play Mjlab-Velocity-Flat-Unitree-G1-Play --wandb-run-path your-org/mjlab/run-id
 ```
 
 ---
@@ -102,7 +102,7 @@ Train a Unitree G1 to mimic reference motions. mjlab uses [WandB](https://wandb.
 ```bash
 MUJOCO_GL=egl uv run train Mjlab-Tracking-Flat-Unitree-G1 --registry-name your-org/motions/motion-name --env.scene.num-envs 4096
 
-uv run play --task Mjlab-Tracking-Flat-Unitree-G1-Play --wandb-run-path your-org/mjlab/run-id
+uv run play Mjlab-Tracking-Flat-Unitree-G1-Play --wandb-run-path your-org/mjlab/run-id
 ```
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ cu12 = ["torch>=2.7.0"]
 train = "mjlab.scripts.train:main"
 play = "mjlab.scripts.play:main"
 demo = "mjlab.scripts.demo:main"
+list_envs = "mjlab.scripts.list_envs:main"
 
 [[tool.uv.index]]
 url = "https://pypi.org/simple"

--- a/src/mjlab/scripts/demo.py
+++ b/src/mjlab/scripts/demo.py
@@ -4,12 +4,8 @@ This demo downloads a pretrained checkpoint and motion file from cloud storage
 and launches an interactive viewer with a humanoid robot performing a cartwheel.
 """
 
-from functools import partial
-
-import tyro
-
 from mjlab.scripts.gcs import ensure_default_checkpoint, ensure_default_motion
-from mjlab.scripts.play import run_play
+from mjlab.scripts.play import PlayConfig, run_play
 
 
 def main() -> None:
@@ -24,17 +20,15 @@ def main() -> None:
     print("Please check your internet connection and try again.")
     return
 
-  tyro.cli(
-    partial(
-      run_play,
-      task="Mjlab-Tracking-Flat-Unitree-G1-Play",
-      checkpoint_file=checkpoint_path,
-      motion_file=motion_path,
-      num_envs=8,
-      render_all_envs=True,
-      viewer="viser",
-    )
+  play_config = PlayConfig(
+    checkpoint_file=checkpoint_path,
+    motion_file=motion_path,
+    num_envs=8,
+    render_all_envs=True,
+    viewer="viser",
   )
+
+  run_play("Mjlab-Tracking-Flat-Unitree-G1-Play", play_config)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This modifies the play script to handle the argument the same way as the train script (removing the need for `--task`). I also added `list_envs` as a project script, so we can now run `uv run list_envs`.

Closes https://github.com/mujocolab/mjlab/issues/122