### PR TITLE
Fix class-based reward term reset not being called (#170).

### DIFF
--- a/src/mjlab/managers/curriculum_manager.py
+++ b/src/mjlab/managers/curriculum_manager.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
+import inspect
 from typing import TYPE_CHECKING, Any, Sequence
 
 import torch
 from prettytable import PrettyTable
 
-from mjlab.managers.manager_base import ManagerBase, ManagerTermBase
+from mjlab.managers.manager_base import ManagerBase
 from mjlab.managers.manager_term_config import CurriculumTermCfg
 from mjlab.utils.dataclasses import get_terms
 
@@ -98,10 +99,11 @@ class CurriculumManager(ManagerBase):
       if term_cfg is None:
         print(f"term: {term_name} set to None, skipping...")
         continue
+      is_class_term = inspect.isclass(term_cfg.func)
       self._resolve_common_term_cfg(term_name, term_cfg)
       self._term_names.append(term_name)
       self._term_cfgs.append(term_cfg)
-      if isinstance(term_cfg.func, ManagerTermBase):
+      if is_class_term:
         self._class_term_cfgs.append(term_cfg)
 
 

--- a/src/mjlab/managers/event_manager.py
+++ b/src/mjlab/managers/event_manager.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 from typing import TYPE_CHECKING
 
 import torch
@@ -177,6 +178,7 @@ class EventManager(ManagerBase):
       if term_cfg is None:
         print(f"term: {term_name} set to None, skipping...")
         continue
+      is_class_term = inspect.isclass(term_cfg.func)
       self._resolve_common_term_cfg(term_name, term_cfg)
       if term_cfg.mode not in self._mode_term_names:
         self._mode_term_names[term_cfg.mode] = list()
@@ -184,6 +186,8 @@ class EventManager(ManagerBase):
         self._mode_class_term_cfgs[term_cfg.mode] = list()
       self._mode_term_names[term_cfg.mode].append(term_name)
       self._mode_term_cfgs[term_cfg.mode].append(term_cfg)
+      if is_class_term:
+        self._mode_class_term_cfgs[term_cfg.mode].append(term_cfg)
       if term_cfg.mode == "interval":
         if term_cfg.interval_range_s is None:
           raise ValueError(

--- a/src/mjlab/managers/observation_manager.py
+++ b/src/mjlab/managers/observation_manager.py
@@ -1,5 +1,6 @@
 """Observation manager for computing observations."""
 
+import inspect
 from typing import Sequence
 
 import numpy as np
@@ -191,12 +192,15 @@ class ObservationManager(ManagerBase):
           print(f"term: {term_name} set to None, skipping...")
           continue
 
+        is_class_term = inspect.isclass(term_cfg.func)
         self._resolve_common_term_cfg(term_name, term_cfg)
 
         if not group_cfg.enable_corruption:
           term_cfg.noise = None
         self._group_obs_term_names[group_name].append(term_name)
         self._group_obs_term_cfgs[group_name].append(term_cfg)
+        if is_class_term:
+          self._group_obs_class_term_cfgs[group_name].append(term_cfg)
 
         obs_dims = tuple(term_cfg.func(self._env, **term_cfg.params).shape)
         self._group_obs_term_dim[group_name].append(obs_dims[1:])

--- a/src/mjlab/managers/reward_manager.py
+++ b/src/mjlab/managers/reward_manager.py
@@ -107,8 +107,9 @@ class RewardManager(ManagerBase):
       if term_cfg is None:
         print(f"term: {term_name} set to None, skipping...")
         continue
+      is_class_term = inspect.isclass(term_cfg.func)
       self._resolve_common_term_cfg(term_name, term_cfg)
       self._term_names.append(term_name)
       self._term_cfgs.append(term_cfg)
-      if inspect.isclass(term_cfg.func):
+      if is_class_term:
         self._class_term_cfgs.append(term_cfg)

--- a/src/mjlab/managers/termination_manager.py
+++ b/src/mjlab/managers/termination_manager.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
+import inspect
 from typing import TYPE_CHECKING, Sequence
 
 import torch
 from prettytable import PrettyTable
 
-from mjlab.managers.manager_base import ManagerBase, ManagerTermBase
+from mjlab.managers.manager_base import ManagerBase
 from mjlab.managers.manager_term_config import TerminationTermCfg
 from mjlab.utils.dataclasses import get_terms
 
@@ -114,8 +115,9 @@ class TerminationManager(ManagerBase):
       if term_cfg is None:
         print(f"term: {term_name} set to None, skipping...")
         continue
+      is_class_term = inspect.isclass(term_cfg.func)
       self._resolve_common_term_cfg(term_name, term_cfg)
       self._term_names.append(term_name)
       self._term_cfgs.append(term_cfg)
-      if isinstance(term_cfg.func, ManagerTermBase):
+      if is_class_term:
         self._class_term_cfgs.append(term_cfg)


### PR DESCRIPTION
Class-based reward terms (like `feet_air_time`) were not having their `reset()` methods called because `_prepare_terms()` checked `inspect.isclass()` AFTER the class was already instantiated in `_resolve_common_term_cfg()`.

The fix checks if `term_cfg.func` is a class BEFORE instantiation and stores that information to properly populate `_class_term_cfgs`.

Applied the same fix to:
- RewardManager
- TerminationManager
- ObservationManager
- EventManager
- CurriculumManager

ActionManager and CommandManager don't need this fix because they only support class-based terms (ActionTerm/CommandTerm) which are always instantiated via `class_type` and reset is called on all terms directly.

Added tests to verify class-based terms are tracked and reset correctly.

Fixes #170