### PR TITLE
Only track class-based terms with reset methods.

### DIFF
--- a/src/mjlab/managers/curriculum_manager.py
+++ b/src/mjlab/managers/curriculum_manager.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import inspect
 from typing import TYPE_CHECKING, Any, Sequence
 
 import torch
@@ -99,11 +98,10 @@ class CurriculumManager(ManagerBase):
       if term_cfg is None:
         print(f"term: {term_name} set to None, skipping...")
         continue
-      is_class_term = inspect.isclass(term_cfg.func)
       self._resolve_common_term_cfg(term_name, term_cfg)
       self._term_names.append(term_name)
       self._term_cfgs.append(term_cfg)
-      if is_class_term:
+      if hasattr(term_cfg.func, "reset") and callable(term_cfg.func.reset):
         self._class_term_cfgs.append(term_cfg)
 
 

--- a/src/mjlab/managers/event_manager.py
+++ b/src/mjlab/managers/event_manager.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import inspect
 from typing import TYPE_CHECKING
 
 import torch
@@ -178,7 +177,6 @@ class EventManager(ManagerBase):
       if term_cfg is None:
         print(f"term: {term_name} set to None, skipping...")
         continue
-      is_class_term = inspect.isclass(term_cfg.func)
       self._resolve_common_term_cfg(term_name, term_cfg)
       if term_cfg.mode not in self._mode_term_names:
         self._mode_term_names[term_cfg.mode] = list()
@@ -186,7 +184,7 @@ class EventManager(ManagerBase):
         self._mode_class_term_cfgs[term_cfg.mode] = list()
       self._mode_term_names[term_cfg.mode].append(term_name)
       self._mode_term_cfgs[term_cfg.mode].append(term_cfg)
-      if is_class_term:
+      if hasattr(term_cfg.func, "reset") and callable(term_cfg.func.reset):
         self._mode_class_term_cfgs[term_cfg.mode].append(term_cfg)
       if term_cfg.mode == "interval":
         if term_cfg.interval_range_s is None:

--- a/src/mjlab/managers/observation_manager.py
+++ b/src/mjlab/managers/observation_manager.py
@@ -1,6 +1,5 @@
 """Observation manager for computing observations."""
 
-import inspect
 from typing import Sequence
 
 import numpy as np
@@ -192,14 +191,13 @@ class ObservationManager(ManagerBase):
           print(f"term: {term_name} set to None, skipping...")
           continue
 
-        is_class_term = inspect.isclass(term_cfg.func)
         self._resolve_common_term_cfg(term_name, term_cfg)
 
         if not group_cfg.enable_corruption:
           term_cfg.noise = None
         self._group_obs_term_names[group_name].append(term_name)
         self._group_obs_term_cfgs[group_name].append(term_cfg)
-        if is_class_term:
+        if hasattr(term_cfg.func, "reset") and callable(term_cfg.func.reset):
           self._group_obs_class_term_cfgs[group_name].append(term_cfg)
 
         obs_dims = tuple(term_cfg.func(self._env, **term_cfg.params).shape)

--- a/src/mjlab/managers/reward_manager.py
+++ b/src/mjlab/managers/reward_manager.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import inspect
 from typing import TYPE_CHECKING
 
 import torch
@@ -107,9 +106,8 @@ class RewardManager(ManagerBase):
       if term_cfg is None:
         print(f"term: {term_name} set to None, skipping...")
         continue
-      is_class_term = inspect.isclass(term_cfg.func)
       self._resolve_common_term_cfg(term_name, term_cfg)
       self._term_names.append(term_name)
       self._term_cfgs.append(term_cfg)
-      if is_class_term:
+      if hasattr(term_cfg.func, "reset") and callable(term_cfg.func.reset):
         self._class_term_cfgs.append(term_cfg)

--- a/src/mjlab/managers/termination_manager.py
+++ b/src/mjlab/managers/termination_manager.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import inspect
 from typing import TYPE_CHECKING, Sequence
 
 import torch
@@ -115,9 +114,8 @@ class TerminationManager(ManagerBase):
       if term_cfg is None:
         print(f"term: {term_name} set to None, skipping...")
         continue
-      is_class_term = inspect.isclass(term_cfg.func)
       self._resolve_common_term_cfg(term_name, term_cfg)
       self._term_names.append(term_name)
       self._term_cfgs.append(term_cfg)
-      if is_class_term:
+      if hasattr(term_cfg.func, "reset") and callable(term_cfg.func.reset):
         self._class_term_cfgs.append(term_cfg)


### PR DESCRIPTION
Fixes AttributeError when calling reset() on stateless class-based terms (e.g., posture) that don't define a reset method.