### PR TITLE
Fixing cartpole example

### DIFF
--- a/docs/create_new_task.md
+++ b/docs/create_new_task.md
@@ -310,16 +310,6 @@ gym.register(
     "rl_cfg_entry_point": f"{__name__}.cartpole_env_cfg:RslRlOnPolicyRunnerCfg",
   },
 )
-
-gym.register(
-  id="Mjlab-Cartpole-Play",
-  entry_point="mjlab.envs:ManagerBasedRlEnv",
-  disable_env_checker=True,
-  kwargs={
-    "env_cfg_entry_point": f"{__name__}.cartpole_env_cfg:CartPoleEnvCfg",
-    "rl_cfg_entry_point": f"{__name__}.cartpole_env_cfg:RslRlOnPolicyRunnerCfg",
-  },
-)
 ```
 
 ---


### PR DESCRIPTION
Hello,

This PR addresses the following  issues in [create_new_task.md](https://github.com/mujocolab/mjlab/blob/main/docs/create_new_task.md):

* Fixes inconsistent indentation
* Fixes the `play` command
* More importantly, the current tutorial is misleading on the way actuators are handled. An actuator is present in the proposed `.xml` file, and an additional one is added programmatically through mjlab with `stiffness=0.0`. From what I understand, this extra actuator has no effect
  * However, the `init_state` keyframe, automatically added by `_add_initial_state_keyframe`, sets a `ctrl` with the same size as `joint_pos` (because of `key.ctrl = joint_pos`). I believe this should not be the case since `len(ctrl) != len(joint_pos)` in general
  * Thanks to the useless extra actuator, the proposed tutorial works because `ctrl` become of size `2` like `joint_pos`, but I don't think this is a proper solution
  * In this PR, a slight workaround is added such that `init_state` is not created if it exists, I believe there is either a misunderstanding on my side, or that a deeper fix/configuration need to be added, please let me know
  * In this PR, I let the actuator in the `.xml` file and removed the definition in the code (along with the note about it that become irrelevant)

Some suggestions

* Maybe `InitialStateCfg` should contain a `ctrl` field, allowing to specify the `ctrl` value for the initial keyframe manually ?
* It could also be useful to have an option to name a keyframe from the `xml` to be used instead of the `InitialStateCfg` contents (or alternatively a field in `InitialStateCfg` to specify

