### PR TITLE
Support exporter for both pytorch 2.9 and backward

### DIFF
--- a/src/mjlab/tasks/onnx_export.py
+++ b/src/mjlab/tasks/onnx_export.py
@@ -1,0 +1,73 @@
+"""Utility helpers for exporting ONNX policies across MJLab tasks."""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable, Sequence
+
+import torch
+
+
+def export_policy_module_to_onnx(
+  policy_module: torch.nn.Module,
+  inputs: torch.Tensor | Sequence[torch.Tensor],
+  export_path: str,
+  *,
+  input_names: Sequence[str],
+  output_names: Sequence[str],
+  dynamic_shapes: Sequence[dict[int, "torch.export.Dim"]] | None = None,
+  dynamic_axes: dict[str, dict[int, str]] | None = None,
+  opset_version: int = 18,
+  verbose: bool = False,
+) -> None:
+  """Export a policy module to ONNX with compatibility across PyTorch versions."""
+  policy_module.to("cpu")
+  policy_module.eval()
+
+  example_inputs: Iterable[torch.Tensor]
+  if isinstance(inputs, torch.Tensor):
+    example_inputs = (inputs,)
+  else:
+    example_inputs = tuple(inputs)
+
+  export_kwargs: dict[str, object] = {
+    "export_params": True,
+    "opset_version": opset_version,
+    "verbose": verbose,
+  }
+  if _supports_dynamic_shapes(dynamic_shapes):
+    export_kwargs["dynamic_shapes"] = dynamic_shapes
+  else:
+    export_kwargs["dynamic_axes"] = dynamic_axes or {}
+    export_kwargs["dynamo"] = False
+
+  with torch.no_grad():
+    torch.onnx.export(
+      policy_module,
+      example_inputs,
+      export_path,
+      input_names=input_names,
+      output_names=output_names,
+      **export_kwargs,
+    )
+
+
+def _supports_dynamic_shapes(
+  dynamic_shapes: Sequence[dict[int, "torch.export.Dim"]] | None,
+) -> bool:
+  if dynamic_shapes is None:
+    return False
+  export_mod = getattr(torch, "export", None)
+  if export_mod is None or not hasattr(export_mod, "Dim"):
+    return False
+  return _torch_version_ge(2, 9)
+
+
+def _torch_version_ge(major: int, minor: int) -> bool:
+  version_str = getattr(torch, "__version__", "")
+  match = re.match(r"(\\d+)\\.(\\d+)", version_str)
+  if not match:
+    return False
+  current_major = int(match.group(1))
+  current_minor = int(match.group(2))
+  return (current_major, current_minor) >= (major, minor)

--- a/src/mjlab/tasks/tracking/rl/exporter.py
+++ b/src/mjlab/tasks/tracking/rl/exporter.py
@@ -8,6 +8,7 @@ from mjlab.entity import Entity
 from mjlab.envs import ManagerBasedRlEnv
 from mjlab.envs.mdp.actions.joint_actions import JointAction
 from mjlab.tasks.tracking.mdp import MotionCommand
+from mjlab.tasks.onnx_export import export_policy_module_to_onnx
 from mjlab.third_party.isaaclab.isaaclab_rl.rsl_rl.exporter import _OnnxPolicyExporter
 
 
@@ -55,16 +56,12 @@ class _OnnxMotionPolicyExporter(_OnnxPolicyExporter):
     )
 
   def export(self, path, filename):
-    self.to("cpu")
     obs = torch.zeros(1, self.actor[0].in_features)
     time_step = torch.zeros(1, 1)
-    torch.onnx.export(
+    export_policy_module_to_onnx(
       self,
       (obs, time_step),
       os.path.join(path, filename),
-      export_params=True,
-      opset_version=11,
-      verbose=self.verbose,
       input_names=["obs", "time_step"],
       output_names=[
         "actions",
@@ -76,6 +73,8 @@ class _OnnxMotionPolicyExporter(_OnnxPolicyExporter):
         "body_ang_vel_w",
       ],
       dynamic_axes={},
+      opset_version=11,
+      verbose=self.verbose,
     )
 
 

--- a/src/mjlab/tasks/velocity/rl/exporter.py
+++ b/src/mjlab/tasks/velocity/rl/exporter.py
@@ -6,6 +6,7 @@ import torch
 from mjlab.entity import Entity
 from mjlab.envs import ManagerBasedRlEnv
 from mjlab.envs.mdp.actions.joint_actions import JointAction
+from mjlab.tasks.onnx_export import export_policy_module_to_onnx
 from mjlab.third_party.isaaclab.isaaclab_rl.rsl_rl.exporter import _OnnxPolicyExporter
 
 
@@ -19,7 +20,7 @@ def export_velocity_policy_as_onnx(
   if not os.path.exists(path):
     os.makedirs(path, exist_ok=True)
   policy_exporter = _OnnxPolicyExporter(actor_critic, normalizer, verbose)
-  policy_exporter.export(path, filename)
+  _export_policy_to_onnx(policy_exporter, path, filename)
 
 
 def list_to_csv_str(arr, *, decimals: int = 3, delimiter: str = ",") -> str:
@@ -64,3 +65,94 @@ def attach_onnx_metadata(
     model.metadata_props.append(entry)
 
   onnx.save(model, onnx_path)
+
+
+def _export_policy_to_onnx(
+  policy_module: _OnnxPolicyExporter, path: str, filename: str
+) -> None:
+  os.makedirs(path, exist_ok=True)
+  export_path = os.path.join(path, filename)
+
+  dynamic_shapes = _build_dynamic_shapes(policy_module)
+  dynamic_axes = _build_dynamic_axes(policy_module)
+
+  if policy_module.is_recurrent:
+    obs = torch.zeros(1, policy_module.rnn.input_size)
+    h_in = torch.zeros(policy_module.rnn.num_layers, 1, policy_module.rnn.hidden_size)
+
+    if policy_module.rnn_type == "lstm":
+      c_in = torch.zeros(policy_module.rnn.num_layers, 1, policy_module.rnn.hidden_size)
+      export_policy_module_to_onnx(
+        policy_module,
+        (obs, h_in, c_in),
+        export_path,
+        input_names=["obs", "h_in", "c_in"],
+        output_names=["actions", "h_out", "c_out"],
+        dynamic_shapes=dynamic_shapes,
+        dynamic_axes=dynamic_axes,
+        opset_version=18,
+        verbose=policy_module.verbose,
+      )
+    elif policy_module.rnn_type == "gru":
+      export_policy_module_to_onnx(
+        policy_module,
+        (obs, h_in),
+        export_path,
+        input_names=["obs", "h_in"],
+        output_names=["actions", "h_out"],
+        dynamic_shapes=dynamic_shapes,
+        dynamic_axes=dynamic_axes,
+        opset_version=18,
+        verbose=policy_module.verbose,
+      )
+    else:
+      raise NotImplementedError(f"Unsupported RNN type: {policy_module.rnn_type}")
+  else:
+    obs = torch.zeros(1, policy_module.actor[0].in_features)
+    export_policy_module_to_onnx(
+      policy_module,
+      obs,
+      export_path,
+      input_names=["obs"],
+      output_names=["actions"],
+      dynamic_shapes=dynamic_shapes,
+      dynamic_axes=dynamic_axes,
+      opset_version=18,
+      verbose=policy_module.verbose,
+    )
+
+
+def _build_dynamic_shapes(
+  policy_module: _OnnxPolicyExporter,
+) -> tuple[dict[int, "torch.export.Dim"], ...] | None:
+  export_mod = getattr(torch, "export", None)
+  dim_cls = getattr(export_mod, "Dim", None) if export_mod is not None else None
+  if dim_cls is None:
+    return None
+
+  batch_dim = dim_cls("batch")
+  obs_shape = {0: batch_dim}
+
+  if policy_module.is_recurrent:
+    hidden_shape = {1: batch_dim}
+    if policy_module.rnn_type == "lstm":
+      return (obs_shape, hidden_shape, hidden_shape)
+    if policy_module.rnn_type == "gru":
+      return (obs_shape, hidden_shape)
+    raise NotImplementedError(f"Unsupported RNN type: {policy_module.rnn_type}")
+
+  return (obs_shape,)
+
+
+def _build_dynamic_axes(policy_module: _OnnxPolicyExporter) -> dict[str, dict[int, str]]:
+  dynamic_axes: dict[str, dict[int, str]] = {
+    "obs": {0: "batch"},
+    "actions": {0: "batch"},
+  }
+  if policy_module.is_recurrent:
+    dynamic_axes["h_in"] = {1: "batch"}
+    dynamic_axes["h_out"] = {1: "batch"}
+    if policy_module.rnn_type == "lstm":
+      dynamic_axes["c_in"] = {1: "batch"}
+      dynamic_axes["c_out"] = {1: "batch"}
+  return dynamic_axes


### PR DESCRIPTION
As discussed in https://github.com/mujocolab/mjlab/issues/230

Maybe we should update the codes for the long run?

Tested Velocity task on `2.7.0+cu128 and 2.9.0+cu128`, but it seems Tracking task is not so easy to train directly?

Note, not meant to merge directly, since the training phase is not done, I am not so sure whether this actually works or not, all codes are done by codex.

But just raise one question, do we need to upgrade all the libs and behave as needed in the long run.