### PR TITLE
Adds --keyword argument to filter environments in list_envs.py

### DIFF
--- a/src/mjlab/scripts/list_envs.py
+++ b/src/mjlab/scripts/list_envs.py
@@ -15,11 +15,10 @@ def list_environments(keyword: str | None = None):
   """
   prefix_substring = "Mjlab-"
 
-  table = PrettyTable(["#", "Task ID", "Entry Point", "env_cfg_entry_point"])
+  table = PrettyTable(["#", "Task ID", "Env Cfg Entry Point"])
   table.title = "Available Environments in Mjlab"
   table.align["Task ID"] = "l"
-  table.align["Entry Point"] = "l"
-  table.align["env_cfg_entry_point"] = "l"
+  table.align["Env Cfg Entry Point"] = "l"
 
   idx = 0
   for spec in gym.registry.values():
@@ -31,7 +30,7 @@ def list_environments(keyword: str | None = None):
         continue
 
       env_cfg_ep = spec.kwargs.get("env_cfg_entry_point", "")
-      table.add_row([idx + 1, spec.id, spec.entry_point, env_cfg_ep])
+      table.add_row([idx + 1, spec.id, env_cfg_ep])
       idx += 1
     except Exception:
       continue


### PR DESCRIPTION
This PR introduces an optional `--keyword <search_term>` argument to the `list_envs.py` script. It allows filtering the list of environments by keyword, making it easier to quickly find relevant tasks.

As said in https://github.com/mujocolab/mjlab/issues/262, even though our repo doesn’t have many tasks, external repos can inherit mjlab’s scripts to enable easy task discovery. The same approach applies to list_envs, which may then yield a long list of environments.

To use it: 

```bash
uv run src/mjlab/scripts/list_envs.py --keyword G1
```
