### PR TITLE
Add plugin system for external task registration.

### DIFF
--- a/docs/create_new_task.md
+++ b/docs/create_new_task.md
@@ -333,3 +333,37 @@ uv run play Mjlab-Cartpole --checkpoint_file <checkpoint_path>
 ```
 
 ![Trained CartPole](static/cartpole_trained.gif)
+
+---
+
+## 5. External Package Registration (Optional)
+
+To develop your task in a separate repository outside of mjlab, add an entry
+point to your package's `pyproject.toml`:
+
+> [!NOTE]
+> The `[build-system]` section is required for the plugin system to work.
+
+```toml
+[build-system]
+requires = ["uv_build>=0.8.19,<0.9.0"]
+build-backend = "uv_build"
+
+[project.entry-points."mjlab.tasks"]
+your_package_name = "your_package_name"
+```
+
+The entry point references a Python module that will be imported when mjlab runs.
+This module should contain your `gym.register()` calls (commonly placed in
+`your_package_name/__init__.py`, but can be any module).
+
+mjlab will auto-import your package when running `train` or `play`, making your
+registered tasks available:
+
+```bash
+# Works from any external package!
+uv run train Mjlab-YourTask
+```
+
+See [g1_spinkick_example](https://github.com/mujocolab/g1_spinkick_example) for
+a complete working example.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -117,6 +117,18 @@ available.
 
 ---
 
+## Development
+
+### Can I develop custom tasks in my own repository?
+
+Yes! mjlab has a plugin system that lets you develop tasks in separate
+repositories while seamlessly integrating with mjlab's `train` and `play`
+commands. See
+[Creating a New Task → External Package Registration](create_new_task.md#5-external-package-registration-optional)
+for a complete guide with a working example.
+
+---
+
 ## Assets & Compatibility
 
 ### What robots are included?

--- a/src/mjlab/__init__.py
+++ b/src/mjlab/__init__.py
@@ -1,19 +1,38 @@
 import os
+from importlib.metadata import entry_points
 from pathlib import Path
 
 import warp as wp
 
+__all__ = ["MJLAB_SRC_PATH"]
+
 MJLAB_SRC_PATH: Path = Path(__file__).parent
 
 
-def configure_warp() -> None:
+def _configure_warp() -> None:
   """Configure Warp globally for mjlab."""
   wp.config.enable_backward = False
 
   # Keep warp verbose by default to show kernel compilation progress.
   # Override with MJLAB_WARP_QUIET=1 environment variable if needed.
-  quiet = os.environ.get("MJLAB_WARP_QUIET", "").lower() in ("1", "true", "yes")
+  quiet = os.environ.get("MJLAB_WARP_QUIET", "0").lower() in ("1", "true", "yes")
   wp.config.quiet = quiet
 
 
-configure_warp()
+def _import_registered_packages() -> None:
+  """Auto-discover and import packages registered via entry points.
+
+  Looks for packages registered under the 'mjlab.tasks' entry point group.
+  Each discovered package is imported, which allows it to register custom
+  environments with gymnasium.
+  """
+  mjlab_tasks = entry_points().select(group="mjlab.tasks")
+  for entry_point in mjlab_tasks:
+    try:
+      entry_point.load()
+    except Exception as e:
+      print(f"[WARN] Failed to load task package {entry_point.name}: {e}")
+
+
+_configure_warp()
+_import_registered_packages()


### PR DESCRIPTION
Enables external plugins to register custom tasks via Python entry points. Plugins are automatically discovered and loaded at runtime, making them available to train/play scripts.