### PR TITLE
Add information regarding Windows compatibility

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -12,12 +12,10 @@ We recommend Linux with an NVIDIA GPU for serious training workloads.
 
 ### Does it work on Windows?
 
-We have performed preliminary testing on Windows and WSL. Apart from a few 
-test cases regarding the nan-guard functionality (see below), all are passed
-by native Windows, while WSL appears fully compatible. Windows support may lag
-behind updates and will be tested less frequently, as the primary platform
-targeted is Linux. However, community contributions for Windows support are
-welcome!
+We have performed preliminary testing on Windows and WSL, but some workflows
+may are not guaranteed to be stable. Windows support may lag behind updates 
+and will be tested less frequently, as the primary platform targeted is Linux.
+However, community contributions for Windows support are welcome!
 
 ### CUDA Compatibility
 

--- a/docs/installation_guide.md
+++ b/docs/installation_guide.md
@@ -23,10 +23,9 @@
 > backend for evaluation — stay tuned for updates.
 
 > **Note on Windows**: As warp/mujoco-warp is supported on Windows, Windows
-> compatibility is possible with mjlab. Core functionality (e.g. the demo and train
-> scripts) works natively. However, some tests of utility tests currently fail on
-> Windows, which is being investigated. Another option Windows users may consider
-> is using WSL, which passes the tests.
+> compatibility is available with mjlab. Core functionality (e.g. the demo and train
+> scripts) has been tested, but support for Windows should be considered
+> experimental. Windows users may also consider WSL as an option.
 ---
 
 ## ⚠️ Beta Status


### PR DESCRIPTION
Ran the example scripts on Windows 11 and WSL, as well as the tests. Windows 11 fails the nan_guard tests due to file read permission errors (despite running them with privileges). However, core functionality seems to work on both platforms, including hardware acceleration.

This PR updates the FAQ and installation docs accordingly.