### PR TITLE
Add `domain_randomization` field to `EventTermCfg` to replace `__name__` inspection. 

### DIFF
--- a/src/mjlab/managers/event_manager.py
+++ b/src/mjlab/managers/event_manager.py
@@ -215,7 +215,7 @@ class EventManager(ManagerBase):
         no_trigger = torch.zeros(self.num_envs, device=self.device, dtype=torch.bool)
         self._reset_term_last_triggered_once.append(no_trigger)
 
-      if term_cfg.func.__name__ == "randomize_field":
+      if term_cfg.domain_randomization:
         field_name = term_cfg.params["field"]
         if field_name not in self._domain_randomization_fields:
           self._domain_randomization_fields.append(field_name)

--- a/src/mjlab/managers/manager_term_config.py
+++ b/src/mjlab/managers/manager_term_config.py
@@ -77,6 +77,9 @@ class EventTermCfg(ManagerTermBaseCfg):
   interval_range_s: tuple[float, float] | None = None
   is_global_time: bool = False
   min_step_count_between_reset: int = 0
+  domain_randomization: bool = False
+  """Whether this event term performs domain randomization. If True, the field
+  name (from params["field"]) will be tracked for domain randomization purposes."""
 
 
 ##

--- a/src/mjlab/tasks/tracking/tracking_env_cfg.py
+++ b/src/mjlab/tasks/tracking/tracking_env_cfg.py
@@ -173,6 +173,7 @@ class EventCfg:
     EventTerm,
     mode="startup",
     func=mdp.randomize_field,
+    domain_randomization=True,
     params={
       "asset_cfg": SceneEntityCfg("robot", body_names=[]),  # Override in robot cfg.
       "operation": "add",
@@ -188,6 +189,7 @@ class EventCfg:
     EventTerm,
     mode="startup",
     func=mdp.randomize_field,
+    domain_randomization=True,
     params={
       "asset_cfg": SceneEntityCfg("robot"),
       "operation": "add",
@@ -199,6 +201,7 @@ class EventCfg:
     EventTerm,
     mode="startup",
     func=mdp.randomize_field,
+    domain_randomization=True,
     params={
       "asset_cfg": SceneEntityCfg("robot", geom_names=[]),  # Override in robot cfg.
       "operation": "abs",

--- a/src/mjlab/tasks/velocity/velocity_env_cfg.py
+++ b/src/mjlab/tasks/velocity/velocity_env_cfg.py
@@ -190,6 +190,7 @@ class EventCfg:
     EventTerm,
     mode="startup",
     func=mdp.randomize_field,
+    domain_randomization=True,
     params={
       "asset_cfg": SceneEntityCfg("robot", geom_names=[]),  # Override in robot cfg.
       "operation": "abs",

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,5 +1,6 @@
 """Tests for MDP events functionality."""
 
+from dataclasses import dataclass
 from unittest.mock import Mock
 
 import pytest
@@ -7,6 +8,8 @@ import torch
 from conftest import get_test_device
 
 from mjlab.envs.mdp import events
+from mjlab.managers.event_manager import EventManager
+from mjlab.managers.manager_term_config import EventTermCfg, term
 from mjlab.managers.scene_entity_config import SceneEntityCfg
 
 
@@ -62,3 +65,60 @@ def test_reset_joints_by_offset(device):
   call_args = mock_entity.write_joint_state_to_sim.call_args
   joint_pos = call_args[0][0]
   assert torch.allclose(joint_pos, torch.ones_like(joint_pos) * 0.5)
+
+
+def test_class_based_event_with_domain_randomization(device):
+  """Test that class-based events work and domain_randomization flag tracks fields."""
+
+  # Create a simple class-based event term.
+  class CustomRandomizer:
+    def __init__(self, cfg, env):
+      self.cfg = cfg
+      self.env = env
+
+    def __call__(self, env, env_ids, field, ranges):
+      pass  # No-op for testing
+
+  # Create a mock environment with minimal requirements.
+  env = Mock()
+  env.num_envs = 4
+  env.device = device
+  env.scene = {}
+  env.sim = Mock()
+
+  # Create event manager config with both DR and non-DR terms.
+  @dataclass
+  class EventCfg:
+    # Class-based DR term should be tracked.
+    custom_dr: EventTermCfg = term(
+      EventTermCfg,
+      mode="startup",
+      func=CustomRandomizer,
+      domain_randomization=True,
+      params={"field": "geom_friction", "ranges": (0.3, 1.2)},
+    )
+    # Regular function-based DR term should be tracked.
+    standard_dr: EventTermCfg = term(
+      EventTermCfg,
+      mode="reset",
+      func=events.randomize_field,
+      domain_randomization=True,
+      params={"field": "body_mass", "ranges": (0.8, 1.2)},
+    )
+    # Non-DR term should not be tracked.
+    regular_event: EventTermCfg = term(
+      EventTermCfg,
+      mode="reset",
+      func=events.reset_joints_by_offset,
+      params={"position_range": (-0.1, 0.1), "velocity_range": (0.0, 0.0)},
+    )
+
+  cfg = EventCfg()
+  manager = EventManager(cfg, env)
+
+  # Verify that DR fields are tracked.
+  assert "geom_friction" in manager.domain_randomization_fields
+  assert "body_mass" in manager.domain_randomization_fields
+
+  # Verify that non-DR event is not tracked.
+  assert len(manager.domain_randomization_fields) == 2


### PR DESCRIPTION
Previously, the event manager relied on checking `func.__name__ == "randomize_field"` to detect domain randomization terms. This broke when users tried to use class-based event terms.

This adds an explicit `domain_randomization` boolean field to EventTermCfg that users can set to mark DR terms. This approach is more explicit, works with any callable (functions, classes, lambdas), and makes the intent clear in the configuration.

Fixes #268.