### PR TITLE
Fix MujocoCfg not being applied when using Simulation directly.

### DIFF
--- a/src/mjlab/envs/manager_based_env.py
+++ b/src/mjlab/envs/manager_based_env.py
@@ -60,7 +60,6 @@ class ManagerBasedEnv:
     self.obs_buf = {}
 
     self.scene = Scene(self.cfg.scene, device=device)
-    self.cfg.sim.mujoco.edit_spec(self.scene.spec)
 
     self.sim = Simulation(
       num_envs=self.scene.num_envs,

--- a/tests/test_sim.py
+++ b/tests/test_sim.py
@@ -1,10 +1,11 @@
 """Tests for sim.py."""
 
 import mujoco
+import numpy as np
 import pytest
 from conftest import get_test_device
 
-from mjlab.sim import Simulation, SimulationCfg
+from mjlab.sim import MujocoCfg, Simulation, SimulationCfg
 
 
 @pytest.fixture
@@ -40,14 +41,42 @@ def robot_xml():
 
 
 def test_simulation_config_is_piped(robot_xml, device):
-  """Test that SimulationCfg values are applied to warp model."""
+  """Test that SimulationCfg values are applied to both mj_model and wp_model."""
   model = mujoco.MjModel.from_xml_string(robot_xml)
 
-  ls_parallel = False
-  maxmatch = 128
+  cfg = SimulationCfg(
+    contact_sensor_maxmatch=128,
+    ls_parallel=False,
+    mujoco=MujocoCfg(
+      timestep=0.02,
+      integrator="euler",
+      solver="cg",
+      iterations=7,
+      ls_iterations=14,
+      gravity=(0, 0, 7.5),
+    ),
+  )
 
-  cfg = SimulationCfg(contact_sensor_maxmatch=maxmatch, ls_parallel=ls_parallel)
   sim = Simulation(num_envs=1, cfg=cfg, model=model, device=device)
 
-  assert sim._wp_model.opt.contact_sensor_maxmatch == maxmatch
-  assert sim._wp_model.opt.ls_parallel == ls_parallel
+  # MujocoCfg should be applied to mj_model.
+  assert sim.mj_model.opt.timestep == cfg.mujoco.timestep
+  assert sim.mj_model.opt.integrator == mujoco.mjtIntegrator.mjINT_EULER
+  assert sim.mj_model.opt.solver == mujoco.mjtSolver.mjSOL_CG
+  assert sim.mj_model.opt.iterations == cfg.mujoco.iterations
+  assert tuple(sim.mj_model.opt.gravity) == cfg.mujoco.gravity
+
+  # MujocoCfg should be inherited by wp_model via put_model.
+  np.testing.assert_almost_equal(
+    sim.model.opt.timestep[0].cpu().numpy(), cfg.mujoco.timestep
+  )
+  np.testing.assert_almost_equal(
+    sim.model.opt.gravity[0].cpu().numpy(), cfg.mujoco.gravity
+  )
+  assert sim.model.opt.integrator == mujoco.mjtIntegrator.mjINT_EULER
+  assert sim.model.opt.solver == mujoco.mjtSolver.mjSOL_CG
+  assert sim.model.opt.iterations == cfg.mujoco.iterations
+
+  # SimulationCfg should be applied to wp_model.
+  assert sim.wp_model.opt.contact_sensor_maxmatch == cfg.contact_sensor_maxmatch
+  assert sim.wp_model.opt.ls_parallel == cfg.ls_parallel


### PR DESCRIPTION
`MujocoCfg` settings are now applied in `Simulation.__init__` via the new `MujocoCfg.apply()` method, ensuring timestep and other parameters are respected regardless of whether Simulation is used standalone or via `ManagerBasedEnv`.

Fixes #294.