### PR TITLE
Test ctrl_ids/joint_ids ordering in BuiltinActuatorGroup

### DIFF
--- a/src/mjlab/actuator/builtin_group.py
+++ b/src/mjlab/actuator/builtin_group.py
@@ -77,5 +77,5 @@ class BuiltinActuatorGroup:
       BuiltinMotorActuator: data.joint_effort_target,
     }
     for actuator_type, index_group in self._index_groups.items():
-      ctrl_ids, joint_ids = index_group
+      joint_ids, ctrl_ids = index_group
       data.write_ctrl(target_tensor_map[actuator_type][:, joint_ids], ctrl_ids)


### PR DESCRIPTION
The index_groups tuple is created as (ctrl_ids, joint_ids) in the process() method, but apply_controls() was unpacking it in the wrong order as (joint_ids, ctrl_ids). This caused actuator controls to be written to incorrect indices when actuators were registered in a different order than joints appear in the model.

This bug manifested whenever ctrl_ids != joint_ids, which occurs when:
- Actuators are added in non-sequential order
- Actuators control a subset of joints

Adds regression test with mismatched indices to prevent future occurrences.

cc @brentyi 