### PR TITLE
Fix joint ordering in find_joints_by_actuator_names.

### DIFF
--- a/src/mjlab/entity/entity.py
+++ b/src/mjlab/entity/entity.py
@@ -292,15 +292,19 @@ class Entity:
   def find_joints_by_actuator_names(
     self,
     actuator_name_keys: str | Sequence[str],
-    preserve_order: bool = False,
   ) -> tuple[list[int], list[str]]:
-    actuated_joint_names = []
+    """Find actuated joints matching the given patterns in natural joint order."""
+    # Collect all actuated joint names.
+    actuated_joint_names_set = set()
     for act in self._actuators:
-      actuated_joint_names.extend(act.joint_names)
+      actuated_joint_names_set.update(act.joint_names)
+    # Filter self.joint_names to only actuated joints, preserving natural order.
+    actuated_in_natural_order = [
+      name for name in self.joint_names if name in actuated_joint_names_set
+    ]
+    # Find joints matching the pattern within actuated joints.
     return self.find_joints(
-      actuator_name_keys,
-      joint_subset=actuated_joint_names,
-      preserve_order=preserve_order,
+      actuator_name_keys, joint_subset=actuated_in_natural_order, preserve_order=False
     )
 
   def find_geoms(

--- a/src/mjlab/envs/mdp/actions/joint_actions.py
+++ b/src/mjlab/envs/mdp/actions/joint_actions.py
@@ -24,7 +24,7 @@ class JointAction(ActionTerm):
     super().__init__(cfg=cfg, env=env)
 
     joint_ids, joint_names = self._asset.find_joints_by_actuator_names(
-      cfg.actuator_names, preserve_order=cfg.preserve_order
+      cfg.actuator_names
     )
     self._joint_ids = torch.tensor(joint_ids, device=self.device, dtype=torch.long)
     self._joint_names = joint_names


### PR DESCRIPTION
Commit 4d0eb82 introduced a regression where joints were returned in actuator definition order instead of natural joint order, breaking motion tracking tasks that expect consistent joint ordering.

This fix ensures joints are always returned in natural order by filtering self.joint_names to actuated joints while preserving order.