### PR TITLE
Fix onnx metadata exporter.

### DIFF
--- a/src/mjlab/tasks/tracking/rl/exporter.py
+++ b/src/mjlab/tasks/tracking/rl/exporter.py
@@ -105,17 +105,17 @@ def attach_onnx_metadata(
   motion_term_cfg = motion_term.cfg
   metadata = {
     "run_path": run_path,
-    "joint_names": robot.joint_names,
+    "joint_names": list(robot.joint_names),
     "joint_stiffness": joint_stiffness.tolist(),
     "joint_damping": joint_damping.tolist(),
     "default_joint_pos": robot.data.default_joint_pos[0].cpu().tolist(),
-    "command_names": env.command_manager.active_terms,
+    "command_names": list(env.command_manager.active_terms),
     "observation_names": env.observation_manager.active_terms["policy"],
     "action_scale": joint_action._scale[0].cpu().tolist()
     if isinstance(joint_action._scale, torch.Tensor)
     else joint_action._scale,
     "anchor_body_name": motion_term_cfg.anchor_body_name,
-    "body_names": motion_term_cfg.body_names,
+    "body_names": list(motion_term_cfg.body_names),
   }
 
   model = onnx.load(onnx_path)

--- a/src/mjlab/tasks/velocity/rl/exporter.py
+++ b/src/mjlab/tasks/velocity/rl/exporter.py
@@ -44,11 +44,11 @@ def attach_onnx_metadata(
   joint_damping = -env.sim.mj_model.actuator_biasprm[ctrl_ids, 2]
   metadata = {
     "run_path": run_path,
-    "joint_names": robot.joint_names,
+    "joint_names": list(robot.joint_names),
     "joint_stiffness": joint_stiffness.tolist(),
     "joint_damping": joint_damping.tolist(),
     "default_joint_pos": robot.data.default_joint_pos[0].cpu().tolist(),
-    "command_names": env.command_manager.active_terms,
+    "command_names": list(env.command_manager.active_terms),
     "observation_names": env.observation_manager.active_terms["policy"],
     "action_scale": joint_action._scale[0].cpu().tolist()
     if isinstance(joint_action._scale, torch.Tensor)


### PR DESCRIPTION
The exporter was expecting list fields but we inadvertently broke this assumption when we converted entity properties to tuples. They now get properly exported to csv fields.