### PR TITLE
Fixes find_joints_by_actuator_names to return global joint indices

### DIFF
--- a/src/mjlab/entity/entity.py
+++ b/src/mjlab/entity/entity.py
@@ -293,21 +293,24 @@ class Entity:
     self,
     actuator_name_keys: str | Sequence[str],
   ) -> tuple[list[int], list[str]]:
-    """Find actuated joints matching the given patterns in natural joint order."""
     # Collect all actuated joint names.
     actuated_joint_names_set = set()
     for act in self._actuators:
       actuated_joint_names_set.update(act.joint_names)
+
     # Filter self.joint_names to only actuated joints, preserving natural order.
     actuated_in_natural_order = [
       name for name in self.joint_names if name in actuated_joint_names_set
     ]
+
     # Find joints matching the pattern within actuated joints.
     _, matched_joint_names = self.find_joints(
       actuator_name_keys, joint_subset=actuated_in_natural_order, preserve_order=False
     )
-    name_to_global_idx = {name: i for i, name in enumerate(self.joint_names)}
-    joint_ids = [name_to_global_idx[name] for name in matched_joint_names]
+
+    # Map joint names back to entity-local indices (indices into self.joint_names).
+    name_to_entity_idx = {name: i for i, name in enumerate(self.joint_names)}
+    joint_ids = [name_to_entity_idx[name] for name in matched_joint_names]
     return joint_ids, matched_joint_names
 
   def find_geoms(

--- a/tests/test_xml_actuator.py
+++ b/tests/test_xml_actuator.py
@@ -44,7 +44,7 @@ def device():
   return get_test_device()
 
 
-def test_xml_actuator_underactuated_with_wildcard(device):
+def test_xml_actuator_underactuated_with_wildcard():
   """XmlActuator filters to joints with XML actuators when using wildcard."""
   cfg = EntityCfg(
     spec_fn=lambda: mujoco.MjSpec.from_string(ROBOT_XML_UNDERACTUATED),
@@ -61,7 +61,7 @@ def test_xml_actuator_underactuated_with_wildcard(device):
   assert actuator._joint_names == ["joint2"]
 
 
-def test_xml_actuator_no_matching_actuators_raises_error(device):
+def test_xml_actuator_no_matching_actuators_raises_error():
   """XmlActuator raises error when no joints have matching XML actuators."""
   with pytest.raises(
     ValueError, match="No XML actuators found for any joints matching the patterns"
@@ -113,10 +113,11 @@ def test_joint_action_underactuated_with_wildcard(device):
 
   env = ManagerBasedRlEnv(cfg=env_cfg, device=device)
   action_term = env.action_manager._terms["joint_effort"]
+  assert isinstance(action_term, mdp.JointEffortAction)
 
-  # Wildcard should resolve to only actuated joint (joint2), not all joints
+  # Wildcard should resolve to only actuated joint (joint2), not all joints.
   assert action_term.action_dim == 1
-  assert action_term._joint_names == ["joint2"]  # type: ignore[attr-defined]
-  assert action_term._joint_ids.tolist() == [1]  # type: ignore[attr-defined]
+  assert action_term._joint_names == ["joint2"]
+  assert action_term._joint_ids.tolist() == [1]
 
   env.close()


### PR DESCRIPTION
This PR fixes a bug where `Entity.find_joints_by_actuator_names` returned indices relative to the actuated subset instead of global joint indices, which could make joint-based actions and rewards target the wrong joints.

Now, `find_joints_by_actuator_names`:

1. Collects all actuated joints in natural joint order.
2. Matches the user patterns (e.g. `".*"`) on that subset.
3. Maps the matched joint names back to global indices using `self.joint_names`.

I also updated the XML actuator tests to actuate `joint2` instead of `joint1` in the underactuated robot, so we cover this edge case and check both the resolved joint names and their indices.

This bug showed up when I added hands to the robot: many hand joints exist but are not actuated. With a zero agent, every actuator should hold its joint at the default position, but before the fix you can see that actuated joints are send to the zero position instead of the default position.

<table>
  <tr>
    <td width="50%">
      <figure>
        <video src="https://github.com/user-attachments/assets/2e3c9957-7cc0-4b30-8942-e611f39095dc" controls muted loop playsinline style="width:100%; height:auto;"></video>
        <figcaption align="center"><em>Kangaroo with hands -- before the fix</em></figcaption>
      </figure>
    </td>
    <td width="50%">
      <figure>
        <video src="https://github.com/user-attachments/assets/41e538b1-8f67-495a-b505-e7217ca86d27" controls muted loop playsinline style="width:100%; height:auto;"></video>
        <figcaption align="center"><em>Kangaroo with hands -- after the fix</em></figcaption>
      </figure>
    </td>
  </tr>
</table>
