### PR TITLE
Add camera sensor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ required-environments = [
   "sys_platform == 'darwin' and platform_machine == 'arm64'",
   "sys_platform == 'linux' and platform_machine == 'x86_64'",
 ]
+config-settings = { editable_mode = "compat" }
 
 [[tool.uv.index]]
 url = "https://pypi.org/simple"
@@ -102,10 +103,11 @@ url = "https://py.mujoco.org"
 explicit = true
 
 [tool.uv.sources]
-mujoco-warp = { git = "https://github.com/google-deepmind/mujoco_warp", rev = "e605c406363805d949b75d50dd5ffb3d79bc3f70"}
+# warp-lang = { path = "../warp", editable = true }
 warp-lang = { index = "nvidia", marker = "sys_platform != 'darwin'" }
 mujoco = { index = "mujoco" }
 torch = { index = "pytorch-cu128", extra = "cu128", marker = "sys_platform != 'darwin'" }
+mujoco-warp = { path = "../mujoco_warp", editable = true }
 
 [tool.ruff]
 src = ["src"]  # Helpful for recognizing first-party imports.

--- a/src/mjlab/asset_zoo/robots/unitree_g1/xmls/g1.xml
+++ b/src/mjlab/asset_zoo/robots/unitree_g1/xmls/g1.xml
@@ -188,6 +188,7 @@
           <body name="torso_link">
             <inertial pos="0.00203158 0.000339683 0.184568" quat="0.999803 -6.03319e-05 0.0198256 0.00131986"
               mass="7.818" diaginertia="0.121847 0.109825 0.0273735"/>
+            <camera name="depth" pos="0.055 0.017 0.433" quat="-0.659 -0.256 0.256 0.659" fovy="58"/>
             <joint name="waist_pitch_joint" axis="0 1 0" range="-0.52 0.52"/>
             <geom class="visual" mesh="torso_link"/>
             <geom class="visual" pos="0.0039635 0 -0.044" quat="1 0 0 0" material="black" mesh="logo_link"/>

--- a/src/mjlab/envs/manager_based_rl_env.py
+++ b/src/mjlab/envs/manager_based_rl_env.py
@@ -274,6 +274,7 @@ class ManagerBasedRlEnv:
     self._reset_idx(env_ids)
     self.scene.write_data_to_sim()
     self.sim.forward()
+    self.scene.render()
     self.obs_buf = self.observation_manager.compute(update_history=True)
     return self.obs_buf, self.extras
 
@@ -312,6 +313,7 @@ class ManagerBasedRlEnv:
       self._reset_idx(reset_env_ids)
       self.scene.write_data_to_sim()
       self.sim.forward()
+      self.scene.render()
 
     self.command_manager.compute(dt=self.step_dt)
 

--- a/src/mjlab/scene/scene.py
+++ b/src/mjlab/scene/scene.py
@@ -7,7 +7,7 @@ import mujoco_warp as mjwarp
 import torch
 
 from mjlab.entity import Entity, EntityCfg
-from mjlab.sensor import BuiltinSensor, Sensor, SensorCfg
+from mjlab.sensor import BuiltinSensor, CameraSensor, RenderManager, Sensor, SensorCfg
 from mjlab.terrains.terrain_importer import TerrainImporter, TerrainImporterCfg
 
 _SCENE_XML = Path(__file__).parent / "scene.xml"
@@ -31,6 +31,7 @@ class Scene:
     self._sensors: dict[str, Sensor] = {}
     self._terrain: TerrainImporter | None = None
     self._default_env_origins: torch.Tensor | None = None
+    self._render_manager: RenderManager | None = None
 
     self._spec = mujoco.MjSpec.from_file(str(_SCENE_XML))
     if self._cfg.extent is not None:
@@ -128,6 +129,12 @@ class Scene:
     for sensor in self._sensors.values():
       sensor.initialize(mj_model, model, data, self._device)
 
+    camera_sensors = [s for s in self._sensors.values() if isinstance(s, CameraSensor)]
+    if camera_sensors:
+      self._render_manager = RenderManager(
+        mj_model, model, data, camera_sensors, self._device
+      )
+
   def reset(self, env_ids: torch.Tensor | slice | None = None) -> None:
     for ent in self._entities.values():
       ent.reset(env_ids)
@@ -139,6 +146,12 @@ class Scene:
       ent.update(dt)
     for sensor in self._sensors.values():
       sensor.update(dt)
+
+    self.render()
+
+  def render(self) -> None:
+    if self._render_manager is not None:
+      self._render_manager.render()
 
   def write_data_to_sim(self) -> None:
     for ent in self._entities.values():

--- a/src/mjlab/sensor/__init__.py
+++ b/src/mjlab/sensor/__init__.py
@@ -1,9 +1,13 @@
 from mjlab.sensor.builtin_sensor import BuiltinSensor as BuiltinSensor
 from mjlab.sensor.builtin_sensor import BuiltinSensorCfg as BuiltinSensorCfg
 from mjlab.sensor.builtin_sensor import ObjRef as ObjRef
+from mjlab.sensor.camera_sensor import CameraSensor as CameraSensor
+from mjlab.sensor.camera_sensor import CameraSensorCfg as CameraSensorCfg
+from mjlab.sensor.camera_sensor import CameraSensorData as CameraSensorData
 from mjlab.sensor.contact_sensor import ContactData as ContactData
 from mjlab.sensor.contact_sensor import ContactMatch as ContactMatch
 from mjlab.sensor.contact_sensor import ContactSensor as ContactSensor
 from mjlab.sensor.contact_sensor import ContactSensorCfg as ContactSensorCfg
+from mjlab.sensor.render_manager import RenderManager as RenderManager
 from mjlab.sensor.sensor import Sensor as Sensor
 from mjlab.sensor.sensor import SensorCfg as SensorCfg

--- a/src/mjlab/sensor/builtin_sensor.py
+++ b/src/mjlab/sensor/builtin_sensor.py
@@ -274,10 +274,12 @@ class BuiltinSensor(Sensor[torch.Tensor]):
     self, cfg: BuiltinSensorCfg | None = None, name: str | None = None
   ) -> None:
     if cfg is not None:
+      super().__init__(cfg.update_period)
       self._name = cfg.name
       self.cfg: BuiltinSensorCfg | None = cfg
     else:
       assert name is not None, "Must provide either cfg or name"
+      super().__init__(0.0)
       self._name = name
       self.cfg = None
     self._data: mjwarp.Data | None = None
@@ -334,7 +336,6 @@ class BuiltinSensor(Sensor[torch.Tensor]):
     dim = sensor.dim[0]
     self._data_view = self._data.sensordata[:, start : start + dim]
 
-  @property
-  def data(self) -> torch.Tensor:
+  def _read(self) -> torch.Tensor:
     assert self._data_view is not None
     return self._data_view

--- a/src/mjlab/sensor/camera_sensor.py
+++ b/src/mjlab/sensor/camera_sensor.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal
+
+import mujoco
+import mujoco_warp as mjwarp
+import torch
+
+from mjlab.entity import Entity
+from mjlab.sensor.sensor import Sensor, SensorCfg
+
+if TYPE_CHECKING:
+  from mjlab.sensor.render_manager import RenderManager
+
+CameraDataType = Literal["rgb", "depth"]
+
+
+@dataclass
+class CameraSensorCfg(SensorCfg):
+  camera_name: str | None = None
+  pos: tuple[float, float, float] = (0.0, 0.0, 1.0)
+  quat: tuple[float, float, float, float] = (1.0, 0.0, 0.0, 0.0)
+  fovy: float = 45
+  width: int = 160
+  height: int = 120
+  type: tuple[CameraDataType, ...] = ("rgb",)
+  use_textures: bool = True
+  use_shadows: bool = False
+  enabled_geom_groups: tuple[int, ...] = (0, 1, 2)
+
+  def build(self) -> CameraSensor:
+    return CameraSensor(self)
+
+
+@dataclass
+class CameraSensorData:
+  """Camera sensor output data.
+
+  Contains RGB and/or depth images based on sensor configuration.
+  Both fields are None if not requested in the sensor's type configuration.
+
+  Shape: [num_envs, height, width, channels]
+    - rgb: channels=3 (uint8)
+    - depth: channels=1 (float32)
+  """
+
+  rgb: torch.Tensor | None = None
+  """RGB image data [num_envs, height, width, 3] (uint8). None if not enabled."""
+  depth: torch.Tensor | None = None
+  """Depth image data [num_envs, height, width, 1] (float32). None if not enabled."""
+
+
+class CameraSensor(Sensor[CameraSensorData]):
+  def __init__(self, cfg: CameraSensorCfg) -> None:
+    super().__init__(cfg.update_period)
+    self.cfg = cfg
+    self._camera_name = cfg.camera_name if cfg.camera_name is not None else cfg.name
+    self._is_wrapping_existing = cfg.camera_name is not None
+    self._render_manager: RenderManager | None = None
+    self._camera_idx: int = -1
+
+  @property
+  def camera_name(self) -> str:
+    return self._camera_name
+
+  @property
+  def camera_idx(self) -> int:
+    return self._camera_idx
+
+  def edit_spec(self, scene_spec: mujoco.MjSpec, entities: dict[str, Entity]) -> None:
+    del entities
+
+    if self._is_wrapping_existing:
+      return
+
+    scene_spec.worldbody.add_camera(
+      name=self.cfg.name,
+      pos=self.cfg.pos,
+      quat=self.cfg.quat,
+      fovy=self.cfg.fovy,
+    )
+
+  def initialize(
+    self, mj_model: mujoco.MjModel, model: mjwarp.Model, data: mjwarp.Data, device: str
+  ) -> None:
+    del model, data, device
+
+    try:
+      cam = mj_model.camera(self._camera_name)
+      self._camera_idx = cam.id
+    except KeyError as e:
+      available = [mj_model.cam(i).name for i in range(mj_model.ncam)]
+      raise ValueError(
+        f"Camera '{self._camera_name}' not found in model. Available: {available}"
+      ) from e
+
+  def set_render_manager(self, render_manager: RenderManager) -> None:
+    self._render_manager = render_manager
+
+  def _read(self) -> CameraSensorData:
+    assert self._render_manager is not None
+    rgb_data = None
+    depth_data = None
+    if "rgb" in self.cfg.type:
+      rgb_data = self._render_manager.get_rgb(self._camera_idx).clone()
+    if "depth" in self.cfg.type:
+      depth_data = self._render_manager.get_depth(self._camera_idx).clone()
+    return CameraSensorData(rgb=rgb_data, depth=depth_data)

--- a/src/mjlab/sensor/render_manager.py
+++ b/src/mjlab/sensor/render_manager.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import mujoco
+import mujoco_warp as mjwarp
+import torch
+import warp as wp
+
+if TYPE_CHECKING:
+  from mjlab.sensor.camera_sensor import CameraSensor
+
+
+@wp.kernel
+def _unpack_rgb_kernel(
+  packed: wp.array2d(dtype=wp.uint32),  # type: ignore
+  rgb: wp.array3d(dtype=wp.uint8),  # type: ignore
+):
+  world_idx, pixel_idx = wp.tid()  # type: ignore
+  b = wp.uint8(packed[world_idx, pixel_idx] & wp.uint32(0xFF))
+  g = wp.uint8((packed[world_idx, pixel_idx] >> wp.uint32(8)) & wp.uint32(0xFF))
+  r = wp.uint8((packed[world_idx, pixel_idx] >> wp.uint32(16)) & wp.uint32(0xFF))
+  rgb[world_idx, pixel_idx, 0] = r
+  rgb[world_idx, pixel_idx, 1] = g
+  rgb[world_idx, pixel_idx, 2] = b
+
+
+class RenderManager:
+  """Manages rendering for all camera sensors in a scene.
+
+  Coordinates rendering across multiple camera sensors using a 2-level control system:
+
+  1. **Static enablement (cam_active)**: Only cameras with corresponding sensors
+    are included in the render context at initialization. This determines the set
+    of cameras that CAN be rendered. This is useful for scenarios where an XML file
+    may contain many cameras, but only a subset are used as sensors. In this case,
+    the other cameras are disabled.
+
+  2. **Dynamic toggle (render_rgb/render_depth)**: On each render() call, these
+    flags control which enabled cameras ACTUALLY render based on their
+    update_period, allowing selective rendering.
+  """
+
+  def __init__(
+    self,
+    mj_model: mujoco.MjModel,
+    model: mjwarp.Model,
+    data: mjwarp.Data,
+    camera_sensors: list[CameraSensor],
+    device: str,
+  ):
+    self.wp_device = wp.get_device(device)
+
+    # Sort sensors by camera index to match mujoco_warp ordering.
+    self.camera_sensors = sorted(camera_sensors, key=lambda s: s.camera_idx)
+    camera_resolutions = [(s.cfg.width, s.cfg.height) for s in self.camera_sensors]
+    render_rgb = ["rgb" in s.cfg.type for s in self.camera_sensors]
+    render_depth = ["depth" in s.cfg.type for s in self.camera_sensors]
+
+    # Create mapping from MuJoCo camera ID to sorted list index.
+    self._cam_idx_to_list_idx = {
+      s.camera_idx: idx for idx, s in enumerate(self.camera_sensors)
+    }
+
+    # Validate that all sensors have consistent rendering settings.
+    first_sensor = self.camera_sensors[0]
+    use_textures = first_sensor.cfg.use_textures
+    use_shadows = first_sensor.cfg.use_shadows
+    enabled_geom_groups = list(first_sensor.cfg.enabled_geom_groups)
+
+    for sensor in self.camera_sensors[1:]:
+      if sensor.cfg.use_textures != use_textures:
+        raise ValueError(
+          f"Camera sensor '{sensor.cfg.name}' has "
+          f"use_textures={sensor.cfg.use_textures}, "
+          f"but '{first_sensor.cfg.name}' has use_textures={use_textures}. "
+          "All camera sensors must have the same use_textures setting."
+        )
+      if sensor.cfg.use_shadows != use_shadows:
+        raise ValueError(
+          f"Camera sensor '{sensor.cfg.name}' has "
+          f"use_shadows={sensor.cfg.use_shadows}, "
+          f"but '{first_sensor.cfg.name}' has use_shadows={use_shadows}. "
+          "All camera sensors must have the same use_shadows setting."
+        )
+      if tuple(sensor.cfg.enabled_geom_groups) != tuple(enabled_geom_groups):
+        raise ValueError(
+          f"Camera sensor '{sensor.cfg.name}' has enabled_geom_groups="
+          f"{sensor.cfg.enabled_geom_groups}, but '{first_sensor.cfg.name}' has "
+          f"enabled_geom_groups={tuple(enabled_geom_groups)}. "
+          "All camera sensors must have the same enabled_geom_groups setting."
+        )
+
+    # Build cam_active list: mark only cameras with sensors as active.
+    cam_active = [False] * mj_model.ncam
+    for sensor in self.camera_sensors:
+      cam_active[sensor.camera_idx] = True
+
+    with wp.ScopedDevice(self.wp_device):
+      self._ctx = mjwarp.create_render_context(
+        mjm=mj_model,
+        m=model.struct,  # type: ignore
+        d=data.struct,  # type: ignore
+        cam_resolutions=camera_resolutions,
+        render_rgb=render_rgb,
+        render_depth=render_depth,
+        use_textures=use_textures,
+        use_shadows=use_shadows,
+        enabled_geom_groups=enabled_geom_groups,
+        cam_active=cam_active,
+      )
+
+    self._model = model
+    self._data = data
+    self._render_rgb = render_rgb
+    self._render_depth = render_depth
+    self._rgb_adr = self._ctx.rgb_adr.numpy()
+    self._depth_adr = self._ctx.depth_adr.numpy()
+    self._rgb_size = self._ctx.rgb_size.numpy()
+    self._depth_size = self._ctx.depth_size.numpy()
+    self._render_rgb_torch = wp.to_torch(self._ctx.render_rgb)
+    self._render_depth_torch = wp.to_torch(self._ctx.render_depth)
+
+    if any(render_rgb):
+      self._rgb_unpacked = wp.array3d(
+        shape=(data.nworld, self._ctx.rgb_data.shape[1], 3),
+        dtype=wp.uint8,
+        device=self.wp_device,
+      )
+    else:
+      self._rgb_unpacked = None
+
+    for sensor in self.camera_sensors:
+      sensor.set_render_manager(self)
+
+    self.use_cuda_graph = self.wp_device.is_cuda and wp.is_mempool_enabled(
+      self.wp_device
+    )
+    self.create_graph()
+
+  def create_graph(self) -> None:
+    self.render_graph = None
+    if self.use_cuda_graph:
+      with wp.ScopedDevice(self.wp_device):
+        with wp.ScopedCapture() as capture:
+          mjwarp.render(self._model, self._data, self._ctx)
+        self.render_graph = capture.graph
+
+  def render(self, dt: float = 0.0) -> None:
+    del dt
+
+    any_render_needed = False
+    any_rgb_rendered = False
+
+    for idx, sensor in enumerate(self.camera_sensors):
+      should_render = sensor._is_outdated
+      should_render_rgb = should_render and ("rgb" in sensor.cfg.type)
+      should_render_depth = should_render and ("depth" in sensor.cfg.type)
+
+      self._render_rgb_torch[idx] = should_render_rgb
+      self._render_depth_torch[idx] = should_render_depth
+
+      if should_render_rgb or should_render_depth:
+        any_render_needed = True
+      if should_render_rgb:
+        any_rgb_rendered = True
+
+    if not any_render_needed:
+      return
+
+    with wp.ScopedDevice(self.wp_device):
+      if self.use_cuda_graph and self.render_graph is not None:
+        wp.capture_launch(self.render_graph)
+      else:
+        mjwarp.render(self._model, self._data, self._ctx)
+
+    if any_rgb_rendered and self._rgb_unpacked is not None:
+      wp.launch(
+        _unpack_rgb_kernel,
+        dim=(self._data.nworld, self._ctx.rgb_data.shape[1]),
+        inputs=[self._ctx.rgb_data],
+        outputs=[self._rgb_unpacked],
+        device=self.wp_device,
+      )
+
+  def get_rgb(self, cam_idx: int) -> torch.Tensor:
+    if self._rgb_unpacked is None:
+      raise RuntimeError(
+        "RGB rendering is not enabled. Ensure at least one camera sensor has "
+        "'rgb' in its type configuration."
+      )
+
+    if cam_idx not in self._cam_idx_to_list_idx:
+      available = list(self._cam_idx_to_list_idx.keys())
+      raise KeyError(
+        f"Camera ID {cam_idx} not found in RenderManager. "
+        f"Available camera IDs: {available}"
+      )
+
+    # Map MuJoCo camera ID to sorted list index.
+    list_idx = self._cam_idx_to_list_idx[cam_idx]
+    rgb_unpacked_torch = wp.to_torch(self._rgb_unpacked)
+    start = int(self._rgb_adr[list_idx])
+    size = int(self._rgb_size[list_idx])
+    rgb_flat = rgb_unpacked_torch[:, start : start + size]
+    return rgb_flat.reshape(
+      self._data.nworld,
+      self.camera_sensors[list_idx].cfg.height,
+      self.camera_sensors[list_idx].cfg.width,
+      3,
+    )
+
+  def get_depth(self, cam_idx: int) -> torch.Tensor:
+    if not any(self._render_depth):
+      raise RuntimeError(
+        "Depth rendering is not enabled. Ensure at least one camera sensor has "
+        "'depth' in its type configuration."
+      )
+
+    if cam_idx not in self._cam_idx_to_list_idx:
+      available = list(self._cam_idx_to_list_idx.keys())
+      raise KeyError(
+        f"Camera ID {cam_idx} not found in RenderManager. "
+        f"Available camera IDs: {available}"
+      )
+
+    # Map MuJoCo camera ID to sorted list index.
+    list_idx = self._cam_idx_to_list_idx[cam_idx]
+    depth_torch = wp.to_torch(self._ctx.depth_data)
+    start = int(self._depth_adr[list_idx])
+    size = int(self._depth_size[list_idx])
+    depth_flat = depth_torch[:, start : start + size]
+    return depth_flat.reshape(
+      self._data.nworld,
+      self.camera_sensors[list_idx].cfg.height,
+      self.camera_sensors[list_idx].cfg.width,
+      1,
+    )

--- a/src/mjlab/sensor/sensor.py
+++ b/src/mjlab/sensor/sensor.py
@@ -17,11 +17,18 @@ if TYPE_CHECKING:
 T = TypeVar("T")
 
 
-@dataclass
+@dataclass(kw_only=True)
 class SensorCfg(ABC):
   """Base configuration for a sensor."""
 
   name: str
+  update_period: float = 0.0
+  """Sensor update period, in seconds.
+
+  Controls how frequently the sensor reads fresh data based on accumulated time.
+  For example, update_period=0.033 means ~30 Hz regardless of simulation rate.
+  Set to 0.0 to update every step (default).
+  """
 
   @abstractmethod
   def build(self) -> Sensor[Any]:
@@ -36,6 +43,13 @@ class Sensor(ABC, Generic[T]):
   - Sensor[torch.Tensor] for sensors returning raw tensors
   - Sensor[ContactData] for sensors returning structured contact data
   """
+
+  def __init__(self, update_period: float = 0.0) -> None:
+    self._timestamp = 0.0
+    self._next_update_time = 0.0
+    self._is_outdated = True
+    self._cached_data: T | None = None
+    self._update_period = update_period
 
   @abstractmethod
   def edit_spec(
@@ -76,36 +90,90 @@ class Sensor(ABC, Generic[T]):
     raise NotImplementedError
 
   @property
-  @abstractmethod
   def data(self) -> T:
     """Get the current sensor data.
 
-    This property returns the sensor's current data in its specific type.
-    The data type is specified by the type parameter T.
+    This property returns cached data if the sensor is not yet outdated based on
+    update_period. Otherwise, it recomputes the data by calling _read().
 
     Returns:
       The sensor data in the format specified by type parameter T.
+    """
+    # When update_period is 0, always get fresh data (no caching).
+    if self._update_period == 0.0:
+      return self._read()
+
+    # With update_period > 0, use caching and only refresh when outdated.
+    if self._is_outdated:
+      self._cached_data = self._read()
+      self._is_outdated = False
+    assert self._cached_data is not None, "Sensor data not initialized"
+    return self._cached_data
+
+  @abstractmethod
+  def _read(self) -> T:
+    """Read and return fresh sensor data.
+
+    This method should be implemented by subclasses to read the actual
+    sensor data. It is only called when the sensor is outdated based on
+    update_period timing.
+
+    Returns:
+      Fresh sensor data in the format specified by type parameter T.
     """
     raise NotImplementedError
 
   def reset(self, env_ids: torch.Tensor | slice | None = None) -> None:
     """Reset sensor state for specified environments.
 
-    Base implementation does nothing. Override in subclasses that maintain
-    internal state.
+    Marks sensor as outdated so it will update on next data access.
 
     Args:
       env_ids: Environment indices to reset. If None, reset all environments.
     """
-    del env_ids  # Unused.
+    # Reset timestamps and mark as outdated.
+    self._timestamp = 0.0
+    self._next_update_time = 0.0
+    self._is_outdated = True
+
+    # Hook for subclasses to add custom reset logic.
+    self._on_reset(env_ids)
+
+  def _on_reset(self, env_ids: torch.Tensor | slice | None = None) -> None:
+    """Override this in subclasses to add custom reset logic.
+
+    Args:
+      env_ids: Environment indices to reset. If None, reset all environments.
+    """
+    pass
 
   def update(self, dt: float) -> None:
-    """Update sensor state after a simulation step.
+    """Update sensor timestamp and check if data needs refresh.
 
-    Base implementation does nothing. Override in subclasses that need
-    per-step updates.
+    This method updates the internal timestamp and marks the sensor as outdated
+    if enough time has passed based on update_period.
 
     Args:
       dt: Time step in seconds.
     """
-    del dt  # Unused.
+    self._timestamp += dt
+
+    # Check if sensor needs an update.
+    if self._update_period > 0.0:
+      if self._timestamp >= self._next_update_time:
+        self._is_outdated = True
+        self._next_update_time = self._timestamp + self._update_period
+    else:
+      assert self._update_period == 0.0  # Update every step.
+      self._is_outdated = True
+
+    # Hook for subclasses to add custom update logic.
+    self._on_update(dt)
+
+  def _on_update(self, dt: float) -> None:
+    """Override this in subclasses to add custom update logic.
+
+    Args:
+      dt: Time step in seconds.
+    """
+    pass

--- a/src/mjlab/tasks/tracking/config/g1/__init__.py
+++ b/src/mjlab/tasks/tracking/config/g1/__init__.py
@@ -1,7 +1,9 @@
 from mjlab.tasks.registry import register_mjlab_task
 from mjlab.tasks.tracking.rl import MotionTrackingOnPolicyRunner
 
-from .env_cfgs import unitree_g1_flat_tracking_env_cfg
+from .env_cfgs import (
+  unitree_g1_flat_tracking_env_cfg,
+)
 from .rl_cfg import unitree_g1_tracking_ppo_runner_cfg
 
 register_mjlab_task(

--- a/src/mjlab/tasks/tracking/config/g1/env_cfgs.py
+++ b/src/mjlab/tasks/tracking/config/g1/env_cfgs.py
@@ -7,7 +7,7 @@ from mjlab.asset_zoo.robots import (
 from mjlab.envs import ManagerBasedRlEnvCfg
 from mjlab.envs.mdp.actions import JointPositionActionCfg
 from mjlab.managers.manager_term_config import ObservationGroupCfg
-from mjlab.sensor import ContactMatch, ContactSensorCfg
+from mjlab.sensor import CameraSensorCfg, ContactMatch, ContactSensorCfg
 from mjlab.tasks.tracking.mdp import MotionCommandCfg
 from mjlab.tasks.tracking.tracking_env_cfg import make_tracking_env_cfg
 
@@ -96,5 +96,27 @@ def unitree_g1_flat_tracking_env_cfg(
     motion_cmd.velocity_range = {}
 
     motion_cmd.sampling_mode = "start"
+
+  # 16:9 aspect ratio camera.
+  width = 128
+  height = int(width * 9 / 16)
+  dt = 1.0 / 20.0
+  depth_camera_cfg = CameraSensorCfg(
+    name="depth",
+    camera_name="robot/depth",
+    width=width,
+    height=height,
+    type=("depth",),
+    update_period=dt,
+  )
+  rgb_camera_cfg = CameraSensorCfg(
+    name="rgb",
+    camera_name="robot/tracking",
+    width=width,
+    height=height,
+    type=("rgb",),
+    update_period=dt,
+  )
+  cfg.scene.sensors = cfg.scene.sensors + (depth_camera_cfg, rgb_camera_cfg)
 
   return cfg

--- a/src/mjlab/terrains/terrain_importer.py
+++ b/src/mjlab/terrains/terrain_importer.py
@@ -14,12 +14,13 @@ _DEFAULT_PLANE_TEXTURE = spec_cfg.TextureCfg(
   name="groundplane",
   type="2d",
   builtin="checker",
-  mark="edge",
   rgb1=(0.2, 0.3, 0.4),
   rgb2=(0.1, 0.2, 0.3),
-  markrgb=(0.8, 0.8, 0.8),
   width=300,
   height=300,
+  # NOTE: These don't render nicely with the CameraSensor.
+  # markrgb=(0.8, 0.8, 0.8),
+  # mark="edge",
 )
 
 _DEFAULT_PLANE_MATERIAL = spec_cfg.MaterialCfg(

--- a/src/mjlab/viewer/viser_camera_viewer.py
+++ b/src/mjlab/viewer/viser_camera_viewer.py
@@ -1,0 +1,89 @@
+"""Camera image visualization for Viser viewer."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import viser
+
+if TYPE_CHECKING:
+  from mjlab.sensor.camera_sensor import CameraSensor
+
+
+class ViserCameraViewer:
+  """Handles camera image visualization for the Viser viewer."""
+
+  def __init__(
+    self,
+    server: viser.ViserServer,
+    camera_sensor: CameraSensor,
+  ):
+    """Initialize the camera viewer.
+
+    Args:
+      server: The Viser server instance
+      camera_sensor: The camera sensor to visualize
+    """
+    self._server = server
+    self._camera_sensor = camera_sensor
+
+    self._rgb_handle: viser.GuiImageHandle | None = None
+    self._depth_handle: viser.GuiImageHandle | None = None
+
+    self._camera_name = camera_sensor.camera_name
+
+    self._has_rgb = "rgb" in self._camera_sensor.cfg.type
+    self._has_depth = "depth" in self._camera_sensor.cfg.type
+
+    height = self._camera_sensor.cfg.height
+    width = self._camera_sensor.cfg.width
+
+    if self._has_rgb:
+      self._rgb_handle = self._server.gui.add_image(
+        image=np.zeros((height, width, 3), dtype=np.uint8),
+        label=f"{self._camera_name}_rgb",
+        format="jpeg",
+      )
+
+    if self._has_depth:
+      self._depth_handle = self._server.gui.add_image(
+        image=np.zeros((height, width), dtype=np.uint8),
+        label=f"{self._camera_name}_depth",
+        format="jpeg",
+      )
+
+  def update(self, env_idx: int = 0) -> None:
+    """Update the camera images for a single environment.
+
+    Only updates viser when sensor has new data to avoid expensive GPU->CPU
+    transfers and JPEG encoding.
+
+    Args:
+      env_idx: Environment index to visualize
+    """
+    will_read_fresh = (
+      self._camera_sensor._update_period == 0.0 or self._camera_sensor._is_outdated
+    )
+    if not will_read_fresh:
+      return
+
+    data = self._camera_sensor.data
+
+    if self._has_rgb and self._rgb_handle is not None and data.rgb is not None:
+      rgb_np = data.rgb[env_idx].cpu().numpy()
+      self._rgb_handle.image = rgb_np
+
+    if self._has_depth and self._depth_handle is not None and data.depth is not None:
+      depth_np = data.depth[env_idx].squeeze().cpu().numpy()
+      depth_scale = 5.0
+      depth_normalized = np.clip(depth_np / depth_scale, 0.0, 1.0)
+      depth_uint8 = (depth_normalized * 255).astype(np.uint8)
+      self._depth_handle.image = depth_uint8
+
+  def cleanup(self) -> None:
+    """Clean up resources."""
+    if self._rgb_handle is not None:
+      self._rgb_handle.remove()
+    if self._depth_handle is not None:
+      self._depth_handle.remove()

--- a/src/mjlab/viewer/viser_play.py
+++ b/src/mjlab/viewer/viser_play.py
@@ -10,8 +10,10 @@ from concurrent.futures import ThreadPoolExecutor
 import viser
 from typing_extensions import override
 
+from mjlab.sensor.camera_sensor import CameraSensor
 from mjlab.sim.sim import Simulation
 from mjlab.viewer.base import BaseViewer, EnvProtocol, PolicyProtocol, VerbosityLevel
+from mjlab.viewer.viser_camera_viewer import ViserCameraViewer
 from mjlab.viewer.viser_reward_plotter import ViserRewardPlotter
 from mjlab.viewer.viser_scene import ViserMujocoScene
 
@@ -28,6 +30,7 @@ class ViserPlayViewer(BaseViewer):
   ) -> None:
     super().__init__(env, policy, frame_rate, verbosity)
     self._reward_plotter: ViserRewardPlotter | None = None
+    self._camera_viewers: list[ViserCameraViewer] = []
 
   @override
   def setup(self) -> None:
@@ -40,7 +43,7 @@ class ViserPlayViewer(BaseViewer):
     self._counter = 0
     self._needs_update = False
 
-    # Create ViserMujocoScene for all 3D visualization (with debug visualization enabled).
+    # Create ViserMujocoScene for all 3D visualization.
     self._scene = ViserMujocoScene.create(
       server=self._server,
       mj_model=sim.mj_model,
@@ -102,7 +105,7 @@ class ViserPlayViewer(BaseViewer):
             self.increase_speed()
           self._update_status_display()
 
-      # Add standard visualization options from ViserMujocoScene (Environment, Visualization, Contacts, Camera Tracking, Debug Visualization).
+      # Add standard visualization options from ViserMujocoScene.
       self._scene.create_visualization_gui(
         camera_distance=self.cfg.distance,
         camera_azimuth=self.cfg.azimuth,
@@ -122,6 +125,22 @@ class ViserPlayViewer(BaseViewer):
           )
         ]
         self._reward_plotter = ViserRewardPlotter(self._server, term_names)
+
+    # Camera tab - collect all camera sensors
+    camera_sensors = [
+      sensor
+      for sensor in self.env.unwrapped.scene.sensors.values()
+      if isinstance(sensor, CameraSensor)
+    ]
+
+    if camera_sensors:
+      with tabs.add_tab("Camera", icon=viser.Icon.CAMERA):
+        # Create a viewer for each camera sensor
+        self._camera_viewers = [
+          ViserCameraViewer(self._server, sensor) for sensor in camera_sensors
+        ]
+    else:
+      self._camera_viewers = []
 
     # Geom groups tab.
     self._scene.create_geom_groups_gui(tabs)
@@ -149,6 +168,11 @@ class ViserPlayViewer(BaseViewer):
           )
         )
         self._reward_plotter.update(terms)
+
+    # Update camera images (sensor update_period handles rate limiting)
+    if self._camera_viewers and not self._is_paused:
+      for camera_viewer in self._camera_viewers:
+        camera_viewer.update(self._scene.env_idx)
 
     # Update debug visualizations if enabled
     if self._scene.debug_visualization_enabled and hasattr(
@@ -187,6 +211,8 @@ class ViserPlayViewer(BaseViewer):
     """Close the viewer and cleanup resources."""
     if self._reward_plotter:
       self._reward_plotter.cleanup()
+    for camera_viewer in self._camera_viewers:
+      camera_viewer.cleanup()
     self._threadpool.shutdown(wait=True)
     self._server.stop()
 
@@ -197,10 +223,12 @@ class ViserPlayViewer(BaseViewer):
 
   def _update_status_display(self) -> None:
     """Update the HTML status display."""
+    fps_display = f"{self._smoothed_fps:.1f}" if self._smoothed_fps > 0 else "—"
     self._status_html.content = f"""
       <div style="font-size: 0.85em; line-height: 1.25; padding: 0 1em 0.5em 1em;">
         <strong>Status:</strong> {"Paused" if self._is_paused else "Running"}<br/>
         <strong>Steps:</strong> {self._step_count}<br/>
-        <strong>Speed:</strong> {self._time_multiplier:.0%}
+        <strong>Speed:</strong> {self._time_multiplier:.0%}<br/>
+        <strong>FPS:</strong> {fps_display}
       </div>
       """

--- a/tests/test_camera_sensor.py
+++ b/tests/test_camera_sensor.py
@@ -1,0 +1,363 @@
+"""Tests for camera_sensor.py."""
+
+from __future__ import annotations
+
+import mujoco
+import pytest
+import torch
+from conftest import get_test_device
+
+from mjlab.entity import EntityCfg
+from mjlab.scene import Scene, SceneCfg
+from mjlab.sensor.camera_sensor import CameraSensorCfg
+from mjlab.sim.sim import Simulation, SimulationCfg
+
+
+@pytest.fixture(scope="module")
+def device():
+  """Test device fixture."""
+  return get_test_device()
+
+
+@pytest.fixture(scope="module")
+def simple_world_xml():
+  """XML for a simple world with a box."""
+  return """
+    <mujoco>
+      <worldbody>
+        <geom name="floor" type="plane" size="5 5 0.1" pos="0 0 0"/>
+        <body name="box" pos="0 0 0.5">
+          <geom name="box_geom" type="box" size="0.2 0.2 0.2" rgba="1 0 0 1"/>
+        </body>
+      </worldbody>
+    </mujoco>
+  """
+
+
+@pytest.fixture(scope="module")
+def world_with_camera_xml():
+  """XML for world with existing camera."""
+  return """
+    <mujoco>
+      <worldbody>
+        <geom name="floor" type="plane" size="5 5 0.1" pos="0 0 0"/>
+        <body name="box" pos="0 0 0.5">
+          <geom name="box_geom" type="box" size="0.2 0.2 0.2" rgba="1 0 0 1"/>
+          <camera name="box_cam" pos="0 0 1" quat="1 0 0 0"/>
+        </body>
+      </worldbody>
+    </mujoco>
+  """
+
+
+def test_camera_sensor_rgb_output(simple_world_xml, device):
+  """Verify camera sensor returns RGB data with correct shape."""
+  entity_cfg = EntityCfg(spec_fn=lambda: mujoco.MjSpec.from_string(simple_world_xml))
+
+  camera_cfg = CameraSensorCfg(
+    name="test_cam",
+    pos=(2.0, 0.0, 1.0),
+    quat=(0.924, 0.0, 0.383, 0.0),
+    width=64,
+    height=48,
+    type=("rgb",),
+  )
+
+  scene_cfg = SceneCfg(
+    num_envs=2,
+    env_spacing=5.0,
+    entities={"world": entity_cfg},
+    sensors=(camera_cfg,),
+  )
+
+  scene = Scene(scene_cfg, device)
+  model = scene.compile()
+  sim_cfg = SimulationCfg(njmax=10)
+  sim = Simulation(num_envs=2, cfg=sim_cfg, model=model, device=device)
+  scene.initialize(sim.mj_model, sim.model, sim.data)
+
+  sensor = scene["test_cam"]
+  sim.step()
+  scene.update(sim.mj_model.opt.timestep)
+  data = sensor.data
+
+  assert data.rgb is not None
+  assert data.depth is None
+  assert data.rgb.shape == (2, 48, 64, 3)
+  assert data.rgb.dtype == torch.uint8
+
+
+def test_camera_sensor_depth_output(simple_world_xml, device):
+  """Verify camera sensor returns depth data with correct shape."""
+  entity_cfg = EntityCfg(spec_fn=lambda: mujoco.MjSpec.from_string(simple_world_xml))
+
+  camera_cfg = CameraSensorCfg(
+    name="test_cam",
+    pos=(2.0, 0.0, 1.0),
+    width=64,
+    height=48,
+    type=("depth",),
+  )
+
+  scene_cfg = SceneCfg(
+    num_envs=2,
+    env_spacing=5.0,
+    entities={"world": entity_cfg},
+    sensors=(camera_cfg,),
+  )
+
+  scene = Scene(scene_cfg, device)
+  model = scene.compile()
+  sim_cfg = SimulationCfg(njmax=10)
+  sim = Simulation(num_envs=2, cfg=sim_cfg, model=model, device=device)
+  scene.initialize(sim.mj_model, sim.model, sim.data)
+
+  sensor = scene["test_cam"]
+  sim.step()
+  scene.update(sim.mj_model.opt.timestep)
+  data = sensor.data
+
+  assert data.depth is not None
+  assert data.rgb is None
+  assert data.depth.shape == (2, 48, 64, 1)
+  assert data.depth.dtype == torch.float32
+
+
+def test_camera_sensor_rgb_and_depth(simple_world_xml, device):
+  """Verify camera sensor returns both RGB and depth when configured."""
+  entity_cfg = EntityCfg(spec_fn=lambda: mujoco.MjSpec.from_string(simple_world_xml))
+
+  camera_cfg = CameraSensorCfg(
+    name="test_cam",
+    pos=(2.0, 0.0, 1.0),
+    width=32,
+    height=24,
+    type=("rgb", "depth"),
+  )
+
+  scene_cfg = SceneCfg(
+    num_envs=1,
+    env_spacing=5.0,
+    entities={"world": entity_cfg},
+    sensors=(camera_cfg,),
+  )
+
+  scene = Scene(scene_cfg, device)
+  model = scene.compile()
+  sim_cfg = SimulationCfg(njmax=10)
+  sim = Simulation(num_envs=1, cfg=sim_cfg, model=model, device=device)
+  scene.initialize(sim.mj_model, sim.model, sim.data)
+
+  sensor = scene["test_cam"]
+  sim.step()
+  scene.update(sim.mj_model.opt.timestep)
+  data = sensor.data
+
+  assert data.rgb is not None
+  assert data.depth is not None
+  assert data.rgb.shape == (1, 24, 32, 3)
+  assert data.depth.shape == (1, 24, 32, 1)
+
+
+def test_camera_sensor_wraps_existing(world_with_camera_xml, device):
+  """Verify camera sensor can wrap an existing camera from XML."""
+  entity_cfg = EntityCfg(
+    spec_fn=lambda: mujoco.MjSpec.from_string(world_with_camera_xml)
+  )
+
+  # Wrap the existing "box_cam" camera.
+  camera_cfg = CameraSensorCfg(
+    name="wrapped_cam",
+    camera_name="world/box_cam",
+    width=64,
+    height=48,
+    type=("rgb",),
+  )
+
+  scene_cfg = SceneCfg(
+    num_envs=1,
+    env_spacing=5.0,
+    entities={"world": entity_cfg},
+    sensors=(camera_cfg,),
+  )
+
+  scene = Scene(scene_cfg, device)
+  model = scene.compile()
+  sim_cfg = SimulationCfg(njmax=10)
+  sim = Simulation(num_envs=1, cfg=sim_cfg, model=model, device=device)
+  scene.initialize(sim.mj_model, sim.model, sim.data)
+
+  sensor = scene["wrapped_cam"]
+  sim.step()
+  scene.update(sim.mj_model.opt.timestep)
+  data = sensor.data
+
+  assert data.rgb is not None
+  assert data.rgb.shape == (1, 48, 64, 3)
+
+
+def test_multiple_cameras_with_different_resolutions(simple_world_xml, device):
+  """Verify multiple cameras with different resolutions work correctly."""
+  entity_cfg = EntityCfg(spec_fn=lambda: mujoco.MjSpec.from_string(simple_world_xml))
+
+  camera1_cfg = CameraSensorCfg(
+    name="cam1",
+    pos=(2.0, 0.0, 1.0),
+    width=64,
+    height=48,
+    type=("rgb",),
+  )
+
+  camera2_cfg = CameraSensorCfg(
+    name="cam2",
+    pos=(-2.0, 0.0, 1.0),
+    width=32,
+    height=24,
+    type=("rgb",),
+  )
+
+  scene_cfg = SceneCfg(
+    num_envs=2,
+    env_spacing=5.0,
+    entities={"world": entity_cfg},
+    sensors=(camera1_cfg, camera2_cfg),
+  )
+
+  scene = Scene(scene_cfg, device)
+  model = scene.compile()
+  sim_cfg = SimulationCfg(njmax=10)
+  sim = Simulation(num_envs=2, cfg=sim_cfg, model=model, device=device)
+  scene.initialize(sim.mj_model, sim.model, sim.data)
+
+  sensor1 = scene["cam1"]
+  sensor2 = scene["cam2"]
+
+  sim.step()
+  scene.update(sim.mj_model.opt.timestep)
+
+  data1 = sensor1.data
+  data2 = sensor2.data
+
+  assert data1.rgb.shape == (2, 48, 64, 3)
+  assert data2.rgb.shape == (2, 24, 32, 3)
+
+
+def test_camera_update_period_caching(simple_world_xml, device):
+  """Verify camera sensor respects update_period for caching."""
+  entity_cfg = EntityCfg(spec_fn=lambda: mujoco.MjSpec.from_string(simple_world_xml))
+
+  # Camera with 0.1s update period.
+  camera_cfg = CameraSensorCfg(
+    name="test_cam",
+    pos=(2.0, 0.0, 1.0),
+    width=32,
+    height=24,
+    type=("rgb",),
+    update_period=0.1,
+  )
+
+  scene_cfg = SceneCfg(
+    num_envs=1,
+    env_spacing=5.0,
+    entities={"world": entity_cfg},
+    sensors=(camera_cfg,),
+  )
+
+  scene = Scene(scene_cfg, device)
+  model = scene.compile()
+  sim_cfg = SimulationCfg(njmax=10)
+  sim = Simulation(num_envs=1, cfg=sim_cfg, model=model, device=device)
+  scene.initialize(sim.mj_model, sim.model, sim.data)
+
+  sensor = scene["test_cam"]
+  dt = sim.mj_model.opt.timestep
+
+  sim.step()
+  scene.update(dt)
+
+  # First access triggers rendering.
+  assert sensor._is_outdated
+  _ = sensor.data
+  assert not sensor._is_outdated
+
+  # Step many times (less than update_period).
+  for _ in range(40):
+    sim.step()
+    scene.update(dt)
+
+  # Should still be cached.
+  assert not sensor._is_outdated
+
+  # Step enough to exceed update_period.
+  for _ in range(30):
+    sim.step()
+    scene.update(dt)
+
+  # Should be outdated now.
+  assert sensor._is_outdated
+
+
+def test_error_on_mismatched_render_settings(simple_world_xml, device):
+  """Verify error when cameras have inconsistent render settings."""
+  entity_cfg = EntityCfg(spec_fn=lambda: mujoco.MjSpec.from_string(simple_world_xml))
+
+  camera1_cfg = CameraSensorCfg(
+    name="cam1",
+    pos=(2.0, 0.0, 1.0),
+    width=64,
+    height=48,
+    type=("rgb",),
+    use_textures=True,
+  )
+
+  camera2_cfg = CameraSensorCfg(
+    name="cam2",
+    pos=(-2.0, 0.0, 1.0),
+    width=64,
+    height=48,
+    type=("rgb",),
+    use_textures=False,
+  )
+
+  scene_cfg = SceneCfg(
+    num_envs=1,
+    env_spacing=5.0,
+    entities={"world": entity_cfg},
+    sensors=(camera1_cfg, camera2_cfg),
+  )
+
+  scene = Scene(scene_cfg, device)
+  model = scene.compile()
+  sim_cfg = SimulationCfg(njmax=10)
+  sim = Simulation(num_envs=1, cfg=sim_cfg, model=model, device=device)
+
+  with pytest.raises(ValueError, match="use_textures"):
+    scene.initialize(sim.mj_model, sim.model, sim.data)
+
+
+def test_error_on_invalid_camera_name(simple_world_xml, device):
+  """Verify error when wrapping nonexistent camera."""
+  entity_cfg = EntityCfg(spec_fn=lambda: mujoco.MjSpec.from_string(simple_world_xml))
+
+  camera_cfg = CameraSensorCfg(
+    name="bad_cam",
+    camera_name="world/nonexistent_cam",
+    width=64,
+    height=48,
+    type=("rgb",),
+  )
+
+  scene_cfg = SceneCfg(
+    num_envs=1,
+    env_spacing=5.0,
+    entities={"world": entity_cfg},
+    sensors=(camera_cfg,),
+  )
+
+  scene = Scene(scene_cfg, device)
+  model = scene.compile()
+  sim_cfg = SimulationCfg(njmax=10)
+  sim = Simulation(num_envs=1, cfg=sim_cfg, model=model, device=device)
+
+  with pytest.raises(ValueError, match="not found in model"):
+    scene.initialize(sim.mj_model, sim.model, sim.data)

--- a/uv.lock
+++ b/uv.lock
@@ -973,7 +973,7 @@ dev = [
 requires-dist = [
     { name = "moviepy" },
     { name = "mujoco", specifier = "<=3.3.8", index = "https://py.mujoco.org/" },
-    { name = "mujoco-warp", git = "https://github.com/google-deepmind/mujoco_warp?rev=e605c406363805d949b75d50dd5ffb3d79bc3f70" },
+    { name = "mujoco-warp", editable = "../mujoco_warp" },
     { name = "onnxscript", specifier = ">=0.5.4" },
     { name = "prettytable" },
     { name = "rsl-rl-lib" },
@@ -1165,7 +1165,7 @@ wheels = [
 [[package]]
 name = "mujoco-warp"
 version = "0.0.1"
-source = { git = "https://github.com/google-deepmind/mujoco_warp?rev=e605c406363805d949b75d50dd5ffb3d79bc3f70#e605c406363805d949b75d50dd5ffb3d79bc3f70" }
+source = { editable = "../mujoco_warp" }
 dependencies = [
     { name = "absl-py" },
     { name = "etils", extra = ["epath"] },
@@ -1175,6 +1175,25 @@ dependencies = [
     { name = "numpy", version = "2.3.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "warp-lang" },
 ]
+
+[package.metadata]
+requires-dist = [
+    { name = "absl-py" },
+    { name = "asv", marker = "extra == 'dev'" },
+    { name = "etils", extras = ["epath"] },
+    { name = "jax", marker = "extra == 'cpu'" },
+    { name = "jax", extras = ["cuda12"], marker = "extra == 'cuda'" },
+    { name = "lsprotocol", marker = "extra == 'dev'", specifier = ">=2023.0.1,<2024.0.0" },
+    { name = "mujoco", specifier = ">=3.3.7", index = "https://py.mujoco.org/" },
+    { name = "numpy" },
+    { name = "pre-commit", marker = "extra == 'dev'" },
+    { name = "pygls", marker = "extra == 'dev'", specifier = ">=1.0.0,<2.0.0" },
+    { name = "pytest", marker = "extra == 'dev'" },
+    { name = "pytest-xdist", marker = "extra == 'dev'" },
+    { name = "ruff", marker = "extra == 'dev'" },
+    { name = "warp-lang", specifier = ">=1.9.1", index = "https://pypi.nvidia.com/" },
+]
+provides-extras = ["dev", "cpu", "cuda"]
 
 [[package]]
 name = "networkx"
@@ -3081,17 +3100,17 @@ wheels = [
 
 [[package]]
 name = "warp-lang"
-version = "1.11.0.dev20251027"
+version = "1.11.0.dev20251115"
 source = { registry = "https://pypi.nvidia.com/" }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 wheels = [
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.11.0.dev20251027-py3-none-macosx_11_0_arm64.whl", hash = "sha256:ce02774f04d1c5fbb147c457081183499ee9fcae0ce04ca72245ef6e3ad429f4" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.11.0.dev20251027-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:03907be5580a9b7cb76217fc691ba49cee5de6556ad379cfaf2878844d9bb821" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.11.0.dev20251027-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:1e42a226f9087a3a8ae383e3031d7855b360eb25a1b75cb9ee90ac631da897d5" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.11.0.dev20251027-py3-none-win_amd64.whl", hash = "sha256:1195827b96ad3c9db9e8994d15750e6014f4ee5098ba6cfaeef4b5cb7b652fd0" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.11.0.dev20251115-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e6c7bb4161870be27cd5a4a2f85392b9f06265bf15256c5d849a05e9a7e5f0c2" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.11.0.dev20251115-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:a3ddda2336e228e080f96cf1e2a9c1a35b30297e66518589cd9a04f1c496e988" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.11.0.dev20251115-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:3ce6c2490447c3e4a5632aee2cb51506011929404dcb6d9885fb0e394e8578e2" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.11.0.dev20251115-py3-none-win_amd64.whl", hash = "sha256:b14e7f24693efdc59d4fba2104edb3c1de24cfcdf5d5cd8d0e4454e00fa406ea" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR adds camera sensors for rgb and depth rendering using mujoco warp's tiled camera renderer. The implementation batches all camera rendering into a single GPU call and supports configurable update rates to decouple rendering frequency from physics simulation rate.

![combined_grid](https://github.com/user-attachments/assets/ceb81b4f-1227-4223-ac81-1d73f850a42e)
<p align="center">
<em>4x4 grid of 16 parallel environments. Left: RGB from tracking camera. Right: Depth from RealSense camera mounted in G1 head.</em>
</p>

## Changes

- Added `CameraSensor` for RGB/depth image capture with configurable update periods
- Added `RenderManager` for batched rendering across all cameras
- Extended base `Sensor` class with `update_period` support and caching to avoid redundant reads
- Updated `BuiltinSensor` and `ContactSensor` to use new caching mechanism
- Added `ViserCameraViewer` for real-time camera feed visualization
- Integrated rendering into `Scene` and `ManagerBasedRlEnv` step/reset flows
- Added example depth camera configuration for G1 humanoid

## Configuration

Camera sensors are declared in the scene's `sensors` tuple. Each `CameraSensorCfg` is a dataclass; the engine instantiates sensors during scene construction. Sensors can either create new cameras or reference existing ones defined in your robot's XML.

```python
from mjlab.sensor import CameraSensorCfg

scene_cfg = SceneCfg(
  sensors=(
    CameraSensorCfg(
      name="front_camera",
      pos=(0.3, 0.0, 0.5),
      quat=(0.707, 0, 0.707, 0),
      fovy=60,
      width=160,
      height=120,
      type=("rgb", "depth"),
      update_period=0.033,  # 30 Hz
    ),
  ),
)
```

### Wrapping Existing XML Cameras

To use cameras already defined in your robot's XML:

```python
# Robot XML has: <camera name="head_cam" pos="..." quat="..."/>

CameraSensorCfg(
  name="head_sensor",
  camera_name="head_cam",  # Reference existing camera
  width=160,
  height=120,
  type=("rgb",),
  update_period=0.05,  # 20 Hz
)
```

The sensor wraps the existing camera without creating a new one. If `camera_name` is not specified, a new camera is created using the sensor's `name`, `pos`, `quat`, and `fovy` parameters.

## Sensor Data

Camera sensors return `CameraSensorData` with optional RGB and depth tensors:

```python
camera = env.scene.sensors["front_camera"]
data = camera.data  # CameraSensorData

# Shape: [num_envs, height, width, 3], dtype: uint8
rgb = data.rgb

# Shape: [num_envs, height, width, 1], dtype: float32
depth = data.depth
```

Fields are `None` if not requested in the sensor's `type` configuration.

## Update Periods and Caching

All sensors now support `update_period` to control read frequency:

```python
CameraSensorCfg(
  name="camera",
  update_period=0.033,  # Read fresh data every 33ms (~30 Hz)
  # ... other params
)
```

When `update_period > 0`, the sensor caches data and only refreshes when enough time has elapsed. This decouples sensor updates from physics simulation rate. For example, with 500Hz physics (2ms steps) and `update_period=0.033`, the sensor updates every ~17 physics steps.

Set `update_period=0.0` (default) to read fresh data every step.

The caching mechanism is implemented in the base `Sensor` class, so it applies to all sensor types (builtin, contact, camera).

## Batched Rendering

`RenderManager` coordinates rendering across all camera sensors:

- **Static enablement**: Only cameras with corresponding sensors are included in the render context. XML files may define many cameras, but only sensor-backed cameras are enabled for rendering.
- **Dynamic rendering**: On each `render()` call, only cameras with outdated data (based on `update_period`) actually render.

All enabled cameras render in a single batched GPU call. RGB data is unpacked from packed RGBA format using a Warp kernel.

**Note**: All camera sensors in a scene must share the same rendering settings (`use_textures`, `use_shadows`, `enabled_geom_groups`). This constraint comes from the tiled renderer's design.

## Example: G1 Humanoid with Depth Camera

```python
from mjlab.sensor import CameraSensorCfg

# G1 XML includes: <camera name="depth" pos="0.055 0.017 0.433" .../>

scene_cfg = SceneCfg(
  sensors=(
    CameraSensorCfg(
      name="depth_sensor",
      camera_name="robot/depth",  # Reference the XML camera (note the prefix)
      width=128,
      height=72,  # 16:9 aspect ratio
      type=("depth",),
      update_period=0.05,  # 20 Hz
    ),
  ),
)
```

## Viser Integration

Camera feeds now automatically appear in the Viser viewer GUI:

https://github.com/user-attachments/assets/17ff315d-2f83-4179-a41e-68a914aa1ae2


