### PR TITLE
Remove unused and non-existent import from create_new_task.md

### DIFF
--- a/docs/create_new_task.md
+++ b/docs/create_new_task.md
@@ -50,8 +50,7 @@ from pathlib import Path
 import mujoco
 
 from mjlab import MJLAB_SRC_PATH
-from mjlab.entity import Entity, EntityCfg, EntityArticulationInfoCfg
-from mjlab.utils.spec_config import ActuatorCfg
+from mjlab.entity import Entity, EntityCfg
 
 CARTPOLE_XML: Path = (
   MJLAB_SRC_PATH / "asset_zoo" / "robots" / "cartpole" / "xmls" / "cartpole.xml"


### PR DESCRIPTION
Removed the `EntityArticulationInfoCfg` because it is unused and the `ActuatorCfg` import because it no longer exists in the `mjlab.utils.spec_config` module.