### PR TITLE
Fix ctrl_ids ordering to use natural joint order.

### DIFF
--- a/src/mjlab/entity/entity.py
+++ b/src/mjlab/entity/entity.py
@@ -694,8 +694,19 @@ class Entity:
     joint_ids = torch.tensor([j.id for j in joints], dtype=torch.int, device=device)
 
     if self.is_actuated:
+      # Build mapping from joint name to actuator ctrl_id.
+      # Each spec actuator controls exactly one joint (via its target field).
+      joint_name_to_ctrl_id = {}
+      for actuator in self.spec.actuators:
+        joint_name = actuator.target.split("/")[-1]
+        joint_name_to_ctrl_id[joint_name] = actuator.id
+      # Get ctrl_ids in natural joint order (same order as self.joint_names).
+      ctrl_ids_list = []
+      for joint_name in self.joint_names:
+        if joint_name in joint_name_to_ctrl_id:
+          ctrl_ids_list.append(joint_name_to_ctrl_id[joint_name])
+      ctrl_ids = torch.tensor(ctrl_ids_list, dtype=torch.int, device=device)
       actuators = tuple(self.spec.actuators)
-      ctrl_ids = torch.tensor([a.id for a in actuators], dtype=torch.int, device=device)
     else:
       actuators = None
       ctrl_ids = torch.empty(0, dtype=torch.int, device=device)

--- a/src/mjlab/rl/exporter_utils.py
+++ b/src/mjlab/rl/exporter_utils.py
@@ -1,0 +1,71 @@
+"""Shared utilities for ONNX policy export across RL tasks."""
+
+import onnx
+import torch
+
+from mjlab.entity import Entity
+from mjlab.envs import ManagerBasedRlEnv
+from mjlab.envs.mdp.actions.joint_actions import JointAction
+
+
+def list_to_csv_str(arr, *, decimals: int = 3, delimiter: str = ",") -> str:
+  """Convert list to CSV string with specified decimal precision."""
+  fmt = f"{{:.{decimals}f}}"
+  return delimiter.join(
+    fmt.format(x)
+    if isinstance(x, (int, float))
+    else str(x)  # numbers → format, strings → as-is
+    for x in arr
+  )
+
+
+def get_base_metadata(
+  env: ManagerBasedRlEnv, run_path: str
+) -> dict[str, list | str | float]:
+  """Get base metadata common to all RL policy exports.
+
+  Args:
+    env: The RL environment.
+    run_path: W&B run path or other identifier.
+
+  Returns:
+    Dictionary of metadata fields that are common across all tasks.
+  """
+  robot: Entity = env.scene["robot"]
+  joint_action = env.action_manager.get_term("joint_pos")
+  assert isinstance(joint_action, JointAction)
+  ctrl_ids = robot.indexing.ctrl_ids.cpu().numpy()
+  joint_stiffness = env.sim.mj_model.actuator_gainprm[ctrl_ids, 0]
+  joint_damping = -env.sim.mj_model.actuator_biasprm[ctrl_ids, 2]
+  return {
+    "run_path": run_path,
+    "joint_names": list(robot.joint_names),
+    "joint_stiffness": joint_stiffness.tolist(),
+    "joint_damping": joint_damping.tolist(),
+    "default_joint_pos": robot.data.default_joint_pos[0].cpu().tolist(),
+    "command_names": list(env.command_manager.active_terms),
+    "observation_names": env.observation_manager.active_terms["policy"],
+    "action_scale": joint_action._scale[0].cpu().tolist()
+    if isinstance(joint_action._scale, torch.Tensor)
+    else joint_action._scale,
+  }
+
+
+def attach_metadata_to_onnx(
+  onnx_path: str, metadata: dict[str, list | str | float]
+) -> None:
+  """Attach metadata to an ONNX model file.
+
+  Args:
+    onnx_path: Path to the ONNX model file.
+    metadata: Dictionary of metadata key-value pairs to attach.
+  """
+  model = onnx.load(onnx_path)
+
+  for k, v in metadata.items():
+    entry = onnx.StringStringEntryProto()
+    entry.key = k
+    entry.value = list_to_csv_str(v) if isinstance(v, list) else str(v)
+    model.metadata_props.append(entry)
+
+  onnx.save(model, onnx_path)

--- a/src/mjlab/tasks/tracking/rl/exporter.py
+++ b/src/mjlab/tasks/tracking/rl/exporter.py
@@ -1,12 +1,13 @@
 import os
 from typing import cast
 
-import onnx
 import torch
 
-from mjlab.entity import Entity
 from mjlab.envs import ManagerBasedRlEnv
-from mjlab.envs.mdp.actions.joint_actions import JointAction
+from mjlab.rl.exporter_utils import (
+  attach_metadata_to_onnx,
+  get_base_metadata,
+)
 from mjlab.tasks.tracking.mdp import MotionCommand
 from mjlab.third_party.isaaclab.isaaclab_rl.rsl_rl.exporter import _OnnxPolicyExporter
 
@@ -80,50 +81,31 @@ class _OnnxMotionPolicyExporter(_OnnxPolicyExporter):
     )
 
 
-def list_to_csv_str(arr, *, decimals: int = 3, delimiter: str = ",") -> str:
-  fmt = f"{{:.{decimals}f}}"
-  return delimiter.join(
-    fmt.format(x)
-    if isinstance(x, (int, float))
-    else str(x)  # numbers → format, strings → as-is
-    for x in arr
-  )
-
-
 def attach_onnx_metadata(
   env: ManagerBasedRlEnv, run_path: str, path: str, filename="policy.onnx"
 ) -> None:
-  robot: Entity = env.scene["robot"]
+  """Attach tracking-specific metadata to ONNX model.
+
+  Args:
+    env: The RL environment.
+    run_path: W&B run path or other identifier.
+    path: Directory containing the ONNX file.
+    filename: Name of the ONNX file.
+  """
   onnx_path = os.path.join(path, filename)
-  joint_action = env.action_manager.get_term("joint_pos")
-  assert isinstance(joint_action, JointAction)
-  ctrl_ids = robot.indexing.ctrl_ids.cpu().numpy()
-  joint_stiffness = env.sim.mj_model.actuator_gainprm[ctrl_ids, 0]
-  joint_damping = -env.sim.mj_model.actuator_biasprm[ctrl_ids, 2]
+
+  # Get base metadata common to all tasks.
+  metadata = get_base_metadata(env, run_path)
+
+  # Add tracking-specific metadata.
   motion_term = env.command_manager.get_term("motion")
   assert isinstance(motion_term, MotionCommand)
   motion_term_cfg = motion_term.cfg
-  metadata = {
-    "run_path": run_path,
-    "joint_names": list(robot.joint_names),
-    "joint_stiffness": joint_stiffness.tolist(),
-    "joint_damping": joint_damping.tolist(),
-    "default_joint_pos": robot.data.default_joint_pos[0].cpu().tolist(),
-    "command_names": list(env.command_manager.active_terms),
-    "observation_names": env.observation_manager.active_terms["policy"],
-    "action_scale": joint_action._scale[0].cpu().tolist()
-    if isinstance(joint_action._scale, torch.Tensor)
-    else joint_action._scale,
-    "anchor_body_name": motion_term_cfg.anchor_body_name,
-    "body_names": list(motion_term_cfg.body_names),
-  }
+  metadata.update(
+    {
+      "anchor_body_name": motion_term_cfg.anchor_body_name,
+      "body_names": list(motion_term_cfg.body_names),
+    }
+  )
 
-  model = onnx.load(onnx_path)
-
-  for k, v in metadata.items():
-    entry = onnx.StringStringEntryProto()
-    entry.key = k
-    entry.value = list_to_csv_str(v) if isinstance(v, list) else str(v)
-    model.metadata_props.append(entry)
-
-  onnx.save(model, onnx_path)
+  attach_metadata_to_onnx(onnx_path, metadata)

--- a/src/mjlab/tasks/velocity/rl/exporter.py
+++ b/src/mjlab/tasks/velocity/rl/exporter.py
@@ -1,11 +1,10 @@
 import os
 
-import onnx
-import torch
-
-from mjlab.entity import Entity
 from mjlab.envs import ManagerBasedRlEnv
-from mjlab.envs.mdp.actions.joint_actions import JointAction
+from mjlab.rl.exporter_utils import (
+  attach_metadata_to_onnx,
+  get_base_metadata,
+)
 from mjlab.third_party.isaaclab.isaaclab_rl.rsl_rl.exporter import _OnnxPolicyExporter
 
 
@@ -22,45 +21,17 @@ def export_velocity_policy_as_onnx(
   policy_exporter.export(path, filename)
 
 
-def list_to_csv_str(arr, *, decimals: int = 3, delimiter: str = ",") -> str:
-  fmt = f"{{:.{decimals}f}}"
-  return delimiter.join(
-    fmt.format(x)
-    if isinstance(x, (int, float))
-    else str(x)  # numbers → format, strings → as-is
-    for x in arr
-  )
-
-
 def attach_onnx_metadata(
   env: ManagerBasedRlEnv, run_path: str, path: str, filename="policy.onnx"
 ) -> None:
-  robot: Entity = env.scene["robot"]
+  """Attach velocity-specific metadata to ONNX model.
+
+  Args:
+    env: The RL environment.
+    run_path: W&B run path or other identifier.
+    path: Directory containing the ONNX file.
+    filename: Name of the ONNX file.
+  """
   onnx_path = os.path.join(path, filename)
-  joint_action = env.action_manager.get_term("joint_pos")
-  assert isinstance(joint_action, JointAction)
-  ctrl_ids = robot.indexing.ctrl_ids.cpu().numpy()
-  joint_stiffness = env.sim.mj_model.actuator_gainprm[ctrl_ids, 0]
-  joint_damping = -env.sim.mj_model.actuator_biasprm[ctrl_ids, 2]
-  metadata = {
-    "run_path": run_path,
-    "joint_names": list(robot.joint_names),
-    "joint_stiffness": joint_stiffness.tolist(),
-    "joint_damping": joint_damping.tolist(),
-    "default_joint_pos": robot.data.default_joint_pos[0].cpu().tolist(),
-    "command_names": list(env.command_manager.active_terms),
-    "observation_names": env.observation_manager.active_terms["policy"],
-    "action_scale": joint_action._scale[0].cpu().tolist()
-    if isinstance(joint_action._scale, torch.Tensor)
-    else joint_action._scale,
-  }
-
-  model = onnx.load(onnx_path)
-
-  for k, v in metadata.items():
-    entry = onnx.StringStringEntryProto()
-    entry.key = k
-    entry.value = list_to_csv_str(v) if isinstance(v, list) else str(v)
-    model.metadata_props.append(entry)
-
-  onnx.save(model, onnx_path)
+  metadata = get_base_metadata(env, run_path)  # Velocity has no extra metadata.
+  attach_metadata_to_onnx(onnx_path, metadata)

--- a/tests/test_rl_exporter.py
+++ b/tests/test_rl_exporter.py
@@ -1,0 +1,85 @@
+"""Tests for RL exporter utilities."""
+
+import os
+import tempfile
+
+import onnx
+
+from mjlab.rl.exporter_utils import (
+  attach_metadata_to_onnx,
+  list_to_csv_str,
+)
+
+
+def test_list_to_csv_str():
+  """Test CSV string conversion utility."""
+  # Test with floats.
+  result = list_to_csv_str([1.23456, 2.34567, 3.45678], decimals=3)
+  assert result == "1.235,2.346,3.457"
+
+  # Test with integers.
+  result = list_to_csv_str([1, 2, 3], decimals=2)
+  assert result == "1.00,2.00,3.00"
+
+  # Test with mixed types.
+  result = list_to_csv_str([1.5, "hello", 2.5], decimals=1)
+  assert result == "1.5,hello,2.5"
+
+  # Test custom delimiter.
+  result = list_to_csv_str([1.0, 2.0, 3.0], decimals=1, delimiter=";")
+  assert result == "1.0;2.0;3.0"
+
+
+def test_attach_metadata_to_onnx():
+  """Test that metadata can be attached to ONNX models."""
+  # Create a dummy ONNX model.
+  with tempfile.TemporaryDirectory() as tmpdir:
+    onnx_path = os.path.join(tmpdir, "test_policy.onnx")
+
+    # Create minimal ONNX model.
+    input_tensor = onnx.helper.make_tensor_value_info(
+      "input", onnx.TensorProto.FLOAT, [1, 2]
+    )
+    output_tensor = onnx.helper.make_tensor_value_info(
+      "output", onnx.TensorProto.FLOAT, [1, 2]
+    )
+    node = onnx.helper.make_node("Identity", ["input"], ["output"])
+    graph = onnx.helper.make_graph(
+      [node], "test_graph", [input_tensor], [output_tensor]
+    )
+    model = onnx.helper.make_model(graph)
+    onnx.save(model, onnx_path)
+
+    # Attach metadata.
+    metadata = {
+      "run_path": "test/run/path",
+      "joint_names": ["joint_a", "joint_b"],
+      "joint_stiffness": [20.0, 10.0],
+      "joint_damping": [1.0, 1.0],
+      "extra_field": "extra_value",
+    }
+    attach_metadata_to_onnx(onnx_path, metadata)
+
+    # Load and verify metadata was attached.
+    loaded_model = onnx.load(onnx_path)
+    metadata_props = {prop.key: prop.value for prop in loaded_model.metadata_props}
+
+    # Check all metadata fields are present.
+    assert "run_path" in metadata_props
+    assert "joint_names" in metadata_props
+    assert "joint_stiffness" in metadata_props
+    assert "extra_field" in metadata_props
+
+    # Check values are correct.
+    assert metadata_props["run_path"] == "test/run/path"
+    assert metadata_props["extra_field"] == "extra_value"
+
+    # Check list was converted to CSV string.
+    joint_names = metadata_props["joint_names"].split(",")
+    assert len(joint_names) == 2
+    assert "joint_a" in joint_names
+    assert "joint_b" in joint_names
+
+    # Check stiffness values are in natural joint order.
+    stiffness_values = [float(x) for x in metadata_props["joint_stiffness"].split(",")]
+    assert stiffness_values == [20.0, 10.0]  # Natural order: joint_a (20), joint_b (10)


### PR DESCRIPTION
There were critical ordering issues that caused subtle bugs in the ONNX exporter. `Entity.indexing.ctrl_ids` was stored in **actuator definition order** (the order actuators appear in XML/spec), while everything else used **natural joint order** (kinematic tree order). This caused mismatches when actuators were defined in non-sequential order in XML. This manifested in ONNX metadata with **mismatched stiffness/damping values**, which we discovered last night when attempting to sim2real a policy.

The solution was to change `Entity._compute_indexing()` to store ctrl_ids in **natural joint order**. Everything now uses natural joint order consistently in the codebase. Also used this opportunity to reduce exporter code duplication and write some tests to catch future regressions.

**Example**: For a robot with joints `[joint_a, joint_b, joint_c]` but actuators defined as `[act_c, act_b, act_a]` with stiffnesses `[30, 20, 10]`, before the fix `ctrl_ids = [2, 1, 0]` (actuator definition order) caused the exporter to write `joint_stiffness = [30, 20, 10]` in actuator order. The ONNX metadata has `joint_names = [joint_a, joint_b, joint_c]` so the deployment code applied stiffness `30` to `joint_a`, `20` to `joint_b`, and `10` to `joint_c`, but the actual stiffnesses are `10, 20, 30` respectively. After the fix `ctrl_ids = [0, 1, 2]` (natural joint order) so the exporter correctly writes `joint_stiffness = [10, 20, 30]` matching `joint_names` order.