### PR TITLE
Fix config mutation in managers by deepcopying cfg on init.

### DIFF
--- a/src/mjlab/managers/curriculum_manager.py
+++ b/src/mjlab/managers/curriculum_manager.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
 from typing import TYPE_CHECKING, Any, Sequence
 
 import torch
@@ -22,7 +23,7 @@ class CurriculumManager(ManagerBase):
     self._term_cfgs: list[CurriculumTermCfg] = list()
     self._class_term_cfgs: list[CurriculumTermCfg] = list()
 
-    self.cfg = cfg
+    self.cfg = deepcopy(cfg)
     super().__init__(env)
 
     self._curriculum_state = dict()

--- a/src/mjlab/managers/event_manager.py
+++ b/src/mjlab/managers/event_manager.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
 from typing import TYPE_CHECKING
 
 import torch
@@ -18,7 +19,7 @@ class EventManager(ManagerBase):
   _env: ManagerBasedRlEnv
 
   def __init__(self, cfg: dict[str, EventTermCfg], env: ManagerBasedRlEnv):
-    self.cfg = cfg
+    self.cfg = deepcopy(cfg)
     self._mode_term_names: dict[EventMode, list[str]] = dict()
     self._mode_term_cfgs: dict[EventMode, list[EventTermCfg]] = dict()
     self._mode_class_term_cfgs: dict[EventMode, list[EventTermCfg]] = dict()

--- a/src/mjlab/managers/manager_base.py
+++ b/src/mjlab/managers/manager_base.py
@@ -85,9 +85,8 @@ class ManagerBase(abc.ABC):
 
   def _resolve_common_term_cfg(self, term_name: str, term_cfg: ManagerTermBaseCfg):
     del term_name  # Unused.
-    for key, value in term_cfg.params.items():
+    for value in term_cfg.params.values():
       if isinstance(value, SceneEntityCfg):
         value.resolve(self._env.scene)
-        term_cfg.params[key] = value
     if inspect.isclass(term_cfg.func):
       term_cfg.func = term_cfg.func(cfg=term_cfg, env=self._env)

--- a/src/mjlab/managers/observation_manager.py
+++ b/src/mjlab/managers/observation_manager.py
@@ -1,5 +1,6 @@
 """Observation manager for computing observations."""
 
+from copy import deepcopy
 from typing import Sequence
 
 import numpy as np
@@ -14,7 +15,7 @@ from mjlab.utils.noise import noise_cfg, noise_model
 
 class ObservationManager(ManagerBase):
   def __init__(self, cfg: dict[str, ObservationGroupCfg], env):
-    self.cfg = cfg
+    self.cfg = deepcopy(cfg)
     super().__init__(env=env)
 
     self._group_obs_dim: dict[str, tuple[int, ...] | list[tuple[int, ...]]] = dict()
@@ -235,6 +236,9 @@ class ObservationManager(ManagerBase):
           print(f"term: {term_name} set to None, skipping...")
           continue
 
+        # NOTE: This deepcopy is important to avoid cross-group contamination of term
+        # configs.
+        term_cfg = deepcopy(term_cfg)
         self._resolve_common_term_cfg(term_name, term_cfg)
 
         if not group_cfg.enable_corruption:

--- a/src/mjlab/managers/reward_manager.py
+++ b/src/mjlab/managers/reward_manager.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
 from typing import TYPE_CHECKING
 
 import torch
@@ -22,7 +23,7 @@ class RewardManager(ManagerBase):
     self._term_cfgs: list[RewardTermCfg] = list()
     self._class_term_cfgs: list[RewardTermCfg] = list()
 
-    self.cfg = cfg
+    self.cfg = deepcopy(cfg)
     super().__init__(env=env)
     self._episode_sums = dict()
     for term_name in self._term_names:

--- a/src/mjlab/managers/termination_manager.py
+++ b/src/mjlab/managers/termination_manager.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
 from typing import TYPE_CHECKING, Sequence
 
 import torch
@@ -22,7 +23,7 @@ class TerminationManager(ManagerBase):
     self._term_cfgs: list[TerminationTermCfg] = list()
     self._class_term_cfgs: list[TerminationTermCfg] = list()
 
-    self.cfg = cfg
+    self.cfg = deepcopy(cfg)
     super().__init__(env)
 
     self._term_dones = dict()

--- a/src/mjlab/scripts/play.py
+++ b/src/mjlab/scripts/play.py
@@ -41,13 +41,13 @@ class PlayConfig:
   _demo_mode: tyro.conf.Suppress[bool] = False
 
 
-def run_play(task: str, cfg: PlayConfig):
+def run_play(task_id: str, cfg: PlayConfig):
   configure_torch_backends()
 
   device = cfg.device or ("cuda:0" if torch.cuda.is_available() else "cpu")
 
-  env_cfg = load_env_cfg(task, play=True)
-  agent_cfg = load_rl_cfg(task)
+  env_cfg = load_env_cfg(task_id, play=True)
+  agent_cfg = load_rl_cfg(task_id)
 
   DUMMY_MODE = cfg.agent in {"zero", "random"}
   TRAINED_MODE = not DUMMY_MODE

--- a/tests/test_manager_config_immutability.py
+++ b/tests/test_manager_config_immutability.py
@@ -1,0 +1,147 @@
+"""Tests for manager config immutability.
+
+Managers should not mutate the original config objects passed to them.
+This allows the same config to be reused across multiple manager instantiations.
+"""
+
+import inspect
+from unittest.mock import Mock
+
+import mujoco
+import pytest
+import torch
+from conftest import get_test_device
+
+from mjlab.entity import Entity, EntityCfg
+from mjlab.managers.manager_term_config import (
+  ObservationGroupCfg,
+  ObservationTermCfg,
+  RewardTermCfg,
+)
+from mjlab.managers.observation_manager import ObservationManager
+from mjlab.managers.reward_manager import RewardManager
+from mjlab.managers.scene_entity_config import SceneEntityCfg
+from mjlab.sim.sim import Simulation, SimulationCfg
+
+
+@pytest.fixture
+def device():
+  return get_test_device()
+
+
+@pytest.fixture
+def mock_env(device):
+  env = Mock()
+  env.num_envs = 2
+  env.device = device
+  env.step_dt = 0.02
+  env.max_episode_length_s = 10.0
+  env.scene = {}
+  return env
+
+
+class ClassObsTerm:
+  """Class-based observation term that triggers func mutation."""
+
+  def __init__(self, cfg, env):
+    self.device = env.device
+
+  def __call__(self, env):
+    return torch.zeros((env.num_envs, 3), device=self.device)
+
+
+class ClassRewardTerm:
+  """Class-based reward term that triggers func mutation."""
+
+  def __init__(self, cfg, env):
+    self.device = env.device
+
+  def __call__(self, env):
+    return torch.ones(env.num_envs, device=self.device)
+
+
+def test_manager_preserves_class_func(mock_env):
+  """Managers should not mutate class-based func to instance.
+
+  When term_cfg.func is a class, _resolve_common_term_cfg instantiates it.
+  Without copying term_cfg first, this mutates the original config.
+  """
+  term_cfg = ObservationTermCfg(func=ClassObsTerm, params={})
+
+  assert inspect.isclass(term_cfg.func), "precondition: func should be a class"
+
+  cfg = {"policy": ObservationGroupCfg(terms={"obs1": term_cfg})}
+  _ = ObservationManager(cfg, mock_env)
+
+  assert inspect.isclass(term_cfg.func), "func was mutated from class to instance"
+
+
+def test_observation_shared_terms_between_groups(mock_env):
+  """Terms shared between policy and critic groups get independent settings."""
+  term_cfg = ObservationTermCfg(func=ClassObsTerm, params={})
+
+  cfg = {
+    "policy": ObservationGroupCfg(terms={"obs": term_cfg}, history_length=5),
+    "critic": ObservationGroupCfg(terms={"obs": term_cfg}),  # no history
+  }
+
+  manager = ObservationManager(cfg, mock_env)
+
+  policy_obs = manager.compute()["policy"]
+  critic_obs = manager.compute()["critic"]
+
+  # Policy has history (5 * 3 = 15), critic doesn't (3).
+  assert isinstance(policy_obs, torch.Tensor)
+  assert isinstance(critic_obs, torch.Tensor)
+  assert policy_obs.shape[1] == 15  # 3 features * 5 history
+  assert critic_obs.shape[1] == 3  # 3 features, no history
+
+
+def test_scene_entity_cfg_in_params_not_mutated(device):
+  """SceneEntityCfg in params should not be mutated when resolved."""
+  # NOTE: 2 joints so selecting one won't optimize to slice(None).
+  xml = """
+  <mujoco>
+    <worldbody>
+      <body name="body1" pos="0 0 1">
+        <joint name="joint1" type="hinge" axis="0 0 1"/>
+        <geom type="sphere" size="0.1" mass="1"/>
+        <body name="body2" pos="0.2 0 0">
+          <joint name="joint2" type="hinge" axis="0 0 1"/>
+          <geom type="sphere" size="0.1" mass="1"/>
+        </body>
+      </body>
+    </worldbody>
+  </mujoco>
+  """
+  entity_cfg = EntityCfg(spec_fn=lambda: mujoco.MjSpec.from_string(xml))
+  entity = Entity(entity_cfg)
+  model = entity.compile()
+
+  sim = Simulation(num_envs=2, cfg=SimulationCfg(), model=model, device=device)
+  entity.initialize(model, sim.model, sim.data, device)
+
+  env = Mock()
+  env.num_envs = 2
+  env.device = device
+  env.max_episode_length_s = 10.0
+  env.scene = {"robot": entity}
+
+  # Select only joint1 --> joint_ids will mutate from slice(None) to [0].
+  asset_cfg = SceneEntityCfg(name="robot", joint_names=("joint1",))
+  original_joint_ids = asset_cfg.joint_ids  # slice(None) before resolve
+
+  def reward_func(env, asset_cfg):
+    del asset_cfg  # Unused.
+    return torch.ones(env.num_envs, device=env.device)
+
+  term_cfg = RewardTermCfg(
+    func=reward_func, params={"asset_cfg": asset_cfg}, weight=1.0
+  )
+
+  _ = RewardManager({"reward1": term_cfg}, env)
+
+  assert asset_cfg.joint_ids == original_joint_ids, (
+    f"SceneEntityCfg.joint_ids was mutated from {original_joint_ids} to "
+    f"{asset_cfg.joint_ids}"
+  )


### PR DESCRIPTION
- `deepcopy` cfg dict in all managers to prevent input mutation
- `deepcopy` term configs in ObservationManager to prevent cross-group contamination
- Add comprehensive immutability tests
- Rename `task`-->`task_id` in `play.py` for consistency