### PR TITLE
Fix demo notebook

### DIFF
--- a/notebooks/demo.ipynb
+++ b/notebooks/demo.ipynb
@@ -1,6 +1,45 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Use W&B offline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!wandb offline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## **Or** login using an API from your W&B account"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!wandb login"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Now you are set to run the demo!"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {


### PR DESCRIPTION
Add cells to use wandb offline or to login before running the demo.

Solves #378 . To keep it general, I added the two possible solutions:

1. Running `wandb offline` and only storing data locally, which does not need login
2. Running `wandb login` to prompt for an API key before running the demo.

It seemed that the login prompt was not caught in the cell, as the stdout etc is being read to know when to stop executing the cells.

 Additionally, I added some markdown cells to give more context. If you find it confusing we can also choose only one option to keep! I think `wandb offline` is the one that adds the least friction for a new user. 