### PR TITLE
Add time_major flag for observation history concatenation (matching leggedLab) 

### DIFF
--- a/src/mjlab/managers/manager_term_config.py
+++ b/src/mjlab/managers/manager_term_config.py
@@ -134,6 +134,9 @@ class ObservationGroupCfg:
   enable_corruption: bool = False
   history_length: int | None = None
   flatten_history_dim: bool = True
+  time_major: bool = False
+  """When True with history, concatenates as [A_t0, B_t0, ..., A_t1, B_t1, ...] (time-major).
+  When False (default), concatenates as [A_t0, A_t1, ..., B_t0, B_t1, ...] (term-major)."""
 
 
 ##

--- a/src/mjlab/managers/observation_manager.py
+++ b/src/mjlab/managers/observation_manager.py
@@ -163,6 +163,8 @@ class ObservationManager(ManagerBase):
   ) -> torch.Tensor | dict[str, torch.Tensor]:
     group_term_names = self._group_obs_term_names[group_name]
     group_obs: dict[str, torch.Tensor] = {}
+    # Keep unflattened history per term for time-major concatenation.
+    per_term_history: dict[str, torch.Tensor] = {}
     obs_terms = zip(
       group_term_names, self._group_obs_term_cfgs[group_name], strict=False
     )
@@ -186,7 +188,9 @@ class ObservationManager(ManagerBase):
         circular_buffer = self._group_obs_term_history_buffer[group_name][term_name]
         if update_history or not circular_buffer.is_initialized:
           circular_buffer.append(obs)
-
+        # Store unflattened (batch, history, dim) for time-major concatenation.
+        per_term_history[term_name] = circular_buffer.buffer
+        # Preserve original per-term output shape behavior when not concatenating.
         if term_cfg.flatten_history_dim:
           group_obs[term_name] = circular_buffer.buffer.reshape(self._env.num_envs, -1)
         else:
@@ -194,6 +198,40 @@ class ObservationManager(ManagerBase):
       else:
         group_obs[term_name] = obs
     if self._group_obs_concatenate[group_name]:
+      # If any term has history and time_major is enabled, build time-major frames.
+      if len(per_term_history) > 0 and self._group_obs_time_major[group_name]:
+        # Determine common history length (assume consistent across terms in the group).
+        # Prepare list of per-term tensors with shape (B, H, D_term).
+        hist_tensors: list[torch.Tensor] = []
+        B = self._env.num_envs
+        # Use history length from the first term that has history.
+        first_hist_name = next(iter(per_term_history.keys()))
+        H = per_term_history[first_hist_name].shape[1]
+        for name in group_term_names:
+          if name in per_term_history:
+            t = per_term_history[name]
+            # Safety: ensure same H.
+            if t.shape[1] != H:
+              raise RuntimeError(
+                f"Mismatched history length in group '{group_name}' for term '{name}':"
+                f" expected {H}, got {t.shape[1]}"
+              )
+            # t: (B, H, D)
+            hist_tensors.append(t)
+          else:
+            # No history for this term: expand to (B, H, D)
+            t2d = group_obs[name]
+            # Ensure 2D: (B, D)
+            if t2d.dim() == 1:
+              t2d = t2d.view(B, -1)
+            t3d = t2d.unsqueeze(1).expand(B, H, t2d.shape[-1])
+            hist_tensors.append(t3d)
+        # Concatenate across terms per time step by concatenating last dim directly.
+        # Result: (B, H, sum(D_i))
+        time_major = torch.cat(hist_tensors, dim=-1)
+        # Flatten time dimension at the end: (B, H * sum(D_i))
+        return time_major.reshape(B, -1)
+      # No history: regular concatenation across terms.
       return torch.cat(
         list(group_obs.values()), dim=self._group_obs_concatenate_dim[group_name]
       )
@@ -206,6 +244,7 @@ class ObservationManager(ManagerBase):
     self._group_obs_class_term_cfgs: dict[str, list[ObservationTermCfg]] = dict()
     self._group_obs_concatenate: dict[str, bool] = dict()
     self._group_obs_concatenate_dim: dict[str, int] = dict()
+    self._group_obs_time_major: dict[str, bool] = dict()
     self._group_obs_class_instances: dict[str, noise_model.NoiseModel] = {}
     self._group_obs_term_delay_buffer: dict[str, dict[str, DelayBuffer]] = dict()
     self._group_obs_term_history_buffer: dict[str, dict[str, CircularBuffer]] = dict()
@@ -229,6 +268,7 @@ class ObservationManager(ManagerBase):
         if group_cfg.concatenate_dim >= 0
         else group_cfg.concatenate_dim
       )
+      self._group_obs_time_major[group_name] = group_cfg.time_major
 
       for term_name, term_cfg in group_cfg.terms.items():
         term_cfg: ObservationTermCfg | None


### PR DESCRIPTION
For context, time major is used in legged lab by default, hence the confusion with sim2sim: https://github.com/Hellod035/LeggedLab/blob/main/legged_lab/envs/base/base_env.py

Add a `time_major` option to ObservationGroupCfg that controls how observation history is concatenated when `concatenate_terms=True`.

When `time_major=False` (default), uses term-major ordering:
  [A_t0, A_t1, ..., A_tH-1, B_t0, B_t1, ..., B_tH-1, ...]

When `time_major=True`, uses time-major ordering:
  [A_t0, B_t0, ..., A_t1, B_t1, ..., A_tH-1, B_tH-1, ...]

This is useful when temporal locality across terms is preferred over grouping all history for each term together.

