### PR TITLE
Merge per-entity keyframes into single scene keyframe.

### DIFF
--- a/tests/test_g1_constants.py
+++ b/tests/test_g1_constants.py
@@ -61,6 +61,7 @@ def test_keyframe_joint_positions(g1_entity, g1_model) -> None:
   """Test that keyframe joint positions match the configuration."""
   key = g1_model.key("init_state")
   expected_joint_pos = g1_constants.KNEES_BENT_KEYFRAME.joint_pos
+  assert expected_joint_pos is not None
   expected_values = resolve_expr(expected_joint_pos, g1_entity.joint_names, 0.0)
   for joint_name, expected_value in zip(
     g1_entity.joint_names, expected_values, strict=True

--- a/tests/test_go1_constants.py
+++ b/tests/test_go1_constants.py
@@ -49,6 +49,7 @@ def test_keyframe_joint_positions(go1_entity, go1_model) -> None:
   """Test that keyframe joint positions match the configuration."""
   key = go1_model.key("init_state")
   expected_joint_pos = go1_constants.INIT_STATE.joint_pos
+  assert expected_joint_pos is not None
   expected_values = resolve_expr(expected_joint_pos, go1_entity.joint_names, 0.0)
   for joint_name, expected_value in zip(
     go1_entity.joint_names, expected_values, strict=True


### PR DESCRIPTION
Previously, each entity created its own keyframe, resulting in multiple separate keyframes when a scene had multiple entities. Each keyframe only contained that entity's qpos/ctrl, with other entities at default values.

Now, the Scene extracts and merges all entity keyframes into a single `init_state` keyframe containing the combined initial state for all entities.

Also adds support for `joint_pos=None` in `EntityCfg.InitialStateCfg` to use the model's existing keyframe instead of manually specifying joint positions. Errors if the model has no keyframe.

Fixes #263.