### PR TITLE
added logic to create graph depending on driver cuda version

### DIFF
--- a/src/mjlab/sim/sim.py
+++ b/src/mjlab/sim/sim.py
@@ -139,11 +139,7 @@ class Simulation:
       and driver_ver >= _MIN_DRIVER_FOR_CONDITIONAL_GRAPHS
     )
 
-    if self.use_cuda_graph:
-      print("Warming up CUDA kernels...")
-      mjwarp.step(self.wp_model, self.wp_data)
-      wp.synchronize()
-    else:
+    if not self.use_cuda_graph:
       print(f"[WARNING] Disabling CUDA Graphs. Current Driver {driver_ver} < 12.4.")
       print("           mujoco_warp solver requires 12.4+ for graph loops.")
 


### PR DESCRIPTION
Starting on CUDA 12.4, loading kernel modules in a graph is supported. However, it does not work for older CUDA versions that are actively used on GPU clusters (like 12.2).

This PR adds the logic to check the CUDA driver version, which might be different from the toolkit version. This way, the variable that enables the graph creation is set properly.

This fixes the following error:
`Warp CUDA error 900: operation not permitted when stream is capturing (in function wp_cuda_load_module, /builds/omniverse/warp/warp/native/warp.cu:4389)`

Tested on pc with rtx5090 cuda 13.0 and on cluster H100 cuda 12.2.