### PR TITLE
Recreate render graph after model field changes

### DIFF
--- a/src/mjlab/envs/manager_based_rl_env.py
+++ b/src/mjlab/envs/manager_based_rl_env.py
@@ -217,6 +217,7 @@ class ManagerBasedRlEnv:
     print_info(f"[INFO] {self.event_manager}")
 
     self.sim.expand_model_fields(self.event_manager.domain_randomization_fields)
+    self.scene.recreate_render_graph()
 
     # Command manager (must be before observation manager since observations
     # may reference commands).

--- a/src/mjlab/scene/scene.py
+++ b/src/mjlab/scene/scene.py
@@ -156,6 +156,10 @@ class Scene:
     if self._render_manager is not None:
       self._render_manager.render()
 
+  def recreate_render_graph(self) -> None:
+    if self._render_manager is not None:
+      self._render_manager.create_graph()
+
   def write_data_to_sim(self) -> None:
     for ent in self._entities.values():
       ent.write_data_to_sim()


### PR DESCRIPTION
We need to re-create the render graph to make sure the model fields from the DR are updated inside the render graph as well.