### PR TITLE
Fix encoder bias shifting joint limits incorrectly.

### DIFF
--- a/docs/api/domain_randomization.md
+++ b/docs/api/domain_randomization.md
@@ -57,7 +57,7 @@ This flag is especially useful when using custom class-based event terms instead
 ## Available Fields
 
 **Joint/DOF:** `dof_armature`, `dof_frictionloss`, `dof_damping`, `jnt_range`,
-`jnt_stiffness`, `qpos0`
+`jnt_stiffness`
 
 **Body:** `body_mass`, `body_ipos`, `body_iquat`, `body_inertia`, `body_pos`,
 `body_quat`
@@ -127,21 +127,25 @@ robot_collision = CollisionCfg(
 )
 ```
 
-### Joint Offset (startup)
+### Encoder Bias (startup)
 
-Randomize default joint positions to simulate joint offset calibration errors:
+Simulate joint encoder calibration errors. Real encoders have small offsets
+from manufacturing/calibration, so the policy should be robust to them.
+
+**How it works:** The bias is added to position observations and subtracted from
+position commands. The policy sees `observed_pos = true_pos + bias` and commands
+`target = command - bias`. This ensures joint limits apply to the true physical
+position, not the biased reading.
 
 ```python
-joint_offset: EventTerm = term(
+encoder_bias: EventTerm = term(
     EventTerm,
     mode="startup",
-    func=mdp.randomize_field,
+    func=mdp.randomize_encoder_bias,
     domain_randomization=True,
     params={
-        "asset_cfg": SceneEntityCfg("robot", joint_names=[".*"]),
-        "field": "qpos0",
-        "ranges": (-0.01, 0.01),
-        "operation": "add",
+        "asset_cfg": SceneEntityCfg("robot"),
+        "bias_range": (-0.01, 0.01),
     },
 )
 ```

--- a/src/mjlab/entity/data.py
+++ b/src/mjlab/entity/data.py
@@ -65,6 +65,8 @@ class EntityData:
   joint_vel_target: torch.Tensor
   joint_effort_target: torch.Tensor
 
+  encoder_bias: torch.Tensor
+
   # State dimensions.
   POS_DIM = 3
   QUAT_DIM = 4
@@ -328,8 +330,13 @@ class EntityData:
 
   @property
   def joint_pos(self) -> torch.Tensor:
-    """Joint positions. Shape (num_envs, nv)"""
+    """Joint positions. Shape (num_envs, num_joints)."""
     return self.data.qpos[:, self.indexing.joint_q_adr]
+
+  @property
+  def joint_pos_biased(self) -> torch.Tensor:
+    """Joint positions with encoder bias applied. Shape (num_envs, num_joints)."""
+    return self.joint_pos + self.encoder_bias
 
   @property
   def joint_vel(self) -> torch.Tensor:

--- a/src/mjlab/entity/entity.py
+++ b/src/mjlab/entity/entity.py
@@ -487,6 +487,15 @@ class Entity:
       joint_vel_target = torch.empty(nworld, 0, dtype=torch.float, device=device)
       joint_effort_target = torch.empty(nworld, 0, dtype=torch.float, device=device)
 
+    # Encoder bias for simulating encoder calibration errors.
+    # Shape: (num_envs, num_joints). Defaults to zero (no bias).
+    if self.is_articulated:
+      encoder_bias = torch.zeros(
+        (nworld, self.num_joints), dtype=torch.float, device=device
+      )
+    else:
+      encoder_bias = torch.empty(nworld, 0, dtype=torch.float, device=device)
+
     self._data = EntityData(
       indexing=indexing,
       data=data,
@@ -506,6 +515,7 @@ class Entity:
       joint_pos_target=joint_pos_target,
       joint_vel_target=joint_vel_target,
       joint_effort_target=joint_effort_target,
+      encoder_bias=encoder_bias,
     )
 
   def update(self, dt: float) -> None:

--- a/src/mjlab/envs/mdp/actions/joint_actions.py
+++ b/src/mjlab/envs/mdp/actions/joint_actions.py
@@ -99,9 +99,9 @@ class JointPositionAction(JointAction):
       self._offset = self._asset.data.default_joint_pos[:, self._joint_ids].clone()
 
   def apply_actions(self) -> None:
-    self._asset.set_joint_position_target(
-      self._processed_actions, joint_ids=self._joint_ids
-    )
+    encoder_bias = self._asset.data.encoder_bias[:, self._joint_ids]
+    target = self._processed_actions - encoder_bias
+    self._asset.set_joint_position_target(target, joint_ids=self._joint_ids)
 
 
 class JointVelocityAction(JointAction):

--- a/src/mjlab/envs/mdp/observations.py
+++ b/src/mjlab/envs/mdp/observations.py
@@ -50,13 +50,15 @@ def projected_gravity(
 
 def joint_pos_rel(
   env: ManagerBasedRlEnv,
+  biased: bool = False,
   asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
 ) -> torch.Tensor:
   asset: Entity = env.scene[asset_cfg.name]
   default_joint_pos = asset.data.default_joint_pos
   assert default_joint_pos is not None
   jnt_ids = asset_cfg.joint_ids
-  return asset.data.joint_pos[:, jnt_ids] - default_joint_pos[:, jnt_ids]
+  joint_pos = asset.data.joint_pos_biased if biased else asset.data.joint_pos
+  return joint_pos[:, jnt_ids] - default_joint_pos[:, jnt_ids]
 
 
 def joint_vel_rel(

--- a/src/mjlab/tasks/tracking/tracking_env_cfg.py
+++ b/src/mjlab/tasks/tracking/tracking_env_cfg.py
@@ -71,7 +71,9 @@ def make_tracking_env_cfg() -> ManagerBasedRlEnvCfg:
       noise=Unoise(n_min=-0.2, n_max=0.2),
     ),
     "joint_pos": ObservationTermCfg(
-      func=mdp.joint_pos_rel, noise=Unoise(n_min=-0.01, n_max=0.01)
+      func=mdp.joint_pos_rel,
+      noise=Unoise(n_min=-0.01, n_max=0.01),
+      params={"biased": True},
     ),
     "joint_vel": ObservationTermCfg(
       func=mdp.joint_vel_rel, noise=Unoise(n_min=-0.5, n_max=0.5)
@@ -184,15 +186,12 @@ def make_tracking_env_cfg() -> ManagerBasedRlEnvCfg:
         },
       },
     ),
-    "add_joint_default_pos": EventTermCfg(
+    "encoder_bias": EventTermCfg(
       mode="startup",
-      func=mdp.randomize_field,
-      domain_randomization=True,
+      func=mdp.randomize_encoder_bias,
       params={
         "asset_cfg": SceneEntityCfg("robot"),
-        "operation": "add",
-        "field": "qpos0",
-        "ranges": (-0.01, 0.01),
+        "bias_range": (-0.01, 0.01),
       },
     ),
     "foot_friction": EventTermCfg(


### PR DESCRIPTION
Fix encoder bias shifting joint limits.

Previously we used MuJoCo's `qpos0` to simulate encoder bias. MuJoCo computes body positions as `(qpos - qpos0)`, so setting `qpos0=bias` makes qpos act like a biased encoder reading while the body stays at the correct physical position.

The problem: qpos has the bias baked in, and joint limits apply to qpos. So the limit triggers based on the biased value, not the true physical position. With bias=0.8 and upper limit=1.0, the limit triggers when qpos hits 1.0, but physical position is only 0.2 at that point. The joint stops 0.8 away from where it should physically be able to go.

This PR adds an encoder_bias field to EntityData instead. Bias is added to observations and subtracted from commands, so limits apply to true physical position.

Code wise, we've made the following changes:
- `EntityData`: added `encoder_bias` field and `joint_pos_biased` property
- `joint_pos_rel`: reads from `joint_pos_biased` if `biased=True`
- `JointPositionAction`: subtracts `encoder_bias` from commands
- Added `randomize_encoder_bias` event function
- Updated tracking task and docs to use `encoder_bias` instead of `qpos0`

Fixes #422.