### PR TITLE
chore: align pre-commit ruff version with CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.12.3
+  rev: v0.14.7
   hooks:
     # Run the linter.
     - id: ruff-check


### PR DESCRIPTION
CI runs Ruff 0.14.7, but pre-commit pinned an older version. This change aligns them to avoid differing lint/format results locally vs CI.