### PR TITLE
fix: prevent NaNs in `apply_delta_pose` for zero rotation

### DIFF
--- a/src/mjlab/utils/lab_api/math.py
+++ b/src/mjlab/utils/lab_api/math.py
@@ -945,7 +945,8 @@ def apply_delta_pose(
     # interpret delta_pose[:, 3:6] as target rotation displacements
     rot_actions = delta_pose[:, 3:6]
     angle = torch.linalg.vector_norm(rot_actions, dim=1)
-    axis = rot_actions / angle.unsqueeze(-1)
+    safe_angle = torch.clamp_min(angle, eps)
+    axis = rot_actions / safe_angle.unsqueeze(-1)
     # change from axis-angle to quat convention
     identity_quat = torch.tensor([1.0, 0.0, 0.0, 0.0], device=device).repeat(num_poses, 1)
     rot_delta_quat = torch.where(

--- a/tests/test_apply_delta_pose.py
+++ b/tests/test_apply_delta_pose.py
@@ -1,0 +1,18 @@
+"""Tests for apply_delta_pose numerical stability."""
+
+import torch
+
+from mjlab.utils.lab_api.math import apply_delta_pose
+
+
+def test_apply_delta_pose_zero_rotation_is_finite_and_identity():
+  source_pos = torch.zeros(2, 3)
+  source_rot = torch.tensor([[1.0, 0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0]])
+  delta_pose = torch.zeros(2, 6)
+
+  target_pos, target_rot = apply_delta_pose(source_pos, source_rot, delta_pose)
+
+  assert torch.isfinite(target_pos).all()
+  assert torch.isfinite(target_rot).all()
+  assert torch.allclose(target_pos, source_pos)
+  assert torch.allclose(target_rot, source_rot)


### PR DESCRIPTION
- `apply_delta_pose` divided by `angle` when `angle==0`, which can produce NaNs.
- Clamp `angle` before division and add a unit test for zero-rotation delta.