### PR TITLE
Add scale_rewards_by_dt flag to disable reward time scaling

### DIFF
--- a/src/mjlab/envs/manager_based_rl_env.py
+++ b/src/mjlab/envs/manager_based_rl_env.py
@@ -85,6 +85,13 @@ class ManagerBasedRlEnvCfg:
     receives a truncated done signal to bootstrap the value of continuing beyond the
     limit.
   """
+  scale_rewards_by_dt: bool = True
+  """Whether to multiply rewards by the environment step duration (dt).
+
+  When True (default), reward values are scaled by step_dt to normalize cumulative
+  episodic rewards across different simulation frequencies. Set to False for
+  algorithms that expect unscaled reward signals (e.g., HER, static reward scaling).
+  """
 
 
 class ManagerBasedRlEnv:
@@ -236,7 +243,9 @@ class ManagerBasedRlEnv:
 
     self.termination_manager = TerminationManager(self.cfg.terminations, self)
     print_info(f"[INFO] {self.termination_manager}")
-    self.reward_manager = RewardManager(self.cfg.rewards, self)
+    self.reward_manager = RewardManager(
+      self.cfg.rewards, self, scale_by_dt=self.cfg.scale_rewards_by_dt
+    )
     print_info(f"[INFO] {self.reward_manager}")
     if self.cfg.curriculum is not None:
       self.curriculum_manager = CurriculumManager(self.cfg.curriculum, self)


### PR DESCRIPTION
## Summary
- Adds `scale_rewards_by_dt: bool = True` config field to `ManagerBasedRlEnvCfg`
- Updates `RewardManager` to conditionally apply dt scaling based on the flag
- Adds comprehensive docstring documentation explaining scaling behavior
- Adds tests verifying both scaling modes

## Behavior

| Setting | `reward_buf` | `_step_reward` |
|---------|--------------|----------------|
| `scale_rewards_by_dt=True` (default) | `raw * weight * dt` | `raw * weight` |
| `scale_rewards_by_dt=False` | `raw * weight` | `raw * weight` |

The default of `True` maintains backward compatibility.

## Test plan
- [x] Added `test_reward_scaling_enabled` - verifies rewards are scaled by dt when enabled
- [x] Added `test_reward_scaling_disabled` - verifies rewards are not scaled when disabled
- [x] Added `test_reward_scaling_default_is_enabled` - verifies default is True for backward compatibility
- [x] All existing tests pass

Closes #405

🤖 Generated with [Claude Code](https://claude.com/claude-code)