### PR TITLE
Fix documentation video responsiveness and GitHub Pages deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,5 +32,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/_build/
-          destination_dir: docs
           keep_files: true

--- a/docs/source/raycast_sensor.rst
+++ b/docs/source/raycast_sensor.rst
@@ -9,7 +9,7 @@ multiple frame attachment options, and configurable alignment modes.
 
 .. raw:: html
 
-   <video height="500" controls style="display: block; margin: 0 auto;">
+   <video controls style="display: block; margin: 0 auto; max-width: 100%; height: auto;">
      <source src="../_static/raycast_demo.mp4" type="video/mp4">
    </video>
 
@@ -63,7 +63,7 @@ Parallel rays arranged in a 2D grid with fixed spatial resolution.
 
 .. raw:: html
 
-   <video width="600" autoplay loop muted playsinline style="display: block; margin: 0 auto;">
+   <video autoplay loop muted playsinline style="display: block; margin: 0 auto; max-width: 100%; height: auto;">
      <source src="../_static/pattern_grid.mp4" type="video/mp4">
    </video>
 
@@ -93,7 +93,7 @@ LiDAR sensor.
 
 .. raw:: html
 
-   <video width="600" autoplay loop muted playsinline style="display: block; margin: 0 auto;">
+   <video autoplay loop muted playsinline style="display: block; margin: 0 auto; max-width: 100%; height: auto;">
      <source src="../_static/pattern_pinhole.mp4" type="video/mp4">
    </video>
 


### PR DESCRIPTION
## Summary
- Make raycast sensor documentation videos responsive for mobile devices
- Deploy documentation to root URL instead of /docs/ subdirectory
- Preserve nightly builds during deployment

## Changes
- **docs/source/raycast_sensor.rst**: Replaced fixed width/height attributes with `max-width: 100%; height: auto;` for all three videos to ensure responsive display on mobile
- **.github/workflows/docs.yml**: Removed `destination_dir: docs` so documentation deploys to `mujocolab.github.io/mjlab/` (root) instead of `/docs/` subdirectory. The `keep_files: true` setting preserves the `/nightly/` directory.

## Test plan
- [ ] Verify videos display correctly on mobile devices after deployment
- [ ] Confirm docs are accessible at `mujocolab.github.io/mjlab/` after merge
- [ ] Verify nightly builds remain accessible at `mujocolab.github.io/mjlab/nightly/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)