### PR TITLE
Update mujoco_warp and use public rays API

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 Run the demo (no installation needed):
 
 ```bash
-uvx --from mjlab --with "mujoco-warp @ git+https://github.com/google-deepmind/mujoco_warp@1c6b31692eaa5d3134093958d839165245d196a6" demo
+uvx --from mjlab --with "mujoco-warp @ git+https://github.com/google-deepmind/mujoco_warp@9491175b7cbea87e28d3e3e67733095317c33398" demo
 ```
 
 This launches an interactive viewer with a pre-trained Unitree G1 agent tracking a reference dance motion in MuJoCo Warp.
@@ -56,7 +56,7 @@ uv run demo
 **From PyPI:**
 
 ```bash
-uv add mjlab "mujoco-warp @ git+https://github.com/google-deepmind/mujoco_warp@1c6b31692eaa5d3134093958d839165245d196a6"
+uv add mjlab "mujoco-warp @ git+https://github.com/google-deepmind/mujoco_warp@9491175b7cbea87e28d3e3e67733095317c33398"
 ```
 
 A Dockerfile is also provided.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,7 +23,7 @@ You can try mjlab *without installing anything* by using `uvx`:
 
    # Run the mjlab demo (no local installation needed)
    uvx --from mjlab \
-       --with "mujoco-warp @ git+https://github.com/google-deepmind/mujoco_warp@1c6b31692eaa5d3134093958d839165245d196a6" \
+       --with "mujoco-warp @ git+https://github.com/google-deepmind/mujoco_warp@9491175b7cbea87e28d3e3e67733095317c33398" \
        demo
 
 If this runs, your setup is compatible with mjlab *for evaluation*.

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -92,7 +92,7 @@ install. These options are interchangeable: you can switch at any time.
 
       .. code:: bash
 
-         uv add mjlab "mujoco-warp @ git+https://github.com/google-deepmind/mujoco_warp@1c6b31692eaa5d3134093958d839165245d196a6"
+         uv add mjlab "mujoco-warp @ git+https://github.com/google-deepmind/mujoco_warp@9491175b7cbea87e28d3e3e67733095317c33398"
 
       .. note::
 
@@ -104,7 +104,7 @@ install. These options are interchangeable: you can switch at any time.
 
       .. code:: bash
 
-         uv add "mjlab @ git+https://github.com/mujocolab/mjlab" "mujoco-warp @ git+https://github.com/google-deepmind/mujoco_warp@1c6b31692eaa5d3134093958d839165245d196a6"
+         uv add "mjlab @ git+https://github.com/mujocolab/mjlab" "mujoco-warp @ git+https://github.com/google-deepmind/mujoco_warp@9491175b7cbea87e28d3e3e67733095317c33398"
 
       .. note::
 
@@ -201,7 +201,7 @@ Install mjlab and dependencies via pip
 
       .. code:: bash
 
-         pip install git+https://github.com/google-deepmind/mujoco_warp@1c6b31692eaa5d3134093958d839165245d196a6
+         pip install git+https://github.com/google-deepmind/mujoco_warp@9491175b7cbea87e28d3e3e67733095317c33398
          pip install mjlab
 
    .. tab-item:: Source
@@ -210,7 +210,7 @@ Install mjlab and dependencies via pip
 
       .. code:: bash
 
-         pip install git+https://github.com/google-deepmind/mujoco_warp@1c6b31692eaa5d3134093958d839165245d196a6
+         pip install git+https://github.com/google-deepmind/mujoco_warp@9491175b7cbea87e28d3e3e67733095317c33398
          git clone https://github.com/mujocolab/mjlab.git
          cd mjlab
          pip install -e .

--- a/notebooks/demo.ipynb
+++ b/notebooks/demo.ipynb
@@ -50,7 +50,7 @@
     "outputId": "4c299831-6279-430e-ca8e-f2a58e8f4720"
    },
    "outputs": [],
-   "source": "import subprocess\nimport sys\n\nprocess = subprocess.Popen(\n  [\n    \"uvx\",\n    \"--refresh\",\n    \"--from\",\n    \"mjlab==1.0.0\",\n    \"--with\",\n    \"mujoco-warp @ git+https://github.com/google-deepmind/mujoco_warp@f2f795796fc433adf8e235f01fae3747585ae5db\",\n    \"demo\",\n  ],\n  stdout=subprocess.PIPE,\n  stderr=subprocess.STDOUT,\n  universal_newlines=True,\n  bufsize=1,\n)\n\nfor line in process.stdout:\n  print(line, end=\"\")\n  sys.stdout.flush()\n\n  if \"serving\" in line.lower() or \"running on\" in line.lower() or \"8081\" in line:\n    print(\"\\n\" + \"=\" * 50)\n    print(\"✅ Server is running! Execute the next cell to view.\")\n    print(\"=\" * 50)\n    break"
+   "source": "import subprocess\nimport sys\n\nprocess = subprocess.Popen(\n  [\n    \"uvx\",\n    \"--refresh\",\n    \"--from\",\n    \"mjlab==1.0.0\",\n    \"--with\",\n    \"mujoco-warp @ git+https://github.com/google-deepmind/mujoco_warp@9491175b7cbea87e28d3e3e67733095317c33398\",\n    \"demo\",\n  ],\n  stdout=subprocess.PIPE,\n  stderr=subprocess.STDOUT,\n  universal_newlines=True,\n  bufsize=1,\n)\n\nfor line in process.stdout:\n  print(line, end=\"\")\n  sys.stdout.flush()\n\n  if \"serving\" in line.lower() or \"running on\" in line.lower() or \"8081\" in line:\n    print(\"\\n\" + \"=\" * 50)\n    print(\"✅ Server is running! Execute the next cell to view.\")\n    print(\"=\" * 50)\n    break"
   },
   {
    "cell_type": "code",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ url = "https://py.mujoco.org"
 explicit = true
 
 [tool.uv.sources]
-mujoco-warp = { git = "https://github.com/google-deepmind/mujoco_warp", rev = "1c6b31692eaa5d3134093958d839165245d196a6"}
+mujoco-warp = { git = "https://github.com/google-deepmind/mujoco_warp", rev = "9491175b7cbea87e28d3e3e67733095317c33398"}
 warp-lang = { index = "nvidia", marker = "sys_platform != 'darwin'" }
 mujoco = { index = "mujoco" }
 torch = { index = "pytorch-cu128", extra = "cu128", marker = "sys_platform != 'darwin'" }

--- a/src/mjlab/sensor/raycast_sensor.py
+++ b/src/mjlab/sensor/raycast_sensor.py
@@ -166,8 +166,7 @@ import mujoco
 import mujoco_warp as mjwarp
 import torch
 import warp as wp
-from mujoco_warp._src.ray import rays
-from mujoco_warp._src.types import vec6
+from mujoco_warp import rays
 
 from mjlab.entity import Entity
 from mjlab.sensor.builtin_sensor import ObjRef
@@ -177,6 +176,9 @@ from mjlab.utils.lab_api.math import quat_from_matrix
 if TYPE_CHECKING:
   from mjlab.viewer.debug_visualizer import DebugVisualizer
 
+
+# NOTE: Need to define this here because it's not publicly exposed by mujoco_warp.
+vec6 = wp.types.vector(length=6, dtype=float)
 
 # Type aliases for configuration choices.
 RayAlignment = Literal["base", "yaw", "world"]
@@ -463,7 +465,7 @@ class RayCastSensor(Sensor[RayCastData]):
     self._ray_geomid: wp.array | None = None
     self._ray_normal: wp.array | None = None
     self._ray_bodyexclude: wp.array | None = None
-    self._geomgroup: vec6 = vec6(-1, -1, -1, -1, -1, -1)
+    self._geomgroup = vec6(-1, -1, -1, -1, -1, -1)
 
     self._distances: torch.Tensor | None = None
     self._normals_w: torch.Tensor | None = None
@@ -669,7 +671,7 @@ class RayCastSensor(Sensor[RayCastData]):
       d=self._data.struct,  # type: ignore[attr-defined]
       pnt=self._ray_pnt,
       vec=self._ray_vec,
-      geomgroup=self._geomgroup,
+      geomgroup=self._geomgroup,  # type: ignore[arg-type]
       flg_static=True,
       bodyexclude=self._ray_bodyexclude,
       dist=self._ray_dist,

--- a/uv.lock
+++ b/uv.lock
@@ -1288,7 +1288,7 @@ requires-dist = [
     { name = "autodocsumm", marker = "extra == 'docs'" },
     { name = "moviepy" },
     { name = "mujoco", specifier = ">=3.4.0", index = "https://py.mujoco.org/" },
-    { name = "mujoco-warp", git = "https://github.com/google-deepmind/mujoco_warp?rev=1c6b31692eaa5d3134093958d839165245d196a6" },
+    { name = "mujoco-warp", git = "https://github.com/google-deepmind/mujoco_warp?rev=9491175b7cbea87e28d3e3e67733095317c33398" },
     { name = "myst-parser", marker = "extra == 'docs'", specifier = ">=4.0.1" },
     { name = "onnxscript", specifier = ">=0.5.4" },
     { name = "prettytable" },
@@ -1461,7 +1461,7 @@ wheels = [
 [[package]]
 name = "mujoco-warp"
 version = "0.0.1"
-source = { git = "https://github.com/google-deepmind/mujoco_warp?rev=1c6b31692eaa5d3134093958d839165245d196a6#1c6b31692eaa5d3134093958d839165245d196a6" }
+source = { git = "https://github.com/google-deepmind/mujoco_warp?rev=9491175b7cbea87e28d3e3e67733095317c33398#9491175b7cbea87e28d3e3e67733095317c33398" }
 dependencies = [
     { name = "absl-py" },
     { name = "etils", extra = ["epath"] },


### PR DESCRIPTION
## Summary
- Update mujoco_warp dependency to commit 9491175b7cbea87e28d3e3e67733095317c33398
- Update all hash references in docs (installation.rst, README.md, docs/index.rst, demo.ipynb)
- Migrate raycast_sensor to use public `mujoco_warp.rays` instead of private `mujoco_warp._src.ray.rays`
- Define vec6 locally since it's not publicly exposed by mujoco_warp

## Test plan
- [x] `make check` passes
- [x] `uv run pytest tests/test_raycast_sensor.py` passes (17 passed, 4 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)