### PR TITLE
Add pre-commit configuration to order the imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,5 +6,10 @@ repos:
     # Run the linter.
     - id: ruff-check
       args: [ --fix ]
+    # Sort imports with ruff
+    - id: ruff
+      name: sort imports with ruff
+      args: [--select, I, --fix]
     # Run the formatter.
     - id: ruff-format
+      name: format with ruff


### PR DESCRIPTION
This adds the pre-commit configuration to reorder the imports of the libraries