### PR TITLE
Fix wrong joint ID mapping with multi-DOF joints

### DIFF
--- a/src/mjlab/entity/data.py
+++ b/src/mjlab/entity/data.py
@@ -139,8 +139,8 @@ class EntityData:
 
     env_ids = self._resolve_env_ids(env_ids)
     joint_ids = joint_ids if joint_ids is not None else slice(None)
-    q_slice = self.indexing.joint_q_adr[joint_ids]
-    self.data.qpos[env_ids, q_slice] = position
+    q_dof_ids = self.indexing.get_q_dof_ids(joint_ids)
+    self.data.qpos[env_ids, q_dof_ids] = position
 
   def write_joint_velocity(
     self,
@@ -153,8 +153,8 @@ class EntityData:
 
     env_ids = self._resolve_env_ids(env_ids)
     joint_ids = joint_ids if joint_ids is not None else slice(None)
-    v_slice = self.indexing.joint_v_adr[joint_ids]
-    self.data.qvel[env_ids, v_slice] = velocity
+    v_dof_ids = self.indexing.get_v_dof_ids(joint_ids)
+    self.data.qvel[env_ids, v_dof_ids] = velocity
 
   def write_external_wrench(
     self,
@@ -340,23 +340,23 @@ class EntityData:
 
   @property
   def joint_pos(self) -> torch.Tensor:
-    """Joint positions. Shape (num_envs, num_joints)."""
-    return self.data.qpos[:, self.indexing.joint_q_adr]
+    """Joint positions. Shape (num_envs, num_q_dofs)."""
+    return self.data.qpos[:, self.indexing.all_q_dof_ids]
 
   @property
   def joint_pos_biased(self) -> torch.Tensor:
-    """Joint positions with encoder bias applied. Shape (num_envs, num_joints)."""
+    """Joint positions with encoder bias applied. Shape (num_envs, num_q_dofs)."""
     return self.joint_pos + self.encoder_bias
 
   @property
   def joint_vel(self) -> torch.Tensor:
-    """Joint velocities. Shape (num_envs, nv)."""
-    return self.data.qvel[:, self.indexing.joint_v_adr]
+    """Joint velocities. Shape (num_envs, num_v_dofs)."""
+    return self.data.qvel[:, self.indexing.all_v_dof_ids]
 
   @property
   def joint_acc(self) -> torch.Tensor:
-    """Joint accelerations. Shape (num_envs, nv)."""
-    return self.data.qacc[:, self.indexing.joint_v_adr]
+    """Joint accelerations. Shape (num_envs, num_v_dofs)."""
+    return self.data.qacc[:, self.indexing.all_v_dof_ids]
 
   # Tendon properties
 

--- a/src/mjlab/entity/entity.py
+++ b/src/mjlab/entity/entity.py
@@ -41,15 +41,66 @@ class EntityIndexing:
   joint_ids: torch.Tensor
   mocap_id: int | None
 
-  # Addresses.
-  joint_q_adr: torch.Tensor
-  joint_v_adr: torch.Tensor
+  # Per-joint addresses and widths (length = num_joints).
+  joint_q_adr: torch.Tensor  # Starting qpos address for each joint
+  joint_v_adr: torch.Tensor  # Starting qvel address for each joint
+  joint_q_width: torch.Tensor  # Number of qpos DOFs per joint (1 for hinge, 4 for ball)
+  joint_v_width: torch.Tensor  # Number of qvel DOFs per joint (1 for hinge, 3 for ball)
+
+  # Flat DOF indices for all joints (for indexing into qpos/qvel).
+  all_q_dof_ids: torch.Tensor
+  all_v_dof_ids: torch.Tensor
+
+  # Free joint addresses (flat, for root state).
   free_joint_q_adr: torch.Tensor
   free_joint_v_adr: torch.Tensor
 
   @property
   def root_body_id(self) -> int:
     return self.bodies[0].id
+
+  def get_q_dof_ids(
+    self, joint_ids: torch.Tensor | list[int] | slice
+  ) -> torch.Tensor | slice:
+    """Get qpos DOF indices for specified joints.
+
+    Args:
+      joint_ids: Local joint indices (0, 1, 2, ...) or slice.
+
+    Returns:
+      Global qpos indices that can be used to index into qpos directly.
+    """
+    if isinstance(joint_ids, slice):
+      return self.all_q_dof_ids
+    return self._expand_dof_ids(
+      self.joint_q_adr[joint_ids], self.joint_q_width[joint_ids]
+    )
+
+  def get_v_dof_ids(
+    self, joint_ids: torch.Tensor | list[int] | slice
+  ) -> torch.Tensor | slice:
+    """Get qvel DOF indices for specified joints.
+
+    Args:
+      joint_ids: Local joint indices (0, 1, 2, ...) or slice.
+
+    Returns:
+      Global qvel indices that can be used to index into qvel directly.
+    """
+    if isinstance(joint_ids, slice):
+      return self.all_v_dof_ids
+    return self._expand_dof_ids(
+      self.joint_v_adr[joint_ids], self.joint_v_width[joint_ids]
+    )
+
+  def _expand_dof_ids(
+    self, addresses: torch.Tensor, widths: torch.Tensor
+  ) -> torch.Tensor:
+    """Expand per-joint addresses and widths into flat DOF indices."""
+    indices = []
+    for adr, w in zip(addresses.tolist(), widths.tolist(), strict=True):
+      indices.extend(range(adr, adr + w))
+    return torch.tensor(indices, device=addresses.device, dtype=torch.int)
 
 
 @dataclass
@@ -889,6 +940,16 @@ class Entity:
   # Private methods.
   ##
 
+  @staticmethod
+  def _expand_dof_ids(
+    addresses: list[int], widths: list[int], device: str
+  ) -> torch.Tensor:
+    """Expand per-joint addresses and widths into flat DOF indices."""
+    indices = []
+    for adr, w in zip(addresses, widths, strict=True):
+      indices.extend(range(adr, adr + w))
+    return torch.tensor(indices, device=device, dtype=torch.int)
+
   def _compute_indexing(self, model: mujoco.MjModel, device: str) -> EntityIndexing:
     bodies = tuple([b for b in self.spec.bodies[1:]])
     joints = self._non_free_joints
@@ -909,8 +970,10 @@ class Entity:
       actuators = None
       ctrl_ids = torch.empty(0, dtype=torch.int, device=device)
 
-    joint_q_adr = []
-    joint_v_adr = []
+    joint_q_adr_list = []
+    joint_v_adr_list = []
+    joint_q_width_list = []
+    joint_v_width_list = []
     free_joint_q_adr = []
     free_joint_v_adr = []
     for joint in self.spec.joints:
@@ -922,12 +985,20 @@ class Entity:
         free_joint_v_adr.extend(range(vadr, vadr + 6))
         free_joint_q_adr.extend(range(qadr, qadr + 7))
       else:
-        joint_v_adr.extend(range(vadr, vadr + dof_width(jnt_type)))
-        joint_q_adr.extend(range(qadr, qadr + qpos_width(jnt_type)))
-    joint_q_adr = torch.tensor(joint_q_adr, dtype=torch.int, device=device)
-    joint_v_adr = torch.tensor(joint_v_adr, dtype=torch.int, device=device)
-    free_joint_v_adr = torch.tensor(free_joint_v_adr, dtype=torch.int, device=device)
+        joint_q_adr_list.append(qadr)
+        joint_v_adr_list.append(vadr)
+        joint_q_width_list.append(qpos_width(jnt_type))
+        joint_v_width_list.append(dof_width(jnt_type))
+    joint_q_adr = torch.tensor(joint_q_adr_list, dtype=torch.int, device=device)
+    joint_v_adr = torch.tensor(joint_v_adr_list, dtype=torch.int, device=device)
+    joint_q_width = torch.tensor(joint_q_width_list, dtype=torch.int, device=device)
+    joint_v_width = torch.tensor(joint_v_width_list, dtype=torch.int, device=device)
     free_joint_q_adr = torch.tensor(free_joint_q_adr, dtype=torch.int, device=device)
+    free_joint_v_adr = torch.tensor(free_joint_v_adr, dtype=torch.int, device=device)
+
+    # Compute flat DOF indices for all joints.
+    all_q_dof_ids = self._expand_dof_ids(joint_q_adr_list, joint_q_width_list, device)
+    all_v_dof_ids = self._expand_dof_ids(joint_v_adr_list, joint_v_width_list, device)
 
     if self.is_fixed_base and self.is_mocap:
       mocap_id = int(model.body_mocapid[self.root_body.id])
@@ -950,6 +1021,10 @@ class Entity:
       mocap_id=mocap_id,
       joint_q_adr=joint_q_adr,
       joint_v_adr=joint_v_adr,
+      joint_q_width=joint_q_width,
+      joint_v_width=joint_v_width,
+      all_q_dof_ids=all_q_dof_ids,
+      all_v_dof_ids=all_v_dof_ids,
       free_joint_q_adr=free_joint_q_adr,
       free_joint_v_adr=free_joint_v_adr,
     )

--- a/src/mjlab/envs/mdp/events.py
+++ b/src/mjlab/envs/mdp/events.py
@@ -359,9 +359,17 @@ def _get_entity_indices(
 ) -> torch.Tensor:
   match spec.entity_type:
     case "dof":
-      return indexing.joint_v_adr[asset_cfg.joint_ids]
+      # joint_v_ids are global qvel addresses.
+      v_ids = asset_cfg.joint_v_ids
+      if isinstance(v_ids, slice):
+        return indexing.all_v_dof_ids
+      return torch.tensor(v_ids, device=indexing.joint_v_adr.device, dtype=torch.int)
     case "joint" if spec.use_address:
-      return indexing.joint_q_adr[asset_cfg.joint_ids]
+      # joint_q_ids are global qpos addresses.
+      q_ids = asset_cfg.joint_q_ids
+      if isinstance(q_ids, slice):
+        return indexing.all_q_dof_ids
+      return torch.tensor(q_ids, device=indexing.joint_q_adr.device, dtype=torch.int)
     case "joint":
       return indexing.joint_ids[asset_cfg.joint_ids]
     case "body":

--- a/src/mjlab/envs/mdp/observations.py
+++ b/src/mjlab/envs/mdp/observations.py
@@ -56,9 +56,9 @@ def joint_pos_rel(
   asset: Entity = env.scene[asset_cfg.name]
   default_joint_pos = asset.data.default_joint_pos
   assert default_joint_pos is not None
-  jnt_ids = asset_cfg.joint_ids
+  q_ids = asset_cfg.joint_q_ids
   joint_pos = asset.data.joint_pos_biased if biased else asset.data.joint_pos
-  return joint_pos[:, jnt_ids] - default_joint_pos[:, jnt_ids]
+  return joint_pos[:, q_ids] - default_joint_pos[:, q_ids]
 
 
 def joint_vel_rel(
@@ -68,8 +68,8 @@ def joint_vel_rel(
   asset: Entity = env.scene[asset_cfg.name]
   default_joint_vel = asset.data.default_joint_vel
   assert default_joint_vel is not None
-  jnt_ids = asset_cfg.joint_ids
-  return asset.data.joint_vel[:, jnt_ids] - default_joint_vel[:, jnt_ids]
+  v_ids = asset_cfg.joint_v_ids
+  return asset.data.joint_vel[:, v_ids] - default_joint_vel[:, v_ids]
 
 
 ##

--- a/src/mjlab/envs/mdp/rewards.py
+++ b/src/mjlab/envs/mdp/rewards.py
@@ -42,7 +42,7 @@ def joint_vel_l2(
 ) -> torch.Tensor:
   """Penalize joint velocities on the articulation using L2 squared kernel."""
   asset: Entity = env.scene[asset_cfg.name]
-  return torch.sum(torch.square(asset.data.joint_vel[:, asset_cfg.joint_ids]), dim=1)
+  return torch.sum(torch.square(asset.data.joint_vel[:, asset_cfg.joint_v_ids]), dim=1)
 
 
 def joint_acc_l2(
@@ -50,7 +50,7 @@ def joint_acc_l2(
 ) -> torch.Tensor:
   """Penalize joint accelerations on the articulation using L2 squared kernel."""
   asset: Entity = env.scene[asset_cfg.name]
-  return torch.sum(torch.square(asset.data.joint_acc[:, asset_cfg.joint_ids]), dim=1)
+  return torch.sum(torch.square(asset.data.joint_acc[:, asset_cfg.joint_v_ids]), dim=1)
 
 
 def action_rate_l2(env: ManagerBasedRlEnv) -> torch.Tensor:
@@ -77,13 +77,12 @@ def joint_pos_limits(
   asset: Entity = env.scene[asset_cfg.name]
   soft_joint_pos_limits = asset.data.soft_joint_pos_limits
   assert soft_joint_pos_limits is not None
+  q_ids = asset_cfg.joint_q_ids
   out_of_limits = -(
-    asset.data.joint_pos[:, asset_cfg.joint_ids]
-    - soft_joint_pos_limits[:, asset_cfg.joint_ids, 0]
+    asset.data.joint_pos[:, q_ids] - soft_joint_pos_limits[:, q_ids, 0]
   ).clip(max=0.0)
   out_of_limits += (
-    asset.data.joint_pos[:, asset_cfg.joint_ids]
-    - soft_joint_pos_limits[:, asset_cfg.joint_ids, 1]
+    asset.data.joint_pos[:, q_ids] - soft_joint_pos_limits[:, q_ids, 1]
   ).clip(min=0.0)
   return torch.sum(out_of_limits, dim=1)
 
@@ -116,8 +115,9 @@ class posture:
   ) -> torch.Tensor:
     del std  # Unused.
     asset: Entity = env.scene[asset_cfg.name]
-    current_joint_pos = asset.data.joint_pos[:, asset_cfg.joint_ids]
-    desired_joint_pos = self.default_joint_pos[:, asset_cfg.joint_ids]
+    q_ids = asset_cfg.joint_q_ids
+    current_joint_pos = asset.data.joint_pos[:, q_ids]
+    desired_joint_pos = self.default_joint_pos[:, q_ids]
     error_squared = torch.square(current_joint_pos - desired_joint_pos)
     return torch.exp(-torch.mean(error_squared / (self.std**2), dim=1))
 

--- a/src/mjlab/managers/scene_entity_config.py
+++ b/src/mjlab/managers/scene_entity_config.py
@@ -44,7 +44,13 @@ class SceneEntityCfg:
   """Names of joints to include. Can be a single string or tuple."""
 
   joint_ids: list[int] | slice = field(default_factory=lambda: slice(None))
-  """IDs of joints to include. Can be a list or slice."""
+  """Joint indices (into the entity's joint list). Can be a list or slice."""
+
+  joint_q_ids: list[int] | slice = field(default_factory=lambda: slice(None))
+  """Expanded qpos DOF indices for the selected joints. Set during resolve()."""
+
+  joint_v_ids: list[int] | slice = field(default_factory=lambda: slice(None))
+  """Expanded qvel DOF indices for the selected joints. Set during resolve()."""
 
   body_names: str | tuple[str, ...] | None = None
   """Names of bodies to include. Can be a single string or tuple."""
@@ -93,6 +99,8 @@ class SceneEntityCfg:
 
     for config in _FIELD_CONFIGS:
       self._resolve_field(entity, config)
+
+    self._resolve_joint_dof_ids(entity)
 
   def _resolve_field(self, entity: Entity, config: _FieldConfig) -> None:
     """Resolve a single field's names and IDs.
@@ -188,3 +196,25 @@ class SceneEntityCfg:
     """Resolve IDs to their corresponding names."""
     resolved_names = [entity_all_names[i] for i in ids]
     setattr(self, names_attr, resolved_names)
+
+  def _resolve_joint_dof_ids(self, entity: Entity) -> None:
+    """Compute expanded DOF indices for the selected joints.
+
+    This converts joint_ids (joint indices) into joint_q_ids and joint_v_ids
+    (expanded DOF indices) that can be used to index into qpos and qvel arrays.
+    """
+    indexing = entity.data.indexing
+
+    if isinstance(self.joint_ids, slice):
+      # All joints selected, use all DOF indices.
+      self.joint_q_ids = slice(None)
+      self.joint_v_ids = slice(None)
+    else:
+      # Expand joint indices to DOF indices.
+      # Since joint_ids is not a slice, get_*_dof_ids returns a tensor.
+      q_dof_ids = indexing.get_q_dof_ids(self.joint_ids)
+      v_dof_ids = indexing.get_v_dof_ids(self.joint_ids)
+      assert not isinstance(q_dof_ids, slice)
+      assert not isinstance(v_dof_ids, slice)
+      self.joint_q_ids = q_dof_ids.tolist()
+      self.joint_v_ids = v_dof_ids.tolist()

--- a/tests/fixtures/mixed_joints.xml
+++ b/tests/fixtures/mixed_joints.xml
@@ -1,0 +1,16 @@
+<mujoco>
+  <worldbody>
+    <body name="base">
+      <joint name="hinge0" type="hinge" axis="0 0 1"/>
+      <geom type="sphere" size="0.1"/>
+      <body name="link1" pos="0.2 0 0">
+        <joint name="ball0" type="ball"/>
+        <geom type="sphere" size="0.1"/>
+        <body name="link2" pos="0.2 0 0">
+          <joint name="hinge1" type="hinge" axis="0 1 0"/>
+          <geom type="sphere" size="0.1"/>
+        </body>
+      </body>
+    </body>
+  </worldbody>
+</mujoco>

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -54,6 +54,8 @@ FIXED_BASE_ARTICULATED_XML = """
 
 FLOATING_BASE_ARTICULATED_XML = load_fixture_xml("floating_base_articulated")
 
+MIXED_JOINTS_XML = load_fixture_xml("mixed_joints")
+
 ACTUATOR_ORDER_TEST_XML = """
 <mujoco>
   <worldbody>
@@ -747,3 +749,106 @@ def test_tendon_and_site_targets_only_allocated_when_needed(device):
 
   # Joint targets should still be allocated (2 joints).
   assert entity.data.joint_pos_target.shape == (4, 2)
+
+
+# ============================================================================
+# Ball Joint Indexing Tests
+# ============================================================================
+
+
+def create_mixed_joints_entity():
+  """Create an entity with mixed joint types (hinge + ball + hinge)."""
+  cfg = EntityCfg(
+    spec_fn=lambda: mujoco.MjSpec.from_string(MIXED_JOINTS_XML),
+  )
+  return Entity(cfg)
+
+
+def test_mixed_joints_indexing_widths(device):
+  """Test EntityIndexing correctly computes widths for mixed joint types.
+
+  Model has: hinge0 (1 qpos, 1 qvel), ball0 (4 qpos, 3 qvel), hinge1 (1 qpos, 1 qvel)
+  """
+  entity = create_mixed_joints_entity()
+  entity, sim = initialize_entity_with_sim(entity, device)
+
+  indexing = entity.data.indexing
+
+  # Verify per-joint widths.
+  assert indexing.joint_q_width.tolist() == [1, 4, 1]
+  assert indexing.joint_v_width.tolist() == [1, 3, 1]
+
+  # Verify total DOF counts.
+  assert len(indexing.all_q_dof_ids) == 6  # 1 + 4 + 1
+  assert len(indexing.all_v_dof_ids) == 5  # 1 + 3 + 1
+
+
+def test_mixed_joints_get_q_dof_ids(device):
+  """Test get_q_dof_ids correctly expands joint indices to qpos DOF indices."""
+  entity = create_mixed_joints_entity()
+  entity, sim = initialize_entity_with_sim(entity, device)
+
+  indexing = entity.data.indexing
+
+  # Single hinge joint (1 qpos DOF).
+  q_ids_0 = indexing.get_q_dof_ids([0])
+  assert isinstance(q_ids_0, torch.Tensor) and len(q_ids_0) == 1
+
+  # Ball joint (4 qpos DOFs).
+  q_ids_1 = indexing.get_q_dof_ids([1])
+  assert isinstance(q_ids_1, torch.Tensor) and len(q_ids_1) == 4
+
+  # Second hinge joint (1 qpos DOF).
+  q_ids_2 = indexing.get_q_dof_ids([2])
+  assert isinstance(q_ids_2, torch.Tensor) and len(q_ids_2) == 1
+
+  # Both hinges (skip ball).
+  q_ids_0_2 = indexing.get_q_dof_ids([0, 2])
+  assert isinstance(q_ids_0_2, torch.Tensor) and len(q_ids_0_2) == 2
+
+  # All joints.
+  q_ids_all = indexing.get_q_dof_ids([0, 1, 2])
+  assert isinstance(q_ids_all, torch.Tensor) and len(q_ids_all) == 6
+
+
+def test_mixed_joints_get_v_dof_ids(device):
+  """Test get_v_dof_ids correctly expands joint indices to qvel DOF indices."""
+  entity = create_mixed_joints_entity()
+  entity, sim = initialize_entity_with_sim(entity, device)
+
+  indexing = entity.data.indexing
+
+  # Single hinge joint (1 qvel DOF).
+  v_ids_0 = indexing.get_v_dof_ids([0])
+  assert isinstance(v_ids_0, torch.Tensor) and len(v_ids_0) == 1
+
+  # Ball joint (3 qvel DOFs).
+  v_ids_1 = indexing.get_v_dof_ids([1])
+  assert isinstance(v_ids_1, torch.Tensor) and len(v_ids_1) == 3
+
+  # Second hinge joint (1 qvel DOF).
+  v_ids_2 = indexing.get_v_dof_ids([2])
+  assert isinstance(v_ids_2, torch.Tensor) and len(v_ids_2) == 1
+
+  # Both hinges (skip ball).
+  v_ids_0_2 = indexing.get_v_dof_ids([0, 2])
+  assert isinstance(v_ids_0_2, torch.Tensor) and len(v_ids_0_2) == 2
+
+  # All joints.
+  v_ids_all = indexing.get_v_dof_ids([0, 1, 2])
+  assert isinstance(v_ids_all, torch.Tensor) and len(v_ids_all) == 5
+
+
+def test_mixed_joints_slice_returns_all_dofs(device):
+  """Test that slice(None) returns all DOF indices."""
+  entity = create_mixed_joints_entity()
+  entity, sim = initialize_entity_with_sim(entity, device)
+
+  indexing = entity.data.indexing
+
+  # Slice should return all DOF indices as a tensor.
+  q_ids = indexing.get_q_dof_ids(slice(None))
+  v_ids = indexing.get_v_dof_ids(slice(None))
+
+  assert isinstance(q_ids, torch.Tensor) and len(q_ids) == 6
+  assert isinstance(v_ids, torch.Tensor) and len(v_ids) == 5

--- a/tests/test_entity_data.py
+++ b/tests/test_entity_data.py
@@ -282,3 +282,173 @@ def test_entity_data_reset_partial_envs(device):
   assert torch.all(entity.data.tendon_effort_target[1] == 0.0)
   assert torch.all(entity.data.tendon_effort_target[2] == 9.0)
   assert torch.all(entity.data.tendon_effort_target[3] == 0.0)
+
+
+# ============================================================================
+# Ball Joint Read/Write Tests
+# ============================================================================
+
+MIXED_JOINTS_XML = """
+<mujoco>
+  <worldbody>
+    <body name="base">
+      <joint name="hinge0" type="hinge" axis="0 0 1"/>
+      <geom type="sphere" size="0.1"/>
+      <body name="link1" pos="0.2 0 0">
+        <joint name="ball0" type="ball"/>
+        <geom type="sphere" size="0.1"/>
+        <body name="link2" pos="0.2 0 0">
+          <joint name="hinge1" type="hinge" axis="0 1 0"/>
+          <geom type="sphere" size="0.1"/>
+        </body>
+      </body>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+
+def create_mixed_joints_entity():
+  """Create an entity with mixed joint types (hinge + ball + hinge)."""
+  cfg = EntityCfg(spec_fn=lambda: mujoco.MjSpec.from_string(MIXED_JOINTS_XML))
+  return Entity(cfg)
+
+
+def test_joint_pos_shape_with_ball_joint(device):
+  """Test joint_pos property has correct shape with ball joints.
+
+  Model has: hinge0 (1 qpos), ball0 (4 qpos), hinge1 (1 qpos) = 6 total
+  """
+  entity = create_mixed_joints_entity()
+  entity, sim = initialize_entity_with_sim(entity, device, num_envs=4)
+
+  sim.forward()
+
+  assert entity.data.joint_pos.shape == (4, 6)
+
+
+def test_joint_vel_shape_with_ball_joint(device):
+  """Test joint_vel property has correct shape with ball joints.
+
+  Model has: hinge0 (1 qvel), ball0 (3 qvel), hinge1 (1 qvel) = 5 total
+  """
+  entity = create_mixed_joints_entity()
+  entity, sim = initialize_entity_with_sim(entity, device, num_envs=4)
+
+  sim.forward()
+
+  assert entity.data.joint_vel.shape == (4, 5)
+
+
+def test_write_joint_position_ball_joint(device):
+  """Test writing position to a ball joint (4 qpos values)."""
+  entity = create_mixed_joints_entity()
+  entity, sim = initialize_entity_with_sim(entity, device, num_envs=2)
+
+  sim.forward()
+
+  # Write to ball joint (index 1) which has 4 qpos DOFs.
+  # Ball joint qpos is a quaternion [w, x, y, z].
+  ball_quat = torch.tensor(
+    [[1.0, 0.0, 0.0, 0.0], [0.707, 0.707, 0.0, 0.0]], device=device
+  )
+  entity.data.write_joint_position(ball_quat, joint_ids=torch.tensor([1]))
+
+  # Read back and verify.
+  q_dof_ids = entity.data.indexing.get_q_dof_ids([1])
+  written_qpos = sim.data.qpos[:, entity.data.indexing.all_q_dof_ids[q_dof_ids]]
+
+  assert torch.allclose(written_qpos, ball_quat, atol=1e-5)
+
+
+def test_write_joint_velocity_ball_joint(device):
+  """Test writing velocity to a ball joint (3 qvel values)."""
+  entity = create_mixed_joints_entity()
+  entity, sim = initialize_entity_with_sim(entity, device, num_envs=2)
+
+  sim.forward()
+
+  # Write to ball joint (index 1) which has 3 qvel DOFs.
+  ball_angvel = torch.tensor([[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]], device=device)
+  entity.data.write_joint_velocity(ball_angvel, joint_ids=torch.tensor([1]))
+
+  # Read back and verify.
+  v_dof_ids = entity.data.indexing.get_v_dof_ids([1])
+  written_qvel = sim.data.qvel[:, entity.data.indexing.all_v_dof_ids[v_dof_ids]]
+
+  assert torch.allclose(written_qvel, ball_angvel, atol=1e-5)
+
+
+def test_write_joint_position_all_joints_mixed(device):
+  """Test writing position to all joints with mixed types."""
+  entity = create_mixed_joints_entity()
+  entity, sim = initialize_entity_with_sim(entity, device, num_envs=1)
+
+  sim.forward()
+
+  # Write to all 3 joints: hinge0 (1), ball0 (4), hinge1 (1) = 6 total DOFs.
+  # fmt: off
+  all_positions = torch.tensor([[
+    0.5,                      # hinge0
+    1.0, 0.0, 0.0, 0.0,       # ball0 (quaternion)
+    -0.3,                     # hinge1
+  ]], device=device)
+  # fmt: on
+
+  entity.data.write_joint_position(all_positions)
+
+  # Verify the positions were written.
+  sim.forward()
+  joint_pos = entity.data.joint_pos
+
+  assert torch.allclose(joint_pos, all_positions, atol=1e-5)
+
+
+def test_write_joint_position_selective_hinges_only(device):
+  """Test writing to selected joints (hinges only, skip ball)."""
+  entity = create_mixed_joints_entity()
+  entity, sim = initialize_entity_with_sim(entity, device, num_envs=1)
+
+  sim.forward()
+
+  # Get initial ball joint position to verify it's unchanged.
+  initial_ball_pos = entity.data.joint_pos[:, 1:5].clone()
+
+  # Write only to hinges (indices 0 and 2), which have 1 DOF each.
+  hinge_positions = torch.tensor([[0.7, -0.4]], device=device)
+  entity.data.write_joint_position(hinge_positions, joint_ids=torch.tensor([0, 2]))
+
+  sim.forward()
+
+  # Verify hinges changed.
+  assert torch.allclose(
+    entity.data.joint_pos[:, 0:1], hinge_positions[:, 0:1], atol=1e-5
+  )
+  assert torch.allclose(
+    entity.data.joint_pos[:, 5:6], hinge_positions[:, 1:2], atol=1e-5
+  )
+
+  # Verify ball joint unchanged.
+  assert torch.allclose(entity.data.joint_pos[:, 1:5], initial_ball_pos, atol=1e-5)
+
+
+def test_joint_pos_roundtrip_with_ball_joint(device):
+  """Test full roundtrip: write all joints → forward → read → verify."""
+  entity = create_mixed_joints_entity()
+  entity, sim = initialize_entity_with_sim(entity, device, num_envs=2)
+
+  sim.forward()
+
+  # fmt: off
+  positions = torch.tensor([
+    [0.1, 1.0, 0.0, 0.0, 0.0, 0.2],   # env 0
+    [0.3, 0.707, 0.707, 0.0, 0.0, 0.4],  # env 1
+  ], device=device)
+  # fmt: on
+
+  entity.data.write_joint_position(positions)
+  sim.forward()
+
+  read_positions = entity.data.joint_pos
+
+  assert torch.allclose(read_positions, positions, atol=1e-4)

--- a/tests/test_scene_entity_config.py
+++ b/tests/test_scene_entity_config.py
@@ -2,9 +2,46 @@
 
 from dataclasses import dataclass
 
+import mujoco
 import pytest
+import torch
+from conftest import get_test_device
 
+from mjlab.entity import Entity, EntityCfg
 from mjlab.managers.scene_entity_config import SceneEntityCfg
+from mjlab.sim.sim import Simulation, SimulationCfg
+
+
+@dataclass
+class _FakeIndexing:
+  """Fake indexing for testing. Assumes all joints are 1-DOF (hinge-like)."""
+
+  num_joints: int
+
+  def get_q_dof_ids(
+    self, joint_ids: torch.Tensor | list[int] | slice
+  ) -> torch.Tensor | slice:
+    if isinstance(joint_ids, slice):
+      return torch.arange(self.num_joints)
+    if isinstance(joint_ids, list):
+      return torch.tensor(joint_ids)
+    return joint_ids
+
+  def get_v_dof_ids(
+    self, joint_ids: torch.Tensor | list[int] | slice
+  ) -> torch.Tensor | slice:
+    if isinstance(joint_ids, slice):
+      return torch.arange(self.num_joints)
+    if isinstance(joint_ids, list):
+      return torch.tensor(joint_ids)
+    return joint_ids
+
+
+@dataclass
+class _FakeData:
+  """Fake data for testing."""
+
+  indexing: _FakeIndexing
 
 
 @dataclass
@@ -31,6 +68,10 @@ class _FakeEntity:
   @property
   def num_sites(self) -> int:
     return len(self.site_names)
+
+  @property
+  def data(self) -> _FakeData:
+    return _FakeData(indexing=_FakeIndexing(num_joints=self.num_joints))
 
   # find_* helpers return (ids, names) similar to Entity API.
   def _find(
@@ -139,3 +180,106 @@ def test_inconsistent_names_and_ids_raise(
 
   with pytest.raises(ValueError):
     cfg.resolve(fake_scene)
+
+
+# ============================================================================
+# Ball Joint DOF Resolution Tests (using real Entity)
+# ============================================================================
+
+
+MIXED_JOINTS_XML = """
+<mujoco>
+  <worldbody>
+    <body name="base">
+      <joint name="hinge0" type="hinge" axis="0 0 1"/>
+      <geom type="sphere" size="0.1"/>
+      <body name="link1" pos="0.2 0 0">
+        <joint name="ball0" type="ball"/>
+        <geom type="sphere" size="0.1"/>
+        <body name="link2" pos="0.2 0 0">
+          <joint name="hinge1" type="hinge" axis="0 1 0"/>
+          <geom type="sphere" size="0.1"/>
+        </body>
+      </body>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+
+@pytest.fixture(scope="module")
+def mixed_joint_scene():
+  """Create a real scene with mixed joint types."""
+  device = get_test_device()
+  cfg = EntityCfg(spec_fn=lambda: mujoco.MjSpec.from_string(MIXED_JOINTS_XML))
+  entity = Entity(cfg)
+  model = entity.compile()
+  sim = Simulation(num_envs=1, cfg=SimulationCfg(), model=model, device=device)
+  entity.initialize(model, sim.model, sim.data, device)
+  return {"robot": entity}
+
+
+def test_joint_q_ids_expands_for_ball_joint(mixed_joint_scene):
+  """Test joint_q_ids correctly expands to 4 indices for a ball joint."""
+  cfg = SceneEntityCfg(name="robot", joint_names=("ball0",))
+  cfg.resolve(mixed_joint_scene)
+
+  # Ball joint should expand to 4 qpos DOFs.
+  assert cfg.joint_q_ids == [1, 2, 3, 4]
+
+
+def test_joint_v_ids_expands_for_ball_joint(mixed_joint_scene):
+  """Test joint_v_ids correctly expands to 3 indices for a ball joint."""
+  cfg = SceneEntityCfg(name="robot", joint_names=("ball0",))
+  cfg.resolve(mixed_joint_scene)
+
+  # Ball joint should expand to 3 qvel DOFs.
+  assert cfg.joint_v_ids == [1, 2, 3]
+
+
+def test_joint_q_ids_mixed_selection(mixed_joint_scene):
+  """Test joint_q_ids for selecting hinge + ball (1 + 4 = 5 DOFs)."""
+  cfg = SceneEntityCfg(name="robot", joint_names=("hinge0", "ball0"))
+  cfg.resolve(mixed_joint_scene)
+
+  # hinge0: 1 DOF at index 0, ball0: 4 DOFs at indices 1-4.
+  assert cfg.joint_q_ids == [0, 1, 2, 3, 4]
+
+
+def test_joint_v_ids_mixed_selection(mixed_joint_scene):
+  """Test joint_v_ids for selecting hinge + ball (1 + 3 = 4 DOFs)."""
+  cfg = SceneEntityCfg(name="robot", joint_names=("hinge0", "ball0"))
+  cfg.resolve(mixed_joint_scene)
+
+  # hinge0: 1 DOF at index 0, ball0: 3 DOFs at indices 1-3.
+  assert cfg.joint_v_ids == [0, 1, 2, 3]
+
+
+def test_joint_q_ids_hinges_only(mixed_joint_scene):
+  """Test joint_q_ids for selecting only hinges (skip ball)."""
+  cfg = SceneEntityCfg(name="robot", joint_names=("hinge0", "hinge1"))
+  cfg.resolve(mixed_joint_scene)
+
+  # hinge0: index 0, hinge1: index 5.
+  assert cfg.joint_q_ids == [0, 5]
+
+
+def test_joint_v_ids_hinges_only(mixed_joint_scene):
+  """Test joint_v_ids for selecting only hinges (skip ball)."""
+  cfg = SceneEntityCfg(name="robot", joint_names=("hinge0", "hinge1"))
+  cfg.resolve(mixed_joint_scene)
+
+  # hinge0: index 0, hinge1: index 4.
+  assert cfg.joint_v_ids == [0, 4]
+
+
+def test_joint_dof_ids_slice_when_all_joints(mixed_joint_scene):
+  """Test joint_q_ids/joint_v_ids remain slice(None) when all joints selected."""
+  cfg = SceneEntityCfg(name="robot", joint_names=("hinge0", "ball0", "hinge1"))
+  cfg.resolve(mixed_joint_scene)
+
+  # When all joints are selected and joint_ids becomes slice(None),
+  # joint_q_ids and joint_v_ids should also be slice(None).
+  assert cfg.joint_ids == slice(None)
+  assert cfg.joint_q_ids == slice(None)
+  assert cfg.joint_v_ids == slice(None)


### PR DESCRIPTION
The EntityIndexing class had a mismatch between joint_ids (one per joint) and DOF address arrays (expanded per DOF). This caused incorrect indexing when models contained ball joints (4 qpos, 3 qvel DOFs) instead of only hinge/slide joints (1 DOF each).

Changes:
- Add per-joint width tracking (joint_q_width, joint_v_width) to EntityIndexing
- Add get_q_dof_ids() and get_v_dof_ids() helpers to expand joint indices to DOF indices
- Add joint_q_ids and joint_v_ids to SceneEntityCfg, computed during resolve()
- Update rewards, observations, and events to use expanded DOF indices

Tests:
- Add mixed_joints.xml fixture (hinge + ball + hinge)
- Add EntityIndexing tests for DOF expansion
- Add EntityData tests for ball joint read/write
- Add SceneEntityCfg tests for DOF resolution

Fixes #475.