### PR TITLE
Fixes Go1 foot collision by setting conaffinity=1 for sphere geoms

### DIFF
--- a/src/mjlab/asset_zoo/robots/unitree_go1/go1_constants.py
+++ b/src/mjlab/asset_zoo/robots/unitree_go1/go1_constants.py
@@ -124,7 +124,7 @@ FULL_COLLISION = CollisionCfg(
   friction={_foot_regex: (0.6,)},
   solimp={_foot_regex: (0.9, 0.95, 0.023)},
   contype=1,
-  conaffinity=0,
+  conaffinity={_foot_regex: 1, ".*_collision": 0},
 )
 
 ##


### PR DESCRIPTION
I ran into this weird issue where the Go1 foot spheres stopped colliding with the flat terrain. The bitwise collision filter is correct - terrain has `contype=1, conaffinity=1` and robot geoms have `contype=1, conaffinity=0`, so `(1 & 1) OR (1 & 0) = 1` which should make them collide. 

What makes this really strange is that only the foot spheres are affected. All other robot geoms (capsules, boxes) collide fine with the exact same settings. Even weirder, it works with rough terrain and it works with the `FEET_ONLY_COLLISION` config which just excludes other meshes from colliding.

So I submit a workaround where for now I'm setting both `contype` and `conaffinity` to 1 specifically for the feet using dict-based assignment:

```python
FULL_COLLISION = CollisionCfg(
  conaffinity={_foot_regex: 1, ".*_collision": 0},
  ...
)
```

This isn't the perfect solution but it makes the environment work while we figure out what's actually going on. I believe I ruled out that it's a mjlab issue so I'll keep investigating whether this is a MuJoCo core issue or something specific to MuJoCo-Warp.


**Before** (feet not colliding with terrain):

https://github.com/user-attachments/assets/019409aa-65ff-424d-842c-3500ec267691

**After** (with `conaffinity=1` workaround):

https://github.com/user-attachments/assets/08c71a83-c25c-4694-a889-fac62e952526

