### PR TITLE
Fixes device key mismatch in noise tensor caching test

### DIFF
--- a/tests/test_observation_noise.py
+++ b/tests/test_observation_noise.py
@@ -213,7 +213,7 @@ def test_noise_tensor_caching(device):
   result1 = noise.apply(data)
 
   # Verify the cache was populated and get reference to cached tensor
-  device_key = str(device)
+  device_key = str(result1.device)
   assert device_key in noise._tensor_cache
   assert "bias" in noise._tensor_cache[device_key]
   cached_tensor = noise._tensor_cache[device_key]["bias"]


### PR DESCRIPTION
The test was checking for `'cuda'` in the cache, but PyTorch normalizes `device='cuda'` to `'cuda:0'`. Fixed by using `str(result1.device)` to get the actual device key instead of checking the input parameter directly.

```bash
=============================================================================== FAILURES ===============================================================================
______________________________________________________________________ test_noise_tensor_caching _______________________________________________________________________

device = 'cuda'

    def test_noise_tensor_caching(device):
      """Test that tensor conversion is cached across multiple calls."""
      noise = ConstantNoiseCfg(bias=0.5)
      data = torch.ones((4, 3), device=device)
    
      # First call should create the tensor
      result1 = noise.apply(data)
    
      # Verify the cache was populated and get reference to cached tensor
      device_key = str(device)
>     assert device_key in noise._tensor_cache
E     AssertionError: assert 'cuda' in {'cuda:0': {'bias': tensor(0.5000, device='cuda:0')}}
E      +  where {'cuda:0': {'bias': tensor(0.5000, device='cuda:0')}} = ConstantNoiseCfg(operation='add', bias=0.5)._tensor_cache

tests/test_observation_noise.py:217: AssertionError
======================================================================= short test summary info ========================================================================
FAILED tests/test_observation_noise.py::test_noise_tensor_caching - AssertionError: assert 'cuda' in {'cuda:0': {'bias': tensor(0.5000, device='cuda:0')}}
==================================================================== 1 failed, 387 passed in 12.07s ====================================================================
make: *** [Makefile:20: test] Error 1

```