### PR TITLE
Upgrade mujoco_warp to 7c20a44

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 Run the demo (no installation needed):
 
 ```bash
-uvx --from mjlab --with "mujoco-warp @ git+https://github.com/google-deepmind/mujoco_warp@4ce1c3e9fd635f6589f8b91b2cfba1739cba01a3" demo
+uvx --from mjlab --with "mujoco-warp @ git+https://github.com/google-deepmind/mujoco_warp@7c20a44bfed722e6415235792a1b247ea6b6a6d3" demo
 ```
 
 This launches an interactive viewer with a pre-trained Unitree G1 agent tracking a reference dance motion in MuJoCo Warp.
@@ -56,7 +56,7 @@ uv run demo
 **From PyPI:**
 
 ```bash
-uv add mjlab "mujoco-warp @ git+https://github.com/google-deepmind/mujoco_warp@4ce1c3e9fd635f6589f8b91b2cfba1739cba01a3"
+uv add mjlab "mujoco-warp @ git+https://github.com/google-deepmind/mujoco_warp@7c20a44bfed722e6415235792a1b247ea6b6a6d3"
 ```
 
 A Dockerfile is also provided.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,7 +23,7 @@ You can try mjlab *without installing anything* by using `uvx`:
 
    # Run the mjlab demo (no local installation needed)
    uvx --from mjlab \
-       --with "mujoco-warp @ git+https://github.com/google-deepmind/mujoco_warp@9491175b7cbea87e28d3e3e67733095317c33398" \
+       --with "mujoco-warp @ git+https://github.com/google-deepmind/mujoco_warp@7c20a44bfed722e6415235792a1b247ea6b6a6d3" \
        demo
 
 If this runs, your setup is compatible with mjlab *for evaluation*.

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -92,7 +92,7 @@ install. These options are interchangeable: you can switch at any time.
 
       .. code:: bash
 
-         uv add mjlab "mujoco-warp @ git+https://github.com/google-deepmind/mujoco_warp@9491175b7cbea87e28d3e3e67733095317c33398"
+         uv add mjlab "mujoco-warp @ git+https://github.com/google-deepmind/mujoco_warp@7c20a44bfed722e6415235792a1b247ea6b6a6d3"
 
       .. note::
 
@@ -104,7 +104,7 @@ install. These options are interchangeable: you can switch at any time.
 
       .. code:: bash
 
-         uv add "mjlab @ git+https://github.com/mujocolab/mjlab" "mujoco-warp @ git+https://github.com/google-deepmind/mujoco_warp@9491175b7cbea87e28d3e3e67733095317c33398"
+         uv add "mjlab @ git+https://github.com/mujocolab/mjlab" "mujoco-warp @ git+https://github.com/google-deepmind/mujoco_warp@7c20a44bfed722e6415235792a1b247ea6b6a6d3"
 
       .. note::
 
@@ -201,7 +201,7 @@ Install mjlab and dependencies via pip
 
       .. code:: bash
 
-         pip install git+https://github.com/google-deepmind/mujoco_warp@9491175b7cbea87e28d3e3e67733095317c33398
+         pip install git+https://github.com/google-deepmind/mujoco_warp@7c20a44bfed722e6415235792a1b247ea6b6a6d3
          pip install mjlab
 
    .. tab-item:: Source
@@ -210,7 +210,7 @@ Install mjlab and dependencies via pip
 
       .. code:: bash
 
-         pip install git+https://github.com/google-deepmind/mujoco_warp@9491175b7cbea87e28d3e3e67733095317c33398
+         pip install git+https://github.com/google-deepmind/mujoco_warp@7c20a44bfed722e6415235792a1b247ea6b6a6d3
          git clone https://github.com/mujocolab/mjlab.git
          cd mjlab
          pip install -e .

--- a/notebooks/demo.ipynb
+++ b/notebooks/demo.ipynb
@@ -50,36 +50,7 @@
     "outputId": "4c299831-6279-430e-ca8e-f2a58e8f4720"
    },
    "outputs": [],
-   "source": [
-    "import subprocess\n",
-    "import sys\n",
-    "\n",
-    "process = subprocess.Popen(\n",
-    "  [\n",
-    "    \"uvx\",\n",
-    "    \"--refresh\",\n",
-    "    \"--from\",\n",
-    "    \"mjlab==1.0.0\",\n",
-    "    \"--with\",\n",
-    "    \"mujoco-warp @ git+https://github.com/google-deepmind/mujoco_warp@4ce1c3e9fd635f6589f8b91b2cfba1739cba01a3\",\n",
-    "    \"demo\",\n",
-    "  ],\n",
-    "  stdout=subprocess.PIPE,\n",
-    "  stderr=subprocess.STDOUT,\n",
-    "  universal_newlines=True,\n",
-    "  bufsize=1,\n",
-    ")\n",
-    "\n",
-    "for line in process.stdout:\n",
-    "  print(line, end=\"\")\n",
-    "  sys.stdout.flush()\n",
-    "\n",
-    "  if \"serving\" in line.lower() or \"running on\" in line.lower() or \"8081\" in line:\n",
-    "    print(\"\\n\" + \"=\" * 50)\n",
-    "    print(\"✅ Server is running! Execute the next cell to view.\")\n",
-    "    print(\"=\" * 50)\n",
-    "    break"
-   ]
+   "source": "import subprocess\nimport sys\n\nprocess = subprocess.Popen(\n  [\n    \"uvx\",\n    \"--refresh\",\n    \"--from\",\n    \"mjlab==1.0.0\",\n    \"--with\",\n    \"mujoco-warp @ git+https://github.com/google-deepmind/mujoco_warp@7c20a44bfed722e6415235792a1b247ea6b6a6d3\",\n    \"demo\",\n  ],\n  stdout=subprocess.PIPE,\n  stderr=subprocess.STDOUT,\n  universal_newlines=True,\n  bufsize=1,\n)\n\nfor line in process.stdout:\n  print(line, end=\"\")\n  sys.stdout.flush()\n\n  if \"serving\" in line.lower() or \"running on\" in line.lower() or \"8081\" in line:\n    print(\"\\n\" + \"=\" * 50)\n    print(\"✅ Server is running! Execute the next cell to view.\")\n    print(\"=\" * 50)\n    break"
   },
   {
    "cell_type": "code",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,7 +120,7 @@ explicit = true
 warp-lang = { index = "nvidia", marker = "sys_platform != 'darwin'" }
 mujoco = { index = "mujoco" }
 torch = { index = "pytorch-cu128", extra = "cu128", marker = "sys_platform != 'darwin'" }
-mujoco-warp = { git = "https://github.com/google-deepmind/mujoco_warp", rev = "4ce1c3e9fd635f6589f8b91b2cfba1739cba01a3" }
+mujoco-warp = { git = "https://github.com/google-deepmind/mujoco_warp", rev = "7c20a44bfed722e6415235792a1b247ea6b6a6d3" }
 
 [tool.ruff]
 src = ["src"]  # Helpful for recognizing first-party imports.

--- a/src/mjlab/sensor/raycast_sensor.py
+++ b/src/mjlab/sensor/raycast_sensor.py
@@ -705,6 +705,7 @@ class RayCastSensor(Sensor[RayCastData]):
     # Transform ray directions (per-ray).
     world_rays = torch.einsum("bij,nj->bni", rot_mat, self._local_directions)
 
+    assert self._ray_pnt is not None and self._ray_vec is not None
     pnt_torch = wp.to_torch(self._ray_pnt).view(num_envs, self._num_rays, 3)
     vec_torch = wp.to_torch(self._ray_vec).view(num_envs, self._num_rays, 3)
     pnt_torch.copy_(world_origins)
@@ -716,6 +717,7 @@ class RayCastSensor(Sensor[RayCastData]):
     else:
       self._raycast_direct()
 
+    assert self._ray_dist is not None and self._ray_normal is not None
     self._distances = wp.to_torch(self._ray_dist)
     self._normals_w = wp.to_torch(self._ray_normal).view(num_envs, self._num_rays, 3)
     self._distances[self._distances > self.cfg.max_distance] = -1.0

--- a/src/mjlab/sim/randomization.py
+++ b/src/mjlab/sim/randomization.py
@@ -13,7 +13,7 @@ def repeat_array_kernel(
   dst: wp.array(dtype=Any),  # type: ignore
 ):
   tid = wp.tid()
-  src_idx = tid % nelems_per_world
+  src_idx = tid % nelems_per_world  # type: ignore[operator]
   dst[tid] = src[src_idx]
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1288,7 +1288,7 @@ requires-dist = [
     { name = "autodocsumm", marker = "extra == 'docs'" },
     { name = "moviepy" },
     { name = "mujoco", specifier = ">=3.4.0", index = "https://py.mujoco.org/" },
-    { name = "mujoco-warp", git = "https://github.com/google-deepmind/mujoco_warp?rev=4ce1c3e9fd635f6589f8b91b2cfba1739cba01a3" },
+    { name = "mujoco-warp", git = "https://github.com/google-deepmind/mujoco_warp?rev=7c20a44bfed722e6415235792a1b247ea6b6a6d3" },
     { name = "myst-parser", marker = "extra == 'docs'", specifier = ">=4.0.1" },
     { name = "onnxscript", specifier = ">=0.5.4" },
     { name = "prettytable" },
@@ -1461,7 +1461,7 @@ wheels = [
 [[package]]
 name = "mujoco-warp"
 version = "0.0.2"
-source = { git = "https://github.com/google-deepmind/mujoco_warp?rev=4ce1c3e9fd635f6589f8b91b2cfba1739cba01a3#4ce1c3e9fd635f6589f8b91b2cfba1739cba01a3" }
+source = { git = "https://github.com/google-deepmind/mujoco_warp?rev=7c20a44bfed722e6415235792a1b247ea6b6a6d3#7c20a44bfed722e6415235792a1b247ea6b6a6d3" }
 dependencies = [
     { name = "absl-py" },
     { name = "etils", extra = ["epath"] },
@@ -3832,17 +3832,17 @@ wheels = [
 
 [[package]]
 name = "warp-lang"
-version = "1.11.0.dev20251211"
+version = "1.12.0.dev20260115"
 source = { registry = "https://pypi.nvidia.com/" }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 wheels = [
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.11.0.dev20251211-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b5813eb82f32c94e625531ff752d627cdc5b64dc49aca832e4ef2eea3af0721e" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.11.0.dev20251211-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:15139f7311634f865146c0842ce62ab259e1132007376c70a3d9b4d04c5e0018" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.11.0.dev20251211-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:c52bb83550b663b3e0c8d067f70af9199cc35d5f62a06da2f748a5dc68e493d8" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.11.0.dev20251211-py3-none-win_amd64.whl", hash = "sha256:5a8c6203863a596ab730e1c57fefc36a00c6687647bcef29d11cb0c78f800930" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.12.0.dev20260115-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e4f0689ff8a30b78089faf0ca450c09ea9530024f74fa5eb72bd595649fd0ede" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.12.0.dev20260115-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:9b717609fba8cd55b1faccce16bf34680305497e85c496d4ca5ddf303d23bc31" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.12.0.dev20260115-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:09edc1e5aee55883c8a00dcb9e8da74cf793718a5410c619efbecca2b909f584" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.12.0.dev20260115-py3-none-win_amd64.whl", hash = "sha256:753e0667c7bc94e177c2fca562b889a047105c83dcaa554956c662ad9da1b06d" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Upgrade mujoco_warp dependency to commit `7c20a44bfed722e6415235792a1b247ea6b6a6d3`
- Update all documentation installation examples with the new hash
- Unify previously inconsistent hashes across config and docs

## Test plan
- [x] `uv sync` completes successfully
- [x] `make test-fast` passes (379 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)