### PR TITLE
Show target sphere for all envs in LiftingCommand

### DIFF
--- a/src/mjlab/tasks/manipulation/mdp/commands.py
+++ b/src/mjlab/tasks/manipulation/mdp/commands.py
@@ -101,17 +101,14 @@ class LiftingCommand(CommandTerm):
     pass
 
   def _debug_vis_impl(self, visualizer: DebugVisualizer) -> None:
-    batch = visualizer.env_idx
-    if batch >= self.num_envs:
-      return
-
-    target_pos = self.target_pos[batch].cpu().numpy()
-    visualizer.add_sphere(
-      center=target_pos,
-      radius=0.03,
-      color=self.cfg.viz.target_color,
-      label="target_position",
-    )
+    for batch in range(self.num_envs):
+      target_pos = self.target_pos[batch].cpu().numpy()
+      visualizer.add_sphere(
+        center=target_pos,
+        radius=0.03,
+        color=self.cfg.viz.target_color,
+        label=f"target_position_{batch}",
+      )
 
 
 @dataclass(kw_only=True)


### PR DESCRIPTION
## Summary
- [x] Modified `LiftingCommand._debug_vis_impl()` to render target position spheres for all environments instead of only the selected one
- [x] Each sphere now has a unique label (`target_position_{batch}`) to avoid collisions
- [x] Enables visibility of target locations when running multiple parallel environments in both viser and native viewers

### Before

<img width="871" height="480" alt="image" src="https://github.com/user-attachments/assets/2afad871-130e-400b-ade1-b08b7bf5c0d4" />

### After

<img width="871" height="480" alt="image" src="https://github.com/user-attachments/assets/2c195606-e554-4065-98f2-5c609e730e78" />

## Test
- Run `uv run play Mjlab-Lift-Cube-Yam --agent random --num-envs 4 --viewer viser`
- Verify semi-transparent target spheres appear for all 4 environments
- All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)