### PR TITLE
Add local motion file support and no-terminations flag

### DIFF
--- a/src/mjlab/scripts/play.py
+++ b/src/mjlab/scripts/play.py
@@ -73,7 +73,7 @@ def run_play(task_id: str, cfg: PlayConfig):
     motion_cmd = env_cfg.commands["motion"]
     assert isinstance(motion_cmd, MotionCommandCfg)
 
-    # Check for local motion file first (works for both dummy and trained modes)
+    # Check for local motion file first (works for both dummy and trained modes).
     if cfg.motion_file is not None and Path(cfg.motion_file).exists():
       print(f"[INFO]: Using local motion file: {cfg.motion_file}")
       motion_cmd.motion_file = cfg.motion_file

--- a/src/mjlab/scripts/train.py
+++ b/src/mjlab/scripts/train.py
@@ -75,7 +75,7 @@ def run_train(task_id: str, cfg: TrainConfig, log_dir: Path) -> None:
     motion_cmd = cfg.env.commands["motion"]
     assert isinstance(motion_cmd, MotionCommandCfg)
 
-    # Check if motion_file is already set (e.g., via CLI --env.commands.motion.motion-file)
+    # Check if motion_file is already set (e.g., via CLI --env.commands.motion.motion-file).
     if motion_cmd.motion_file and Path(motion_cmd.motion_file).exists():
       print(f"[INFO] Using local motion file: {motion_cmd.motion_file}")
     elif cfg.registry_name:


### PR DESCRIPTION
## Summary

- **train.py**: Allow local NPZ motion files via `--env.commands.motion.motion-file` as an alternative to WandB registry download
- **play.py**: Add `--no-terminations` flag to disable all termination conditions (useful for viewing full motions with dummy agents)
- **play.py**: Check for local `--motion-file` before requiring WandB registry in dummy mode (zero/random agents)

This enables offline training and playback without requiring a WandB account or internet access.

## Usage

### Training with local motion file
```bash
uv run train Mjlab-Tracking-Flat-Unitree-G1 \
  --env.commands.motion.motion-file ./mocap/motion.npz \
  --env.scene.num-envs 4096
```

### Playing with dummy agent and local motion file
```bash
uv run play Mjlab-Tracking-Flat-Unitree-G1 \
  --agent zero \
  --motion-file ./mocap/motion.npz \
  --no-terminations True
```

## Test plan

- [ ] Test training with local motion file
- [ ] Test training with WandB registry (existing behavior)
- [ ] Test play with zero agent + local motion file + no-terminations
- [ ] Test play with trained agent + checkpoint file + motion file