### PR TITLE
Fix viser plane rendering ignoring MuJoCo size parameter

### DIFF
--- a/src/mjlab/viewer/viser/conversions.py
+++ b/src/mjlab/viewer/viser/conversions.py
@@ -294,7 +294,10 @@ def create_primitive_mesh(mj_model: mujoco.MjModel, geom_id: int) -> trimesh.Tri
   elif geom_type == mjtGeom.mjGEOM_CYLINDER:
     mesh = trimesh.creation.cylinder(radius=size[0], height=2.0 * size[1])
   elif geom_type == mjtGeom.mjGEOM_PLANE:
-    mesh = trimesh.creation.box((20, 20, 0.01))
+    # size[0], size[1] are half-lengths in x, y (0 means infinite).
+    plane_x = 2.0 * size[0] if size[0] > 0 else 20.0
+    plane_y = 2.0 * size[1] if size[1] > 0 else 20.0
+    mesh = trimesh.creation.box((plane_x, plane_y, 0.001))
   elif geom_type == mjtGeom.mjGEOM_ELLIPSOID:
     mesh = trimesh.creation.icosphere(subdivisions=3, radius=1.0)
     mesh.apply_scale(size)


### PR DESCRIPTION
## Summary
- Fixes #535: Viser viewer now respects the MuJoCo `size` parameter for plane geoms instead of rendering a hardcoded 20×20 box
- Finite planes use `2 * size[0]` and `2 * size[1]` as full extents; infinite dimensions (size=0) fall back to 20.0
- Plane thickness reduced from 0.01 to 0.001 for a flatter visual representation

## Test plan
- [x] Type check passes (`uv run pyright src/mjlab/viewer/viser/conversions.py` — 0 errors)
- [x] Existing conversion tests pass (`uv run pytest tests/test_viser_conversions.py` — 7/7 passed)
- [ ] Manual verification with a small finite-size plane geom renders at the correct dimensions

🤖 Generated with [Claude Code](https://claude.com/claude-code)