### PR TITLE
Add flat patch sampling for heightfield terrains

### DIFF
--- a/scripts/demos/flat_patch_terrain.py
+++ b/scripts/demos/flat_patch_terrain.py
@@ -1,0 +1,125 @@
+"""Flat patch terrain demo.
+
+Spawns a Go1 on rough terrain with flat-patch sampling.
+On each reset, the robot lands on a flat patch.
+
+Run with:
+  uv run python scripts/demos/flat_patch_terrain.py [--viewer native|viser]
+
+Toggle visualization group 3 to see flat patch locations visualized as box sites.
+"""
+
+from __future__ import annotations
+
+import os
+
+import torch
+import tyro
+
+import mjlab
+import mjlab.terrains as terrain_gen
+from mjlab.envs import ManagerBasedRlEnv
+from mjlab.envs.mdp import events as mdp
+from mjlab.managers.event_manager import EventTermCfg
+from mjlab.rl import RslRlVecEnvWrapper
+from mjlab.tasks.velocity.config.go1.env_cfgs import unitree_go1_rough_env_cfg
+from mjlab.terrains import FlatPatchSamplingCfg
+from mjlab.terrains.terrain_generator import TerrainGeneratorCfg
+from mjlab.utils.torch import configure_torch_backends
+from mjlab.viewer import NativeMujocoViewer, ViserPlayViewer
+
+
+def main(viewer: str = "auto") -> None:
+  configure_torch_backends()
+  device = "cuda:0" if torch.cuda.is_available() else "cpu"
+
+  cfg = unitree_go1_rough_env_cfg(play=True)
+
+  spawn_patch_cfg = FlatPatchSamplingCfg(
+    num_patches=100,
+    patch_radius=0.3,
+    max_height_diff=0.05,
+  )
+
+  # Override terrain: 1 row x 2 cols, curriculum mode so each column is deterministic.
+  # Column 0 = discrete obstacles, Column 1 = pyramid slope.
+  assert cfg.scene.terrain is not None
+  cfg.scene.terrain.terrain_generator = TerrainGeneratorCfg(
+    size=(4.0, 4.0),
+    num_rows=1,
+    num_cols=2,
+    border_width=1.0,
+    curriculum=True,
+    add_lights=True,
+    sub_terrains={
+      "discrete_obstacles": terrain_gen.HfDiscreteObstaclesTerrainCfg(
+        proportion=0.5,
+        obstacle_height_range=(0.05, 0.5),
+        obstacle_width_range=(0.4, 1.2),
+        num_obstacles=30,
+        platform_width=1.5,
+        border_width=0.25,
+        flat_patch_sampling={"spawn": spawn_patch_cfg},
+      ),
+      "pyramid_slope": terrain_gen.HfPyramidSlopedTerrainCfg(
+        proportion=0.5,
+        slope_range=(0.3, 0.8),
+        platform_width=1.5,
+        border_width=0.25,
+        flat_patch_sampling={"spawn": spawn_patch_cfg},
+      ),
+    },
+  )
+
+  # Remove all termination conditions except time limit.
+  for key in list(cfg.terminations):
+    if key != "time_out":
+      del cfg.terminations[key]
+
+  # Reset every 2 seconds to better showcase flat patch spawning.
+  cfg.episode_length_s = 2.0
+
+  # Replace reset_base event with flat-patch spawning.
+  cfg.events["reset_base"] = EventTermCfg(
+    func=mdp.reset_root_state_from_flat_patches,
+    mode="reset",
+    params={
+      "patch_name": "spawn",
+      "pose_range": {"z": (0.01, 0.05), "yaw": (-3.14, 3.14)},
+    },
+  )
+
+  print("=" * 60)
+  print("Flat Patch Terrain Demo")
+  print("  Toggle group 3 to see flat patch markers (orange spheres)")
+  print("  Press Enter in terminal to reset robot onto a flat patch")
+  print("=" * 60)
+
+  env = ManagerBasedRlEnv(cfg=cfg, device=device)
+  env = RslRlVecEnvWrapper(env)
+
+  class ZeroPolicy:
+    def __call__(self, obs) -> torch.Tensor:
+      del obs
+      return torch.zeros(env.unwrapped.action_space.shape, device=device)
+
+  policy = ZeroPolicy()
+
+  if viewer == "auto":
+    has_display = bool(os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"))
+    resolved_viewer = "native" if has_display else "viser"
+  else:
+    resolved_viewer = viewer
+
+  if resolved_viewer == "native":
+    NativeMujocoViewer(env, policy).run()
+  elif resolved_viewer == "viser":
+    ViserPlayViewer(env, policy).run()
+  else:
+    raise ValueError(f"Unknown viewer: {viewer}")
+
+  env.close()
+
+
+if __name__ == "__main__":
+  tyro.cli(main, config=mjlab.TYRO_FLAGS)

--- a/src/mjlab/terrains/__init__.py
+++ b/src/mjlab/terrains/__init__.py
@@ -18,6 +18,9 @@ from mjlab.terrains.primitive_terrains import (
 from mjlab.terrains.primitive_terrains import (
   BoxRandomGridTerrainCfg as BoxRandomGridTerrainCfg,
 )
+from mjlab.terrains.terrain_generator import (
+  FlatPatchSamplingCfg as FlatPatchSamplingCfg,
+)
 from mjlab.terrains.terrain_generator import SubTerrainCfg as SubTerrainCfg
 from mjlab.terrains.terrain_generator import TerrainGenerator as TerrainGenerator
 from mjlab.terrains.terrain_generator import TerrainGeneratorCfg as TerrainGeneratorCfg

--- a/src/mjlab/terrains/utils.py
+++ b/src/mjlab/terrains/utils.py
@@ -5,7 +5,109 @@ References:
   https://github.com/isaac-sim/IsaacLab/blob/main/source/isaaclab/isaaclab/terrains/trimesh/utils.py
 """
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import mujoco
+import numpy as np
+from scipy import ndimage
+
+if TYPE_CHECKING:
+  from mjlab.terrains.terrain_generator import FlatPatchSamplingCfg
+
+
+def find_flat_patches_from_heightfield(
+  heights: np.ndarray,
+  horizontal_scale: float,
+  z_offset: float,
+  cfg: FlatPatchSamplingCfg,
+  rng: np.random.Generator,
+) -> np.ndarray:
+  """Find flat patches on a heightfield surface using morphological filtering.
+
+  Slides a circular footprint over every pixel and keeps those where the
+  height variation is within tolerance. Randomly samples from the valid set.
+
+  Args:
+    heights: 2D array of physical heights (meters), shape (num_rows, num_cols).
+    horizontal_scale: Physical size of each pixel in meters.
+    z_offset: Vertical offset of the heightfield origin.
+    cfg: Flat patch sampling configuration.
+    rng: Random number generator.
+
+  Returns:
+    Array of shape (num_patches, 3) with (x, y, z) positions in sub-terrain
+    local frame.
+  """
+  # Optionally upsample to a finer grid for higher-precision boundary detection.
+  if cfg.grid_resolution is not None and cfg.grid_resolution < horizontal_scale:
+    zoom_factor = horizontal_scale / cfg.grid_resolution
+    heights = np.asarray(ndimage.zoom(heights, zoom_factor, order=1))
+    horizontal_scale = cfg.grid_resolution
+
+  num_rows, num_cols = heights.shape
+
+  # Build circular footprint.
+  radius_pixels = int(np.ceil(cfg.patch_radius / horizontal_scale))
+  y_grid, x_grid = np.ogrid[
+    -radius_pixels : radius_pixels + 1, -radius_pixels : radius_pixels + 1
+  ]
+  footprint = (x_grid**2 + y_grid**2) <= radius_pixels**2
+
+  # Morphological max/min filter to find height variation within footprint.
+  # Use constant padding so edge pixels where the footprint extends outside
+  # the data are not incorrectly marked flat (default 'reflect' hides edges).
+  max_h = ndimage.maximum_filter(
+    heights, footprint=footprint, mode="constant", cval=-np.inf
+  )
+  min_h = ndimage.minimum_filter(
+    heights, footprint=footprint, mode="constant", cval=np.inf
+  )
+  valid_mask = (max_h - min_h) <= cfg.max_height_diff
+
+  # Exclude pixels whose footprint would extend outside the array. This
+  # ensures the full patch circle lies within the heightfield bounds.
+  valid_mask[:radius_pixels, :] = False
+  valid_mask[-radius_pixels:, :] = False
+  valid_mask[:, :radius_pixels] = False
+  valid_mask[:, -radius_pixels:] = False
+
+  # Apply spatial range constraints.
+  # MuJoCo hfield convention: columns map to the x-axis, rows map to the
+  # y-axis (see engine_ray.c vertex: {dx*c - size[0], dy*r - size[1], ...}).
+  x_coords = np.arange(num_cols) * horizontal_scale
+  y_coords = np.arange(num_rows) * horizontal_scale
+
+  x_valid = (x_coords >= cfg.x_range[0]) & (x_coords <= cfg.x_range[1])
+  y_valid = (y_coords >= cfg.y_range[0]) & (y_coords <= cfg.y_range[1])
+  valid_mask &= y_valid[:, None] & x_valid[None, :]
+
+  # Apply z range constraint.
+  z_values = heights + z_offset
+  z_valid = (z_values >= cfg.z_range[0]) & (z_values <= cfg.z_range[1])
+  valid_mask &= z_valid
+
+  valid_indices = np.argwhere(valid_mask)
+
+  if len(valid_indices) == 0:
+    # Fallback: return sub-terrain center repeated.
+    center_x = num_cols * horizontal_scale / 2.0
+    center_y = num_rows * horizontal_scale / 2.0
+    center_row = min(num_rows // 2, num_rows - 1)
+    center_col = min(num_cols // 2, num_cols - 1)
+    center_z = heights[center_row, center_col] + z_offset
+    return np.tile([center_x, center_y, center_z], (cfg.num_patches, 1))
+
+  replace = len(valid_indices) < cfg.num_patches
+  chosen = rng.choice(len(valid_indices), size=cfg.num_patches, replace=replace)
+  selected = valid_indices[chosen]
+
+  x = selected[:, 1] * horizontal_scale
+  y = selected[:, 0] * horizontal_scale
+  z = heights[selected[:, 0], selected[:, 1]] + z_offset
+
+  return np.stack([x, y, z], axis=-1)
 
 
 def make_plane(

--- a/tests/test_flat_patch_sampling.py
+++ b/tests/test_flat_patch_sampling.py
@@ -1,0 +1,159 @@
+"""Tests for flat patch sampling on heightfield terrains."""
+
+import numpy as np
+import pytest
+import torch
+from conftest import get_test_device
+
+from mjlab.terrains.heightfield_terrains import HfRandomUniformTerrainCfg
+from mjlab.terrains.terrain_generator import (
+  FlatPatchSamplingCfg,
+  TerrainGeneratorCfg,
+)
+from mjlab.terrains.terrain_importer import TerrainImporter, TerrainImporterCfg
+from mjlab.terrains.utils import find_flat_patches_from_heightfield
+
+
+@pytest.fixture
+def rng() -> np.random.Generator:
+  return np.random.default_rng(42)
+
+
+def test_patches_avoid_step_boundary(rng: np.random.Generator):
+  """Patches must not land near a sharp height discontinuity."""
+  heights = np.zeros((80, 80), dtype=np.float64)
+  # Step along column axis → appears on MuJoCo x-axis.
+  heights[:, 40:] = 1.0
+  patch_radius = 0.3
+  cfg = FlatPatchSamplingCfg(
+    num_patches=50, patch_radius=patch_radius, max_height_diff=0.05
+  )
+  patches = find_flat_patches_from_heightfield(
+    heights=heights, horizontal_scale=0.1, z_offset=0.0, cfg=cfg, rng=rng
+  )
+  assert patches.shape == (50, 3)
+  for i in range(len(patches)):
+    x, z = patches[i, 0], patches[i, 2]
+    # Step is at x=4.0; no patch center should be within patch_radius of it.
+    assert x < 3.7 or x >= 4.3, f"Patch {i} at x={x:.2f} too close to step"
+    # z must be consistent with the side the patch landed on.
+    if x < 3.7:
+      assert abs(z) < 0.1, f"Low-x patch should have z~0, got {z}"
+    else:
+      assert abs(z - 1.0) < 0.1, f"High-x patch should have z~1, got {z}"
+
+
+def test_range_constraints(rng: np.random.Generator):
+  """x/y range filters restrict where patches can land."""
+  heights = np.zeros((80, 80), dtype=np.float64)
+  cfg = FlatPatchSamplingCfg(
+    num_patches=10,
+    patch_radius=0.3,
+    max_height_diff=0.1,
+    x_range=(2.0, 6.0),
+    y_range=(2.0, 6.0),
+  )
+  patches = find_flat_patches_from_heightfield(
+    heights=heights, horizontal_scale=0.1, z_offset=0.0, cfg=cfg, rng=rng
+  )
+  assert np.all(patches[:, 0] >= 2.0) and np.all(patches[:, 0] <= 6.0)
+  assert np.all(patches[:, 1] >= 2.0) and np.all(patches[:, 1] <= 6.0)
+
+
+def test_fallback_when_no_valid_patches(rng: np.random.Generator):
+  """When nothing is flat, all patches fall back to the terrain center."""
+  # Linear ramp along rows — every footprint spans a large height range.
+  heights = np.arange(80).reshape(80, 1).repeat(80, axis=1).astype(np.float64)
+  cfg = FlatPatchSamplingCfg(num_patches=5, patch_radius=0.3, max_height_diff=0.001)
+  patches = find_flat_patches_from_heightfield(
+    heights=heights, horizontal_scale=0.1, z_offset=0.0, cfg=cfg, rng=rng
+  )
+  center_x = 80 * 0.1 / 2.0
+  center_y = 80 * 0.1 / 2.0
+  np.testing.assert_allclose(patches[:, 0], center_x)
+  np.testing.assert_allclose(patches[:, 1], center_y)
+
+
+def test_patches_respect_edge_margin(rng: np.random.Generator):
+  """No patch center should be within patch_radius of the heightfield edge."""
+  heights = np.zeros((80, 80), dtype=np.float64)
+  patch_radius = 0.5
+  h_scale = 0.1
+  cfg = FlatPatchSamplingCfg(
+    num_patches=200, patch_radius=patch_radius, max_height_diff=0.1
+  )
+  patches = find_flat_patches_from_heightfield(
+    heights=heights, horizontal_scale=h_scale, z_offset=0.0, cfg=cfg, rng=rng
+  )
+  terrain_x = 80 * h_scale
+  terrain_y = 80 * h_scale
+  margin = patch_radius
+  # Every patch center must be at least patch_radius from each edge.
+  assert np.all(patches[:, 0] >= margin - h_scale)
+  assert np.all(patches[:, 0] <= terrain_x - margin + h_scale)
+  assert np.all(patches[:, 1] >= margin - h_scale)
+  assert np.all(patches[:, 1] <= terrain_y - margin + h_scale)
+
+
+def test_grid_resolution(rng: np.random.Generator):
+  """Finer grid_resolution still produces correct flat patches on a step."""
+  heights = np.zeros((80, 80), dtype=np.float64)
+  heights[:, 40:] = 1.0
+  cfg = FlatPatchSamplingCfg(
+    num_patches=30,
+    patch_radius=0.3,
+    max_height_diff=0.05,
+    grid_resolution=0.025,
+  )
+  patches = find_flat_patches_from_heightfield(
+    heights=heights, horizontal_scale=0.1, z_offset=0.0, cfg=cfg, rng=rng
+  )
+  assert patches.shape == (30, 3)
+  for i in range(len(patches)):
+    x, z = patches[i, 0], patches[i, 2]
+    assert x < 3.7 or x >= 4.3, f"Patch {i} at x={x:.2f} too close to step"
+    if x < 3.7:
+      assert abs(z) < 0.1
+    else:
+      assert abs(z - 1.0) < 0.1
+
+
+def test_terrain_importer_end_to_end():
+  """Flat patches flow through generator → importer with correct shape and bounds."""
+  device = get_test_device()
+  terrain_size = (4.0, 4.0)
+  num_patches = 5
+  patch_cfg = FlatPatchSamplingCfg(
+    num_patches=num_patches, patch_radius=0.3, max_height_diff=0.1
+  )
+  gen_cfg = TerrainGeneratorCfg(
+    seed=123,
+    size=terrain_size,
+    num_rows=2,
+    num_cols=2,
+    sub_terrains={
+      "rough": HfRandomUniformTerrainCfg(
+        proportion=1.0,
+        noise_range=(0.02, 0.08),
+        noise_step=0.01,
+        flat_patch_sampling={"spawn": patch_cfg},
+      ),
+    },
+  )
+  importer_cfg = TerrainImporterCfg(
+    terrain_type="generator", terrain_generator=gen_cfg, num_envs=4
+  )
+  importer = TerrainImporter(importer_cfg, device=device)
+
+  assert "spawn" in importer.flat_patches
+  patches = importer.flat_patches["spawn"]
+  assert patches.shape == (2, 2, num_patches, 3)
+  assert patches.dtype == torch.float
+
+  # Every patch should be within the world-space extent of the full terrain grid.
+  # Grid is centered at origin → spans [-total/2, +total/2].
+  half_x = gen_cfg.num_rows * terrain_size[0] / 2
+  half_y = gen_cfg.num_cols * terrain_size[1] / 2
+  pts = patches.cpu().numpy().reshape(-1, 3)
+  assert np.all(pts[:, 0] >= -half_x) and np.all(pts[:, 0] <= half_x)
+  assert np.all(pts[:, 1] >= -half_y) and np.all(pts[:, 1] <= half_y)


### PR DESCRIPTION
- Adds morphological-filter-based flat patch sampling for heightfield terrains, enabling robots to spawn on verified-flat regions of rough terrain
- Wires flat patch computation through all four heightfield terrain types, the terrain generator, and the terrain importer with box site visualization (group 3)
- Adds `reset_root_state_from_flat_patches` event function for spawning assets on sampled flat patches
- Includes demo script (`scripts/demos/flat_patch_terrain.py`) and tests

<figure>
  <img width="1264" alt="Flat patch terrain demo" src="https://github.com/user-attachments/assets/d3a0ca35-87d6-4518-be5d-185aca80a24f" />
  <figcaption>Yellow boxes show sampled flat patches on discrete obstacle and pyramid slope terrains.</figcaption>
</figure>

## Test plan

- [x] `uv run pytest tests/test_flat_patch_sampling.py` — 6 tests covering step avoidance, range constraints, fallback, edge margin, grid resolution, and end-to-end importer pipeline
- [x] Visual verification with `uv run python scripts/demos/flat_patch_terrain.py` — toggle group 3 to see orange box sites on flat patches
- [x] `make check` passes (format + type check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)