### PR TITLE
Fix viser viewer rendering textured robots as gray

### DIFF
--- a/src/mjlab/viewer/viser/__init__.py
+++ b/src/mjlab/viewer/viser/__init__.py
@@ -4,6 +4,12 @@ from mjlab.viewer.viser.conversions import (
   create_primitive_mesh as create_primitive_mesh,
 )
 from mjlab.viewer.viser.conversions import get_body_name as get_body_name
+from mjlab.viewer.viser.conversions import (
+  get_geom_texture_id as get_geom_texture_id,
+)
+from mjlab.viewer.viser.conversions import (
+  group_geoms_by_visual_compat as group_geoms_by_visual_compat,
+)
 from mjlab.viewer.viser.conversions import is_fixed_body as is_fixed_body
 from mjlab.viewer.viser.conversions import merge_geoms as merge_geoms
 from mjlab.viewer.viser.conversions import (

--- a/src/mjlab/viewer/viser/conversions.py
+++ b/src/mjlab/viewer/viser/conversions.py
@@ -401,6 +401,67 @@ def create_primitive_mesh(mj_model: mujoco.MjModel, geom_id: int) -> trimesh.Tri
   return mesh
 
 
+def get_geom_texture_id(mj_model: mujoco.MjModel, geom_idx: int) -> int:
+  """Return the texture ID that the trimesh conversion will use, or -1.
+
+  Returns -1 (untextured) when any of these hold:
+    - The geom is a primitive (``create_primitive_mesh`` always emits
+      ``ColorVisuals``, even if the material references a texture).
+    - The material has no texture (neither mjTEXROLE_RGB nor mjTEXROLE_RGBA).
+    - The mesh has no UV coordinates (mesh_texcoordnum == 0).
+
+  Args:
+    mj_model: MuJoCo model containing geom definitions.
+    geom_idx: Index of the geometry in the model.
+
+  Returns:
+    Texture ID (>= 0) if conversion will produce TextureVisuals, -1 otherwise.
+  """
+  if mj_model.geom_type[geom_idx] != mjtGeom.mjGEOM_MESH:
+    return -1
+
+  matid = mj_model.geom_matid[geom_idx]
+  if matid < 0 or matid >= mj_model.nmat:
+    return -1
+
+  texid = int(mj_model.mat_texid[matid, int(mujoco.mjtTextureRole.mjTEXROLE_RGB)])
+  if texid < 0:
+    texid = int(mj_model.mat_texid[matid, int(mujoco.mjtTextureRole.mjTEXROLE_RGBA)])
+
+  if texid < 0:
+    return -1
+
+  mesh_id = mj_model.geom_dataid[geom_idx]
+  if mj_model.mesh_texcoordnum[mesh_id] <= 0:
+    return -1
+
+  return texid
+
+
+def group_geoms_by_visual_compat(
+  mj_model: mujoco.MjModel, geom_ids: list[int]
+) -> list[list[int]]:
+  """Partition geom IDs into groups that can be safely merged.
+
+  Geoms sharing the same texture ID are grouped together. All untextured
+  geoms (texture ID = -1) form a single group. This prevents trimesh
+  concatenation from producing gray meshes when mixing TextureVisuals
+  and ColorVisuals, or when combining different texture images.
+
+  Args:
+    mj_model: MuJoCo model containing geom definitions.
+    geom_ids: List of geom indices to partition.
+
+  Returns:
+    List of geom ID lists, each safe to pass to ``merge_geoms``.
+  """
+  groups: dict[int, list[int]] = {}
+  for gid in geom_ids:
+    tex_id = get_geom_texture_id(mj_model, gid)
+    groups.setdefault(tex_id, []).append(gid)
+  return list(groups.values())
+
+
 def merge_geoms(mj_model: mujoco.MjModel, geom_ids: list[int]) -> trimesh.Trimesh:
   """Merge multiple geoms into a single trimesh.
 


### PR DESCRIPTION
## Summary
- Added `get_geom_texture_id()` and `group_geoms_by_visual_compat()` helpers to partition geoms by texture compatibility before merging
- Updated `ViserMujocoScene` to create separate mesh handles per visual-compat subgroup, preventing trimesh from mixing `TextureVisuals` and `ColorVisuals` (which causes gray fallback)
- Split both fixed geometry and per-body batched geometry by visual compatibility

**Before**

<img width="1840" height="1191" alt="Screenshot 2026-01-30 at 7 47 25 PM" src="https://github.com/user-attachments/assets/343f0e68-0131-405d-95f0-03783b411701" />


**After**

<img width="1840" height="1191" alt="Screenshot 2026-01-30 at 7 46 00 PM" src="https://github.com/user-attachments/assets/1268ac34-6d0a-43ea-9c72-43ee059bbd09" />


## Test plan
- [x] New unit tests for `get_geom_texture_id`, `group_geoms_by_visual_compat`, and mixed-visual merge regression
- [x] All existing `test_viser_conversions.py` tests pass
- [x] `ty check` and `pyright` pass with 0 errors
- [x] Manual: verify ANYmal C (or other textured+colored robot) renders with correct textures and colors in viser viewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)