### PR TITLE
Add site group visualization to the Viser viewer

### DIFF
--- a/src/mjlab/viewer/viser/__init__.py
+++ b/src/mjlab/viewer/viser/__init__.py
@@ -3,15 +3,20 @@
 from mjlab.viewer.viser.conversions import (
   create_primitive_mesh as create_primitive_mesh,
 )
+from mjlab.viewer.viser.conversions import (
+  create_site_mesh as create_site_mesh,
+)
 from mjlab.viewer.viser.conversions import get_body_name as get_body_name
 from mjlab.viewer.viser.conversions import (
   get_geom_texture_id as get_geom_texture_id,
 )
+from mjlab.viewer.viser.conversions import get_site_name as get_site_name
 from mjlab.viewer.viser.conversions import (
   group_geoms_by_visual_compat as group_geoms_by_visual_compat,
 )
 from mjlab.viewer.viser.conversions import is_fixed_body as is_fixed_body
 from mjlab.viewer.viser.conversions import merge_geoms as merge_geoms
+from mjlab.viewer.viser.conversions import merge_sites as merge_sites
 from mjlab.viewer.viser.conversions import (
   mujoco_mesh_to_trimesh as mujoco_mesh_to_trimesh,
 )

--- a/src/mjlab/viewer/viser/viewer.py
+++ b/src/mjlab/viewer/viser/viewer.py
@@ -121,6 +121,9 @@ class ViserPlayViewer(BaseViewer):
     # Geom groups tab.
     self._scene.create_geom_groups_gui(tabs)
 
+    # Site groups tab.
+    self._scene.create_site_groups_gui(tabs)
+
   @override
   def _process_actions(self) -> None:
     """Process queued actions and sync UI state."""


### PR DESCRIPTION
## Summary

- Adds support for toggling MuJoCo site groups (S0-S5) in the Viser viewer, matching the native MuJoCo viewer's Shift+1-5 functionality
- Sites default to hidden and can be toggled via a new "Sites" tab in the GUI
- Supports all 5 site types: sphere, capsule, ellipsoid, cylinder, box
- Fixed body sites are rendered as static scene nodes; non-fixed body sites use batched handles updated per-frame from body transforms

## Test plan

- [x] `uv run pytest tests/test_viser_conversions.py` — all 20 tests pass (8 new site tests)
- [x] `uv run pyright` — 0 errors on modified files
- [x] `uv run ruff check` — lint clean
- [x] Manual: Launch a viewer with a model containing sites, toggle S0-S5 checkboxes, verify sites appear/disappear at correct positions

🤖 Generated with [Claude Code](https://claude.com/claude-code)