### PR TITLE
Add docstrings to terrain config fields

### DIFF
--- a/src/mjlab/terrains/heightfield_terrains.py
+++ b/src/mjlab/terrains/heightfield_terrains.py
@@ -129,12 +129,20 @@ def _compute_flat_patches(
 @dataclass(kw_only=True)
 class HfPyramidSlopedTerrainCfg(SubTerrainCfg):
   slope_range: tuple[float, float]
+  """Range of slope gradients (rise / run), interpolated by difficulty."""
   platform_width: float = 1.0
+  """Side length of the flat square platform at the terrain center, in meters."""
   inverted: bool = False
+  """If True, the pyramid is inverted so the platform is at the bottom."""
   border_width: float = 0.0
+  """Width of the flat border around the terrain edges, in meters. Must be >=
+  horizontal_scale if non-zero."""
   horizontal_scale: float = 0.1
+  """Heightfield grid resolution along x and y, in meters per cell."""
   vertical_scale: float = 0.005
+  """Heightfield height resolution, in meters per integer unit of the noise array."""
   base_thickness_ratio: float = 1.0
+  """Ratio of the heightfield base thickness to its maximum surface height."""
 
   def function(
     self, difficulty: float, spec: mujoco.MjSpec, rng: np.random.Generator
@@ -290,12 +298,22 @@ class HfPyramidSlopedTerrainCfg(SubTerrainCfg):
 @dataclass(kw_only=True)
 class HfRandomUniformTerrainCfg(SubTerrainCfg):
   noise_range: tuple[float, float]
+  """Min and max height noise, in meters."""
   noise_step: float = 0.005
+  """Height quantization step, in meters. Sampled heights are multiples of this
+  value within noise_range."""
   downsampled_scale: float | None = None
+  """Spacing between randomly sampled height points before interpolation, in
+  meters. If None, uses horizontal_scale. Must be >= horizontal_scale."""
   horizontal_scale: float = 0.1
+  """Heightfield grid resolution along x and y, in meters per cell."""
   vertical_scale: float = 0.005
+  """Heightfield height resolution, in meters per integer unit of the noise array."""
   base_thickness_ratio: float = 1.0
+  """Ratio of the heightfield base thickness to its maximum surface height."""
   border_width: float = 0.0
+  """Width of the flat border around the terrain edges, in meters. Must be >=
+  horizontal_scale if non-zero."""
 
   def function(
     self, difficulty: float, spec: mujoco.MjSpec, rng: np.random.Generator
@@ -435,11 +453,18 @@ class HfRandomUniformTerrainCfg(SubTerrainCfg):
 @dataclass(kw_only=True)
 class HfWaveTerrainCfg(SubTerrainCfg):
   amplitude_range: tuple[float, float]
+  """Min and max wave amplitude, in meters. Interpolated by difficulty."""
   num_waves: int = 1
+  """Number of complete wave cycles along the terrain length."""
   horizontal_scale: float = 0.1
+  """Heightfield grid resolution along x and y, in meters per cell."""
   vertical_scale: float = 0.005
+  """Heightfield height resolution, in meters per integer unit of the noise array."""
   base_thickness_ratio: float = 0.25
+  """Ratio of the heightfield base thickness to its maximum surface height."""
   border_width: float = 0.0
+  """Width of the flat border around the terrain edges, in meters. Must be >=
+  horizontal_scale if non-zero."""
 
   def function(
     self, difficulty: float, spec: mujoco.MjSpec, rng: np.random.Generator
@@ -555,15 +580,28 @@ class HfWaveTerrainCfg(SubTerrainCfg):
 @dataclass(kw_only=True)
 class HfDiscreteObstaclesTerrainCfg(SubTerrainCfg):
   obstacle_height_mode: Literal["choice", "fixed"] = "choice"
+  """How obstacle heights are chosen. "choice" randomly picks from [-h, -h/2,
+  h/2, h] (mix of pits and bumps); "fixed" uses h for all obstacles."""
   obstacle_width_range: tuple[float, float]
+  """Min and max obstacle width, in meters."""
   obstacle_height_range: tuple[float, float]
+  """Min and max obstacle height, in meters. Interpolated by difficulty."""
   num_obstacles: int
+  """Number of obstacles to place on the terrain."""
   platform_width: float = 1.0
+  """Side length of the obstacle-free flat square at the terrain center, in meters."""
   horizontal_scale: float = 0.1
+  """Heightfield grid resolution along x and y, in meters per cell."""
   vertical_scale: float = 0.005
+  """Heightfield height resolution, in meters per integer unit of the noise array."""
   base_thickness_ratio: float = 1.0
+  """Ratio of the heightfield base thickness to its maximum surface height."""
   border_width: float = 0.0
+  """Width of the flat border around the terrain edges, in meters. Must be >=
+  horizontal_scale if non-zero."""
   square_obstacles: bool = False
+  """If True, obstacles have equal width and length. If False, each dimension
+  is sampled independently."""
   origin_z_offset: float = 0.0
   """Vertical offset added to spawn origin height (meters).
 

--- a/src/mjlab/terrains/primitive_terrains.py
+++ b/src/mjlab/terrains/primitive_terrains.py
@@ -68,10 +68,16 @@ class BoxPyramidStairsTerrainCfg(SubTerrainCfg):
   """Configuration for a pyramid stairs terrain."""
 
   border_width: float = 0.0
+  """Width of the flat border frame around the staircase, in meters. Ignored
+  when holes is True."""
   step_height_range: tuple[float, float]
+  """Min and max step height, in meters. Interpolated by difficulty."""
   step_width: float
+  """Depth (run) of each step, in meters."""
   platform_width: float = 1.0
+  """Side length of the flat square platform at the top of the staircase, in meters."""
   holes: bool = False
+  """If True, steps form a cross pattern with empty gaps in the corners."""
 
   def function(
     self, difficulty: float, spec: mujoco.MjSpec, rng: np.random.Generator
@@ -379,12 +385,22 @@ class BoxInvertedPyramidStairsTerrainCfg(BoxPyramidStairsTerrainCfg):
 @dataclass(kw_only=True)
 class BoxRandomGridTerrainCfg(SubTerrainCfg):
   grid_width: float
+  """Side length of each square grid cell, in meters."""
   grid_height_range: tuple[float, float]
+  """Min and max grid cell height bound, in meters. Interpolated by difficulty.
+  At a given difficulty, cell heights are sampled uniformly from
+  [-bound, +bound]."""
   platform_width: float = 1.0
+  """Side length of the flat square platform at the grid center, in meters."""
   holes: bool = False
+  """If True, only the cross-shaped region around the center platform has grid cells."""
   merge_similar_heights: bool = False
+  """If True, adjacent cells with similar heights are merged into larger boxes
+  to reduce geom count."""
   height_merge_threshold: float = 0.05
+  """Maximum height difference between cells that can be merged, in meters."""
   max_merge_distance: int = 3
+  """Maximum number of grid cells that can be merged in each direction."""
 
   def function(
     self, difficulty: float, spec: mujoco.MjSpec, rng: np.random.Generator

--- a/src/mjlab/terrains/terrain_generator.py
+++ b/src/mjlab/terrains/terrain_generator.py
@@ -40,22 +40,31 @@ class FlatPatchSamplingCfg:
 @dataclass
 class TerrainGeometry:
   geom: mujoco.MjsGeom | None = None
+  """MuJoCo geometry spec element, or None."""
   hfield: mujoco.MjsHField | None = None
+  """MuJoCo heightfield spec element, or None."""
   color: tuple[float, float, float, float] | None = None
+  """RGBA color override for this geometry, or None to use default."""
 
 
 @dataclass
 class TerrainOutput:
   origin: np.ndarray
+  """Spawn origin position (x, y, z) in the sub-terrain's local frame."""
   geometries: list[TerrainGeometry]
+  """List of geometry elements comprising this terrain."""
   flat_patches: dict[str, np.ndarray] | None = None
+  """Named sets of flat patch positions, each an (N, 3) array. None if not configured."""
 
 
 @dataclass
 class SubTerrainCfg(abc.ABC):
   proportion: float = 1.0
+  """Relative weight for randomly selecting this terrain type."""
   size: tuple[float, float] = (10.0, 10.0)
+  """Width and length of the terrain patch, in meters."""
   flat_patch_sampling: dict[str, FlatPatchSamplingCfg] | None = None
+  """Named flat-patch sampling configurations, or None to disable."""
 
   @abc.abstractmethod
   def function(
@@ -72,16 +81,28 @@ class SubTerrainCfg(abc.ABC):
 @dataclass(kw_only=True)
 class TerrainGeneratorCfg:
   seed: int | None = None
+  """Random seed for terrain generation. None uses a random seed."""
   curriculum: bool = False
+  """If True, difficulty increases along rows. If False, difficulty is random."""
   size: tuple[float, float]
+  """Width and length of each sub-terrain patch, in meters."""
   border_width: float = 0.0
+  """Width of the flat border around the entire terrain grid, in meters."""
   border_height: float = 1.0
+  """Height of the border wall around the terrain grid, in meters."""
   num_rows: int = 1
+  """Number of sub-terrain rows in the grid."""
   num_cols: int = 1
+  """Number of sub-terrain columns in the grid."""
   color_scheme: Literal["height", "random", "none"] = "height"
+  """Coloring strategy for terrain geometry. "height" colors by elevation,
+  "random" assigns random colors, "none" uses uniform gray."""
   sub_terrains: dict[str, SubTerrainCfg] = field(default_factory=dict)
+  """Named sub-terrain configurations to populate the grid."""
   difficulty_range: tuple[float, float] = (0.0, 1.0)
+  """Min and max difficulty values used when generating sub-terrains."""
   add_lights: bool = False
+  """If True, adds a directional light above the terrain grid."""
 
 
 class TerrainGenerator:

--- a/src/mjlab/terrains/terrain_importer.py
+++ b/src/mjlab/terrains/terrain_importer.py
@@ -48,21 +48,16 @@ class TerrainImporterCfg:
   """Maximum initial difficulty level (row index) for environment placement in
   curriculum mode. None uses all available rows."""
   num_envs: int = 1
-  """Number of parallel environments to create. This will get overriden by the
+  """Number of parallel environments to create. This will get overridden by the
   scene configuration if specified there."""
 
 
 class TerrainImporter:
-  """A class to handle terrain geometry and import it into the simulator.
+  """Builds a MuJoCo spec with terrain geometry and maps environments to spawn origins.
 
-  We assume that a terrain geometry comprises of sub-terrains that are arranged in a
-  grid with `num_rows` rows and `num_cols` columns. The terrain origins are the
-  positions of the sub-terrains where the robot should be spawned.
-
-  Based on the configuration, the terrain importer handles computing the environment
-  origins from the sub-terrain origins. In a typical setup, the number of sub-terrains
-  `num_rows x num_cols` is smaller than the number of environments `num_envs`. In this
-  case, the environment origins are computed by sampling the sub-terrain origins.
+  The terrain is a grid of sub-terrain patches (num_rows x num_cols), each with
+  a spawn origin. When num_envs exceeds the number of patches, environment
+  origins are sampled from the sub-terrain origins.
   """
 
   def __init__(self, cfg: TerrainImporterCfg, device: str) -> None:


### PR DESCRIPTION
Add attribute docstrings to all undocumented dataclass fields in the terrain modules. Fix typo "overriden" → "overridden" in TerrainImporterCfg.