### PR TITLE
Fix `randomize_pd_gains` crash with `num_envs > 1`

### DIFF
--- a/src/mjlab/envs/mdp/events.py
+++ b/src/mjlab/envs/mdp/events.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Dict, Literal, Tuple
 import torch
 
 from mjlab.entity import Entity, EntityIndexing
+from mjlab.managers.event_manager import requires_model_fields
 from mjlab.managers.scene_entity_config import SceneEntityCfg
 from mjlab.utils.lab_api.math import (
   quat_from_euler_xyz,
@@ -637,6 +638,7 @@ def _sample_distribution(
     raise ValueError(f"Unknown distribution: {distribution}")
 
 
+@requires_model_fields("actuator_gainprm", "actuator_biasprm")
 def randomize_pd_gains(
   env: ManagerBasedRlEnv,
   env_ids: torch.Tensor | None,
@@ -745,6 +747,7 @@ def randomize_pd_gains(
       )
 
 
+@requires_model_fields("actuator_forcerange")
 def randomize_effort_limits(
   env: ManagerBasedRlEnv,
   env_ids: torch.Tensor | None,


### PR DESCRIPTION
## Summary

- Add `@requires_model_fields` decorator so event functions can declare which model fields they write to and need expanded to per-world storage
- Apply decorator to `randomize_pd_gains` (`actuator_gainprm`, `actuator_biasprm`) and `randomize_effort_limits` (`actuator_forcerange`)
- `EventManager._prepare_terms()` discovers decorated fields and registers them in `domain_randomization_fields`, ensuring `sim.expand_model_fields()` allocates real per-world memory

Fixes #563

## Test plan

- [x] `uv run pytest tests/test_events.py -x` — new multi-env tests verify independent per-env writes; field registration test verifies decorator integration with `EventManager`
- [x] `uv run pytest tests/test_domain_randomization.py -x` — existing integration tests still pass
- [x] `uv run pyright` — no type errors
- [x] `uv run ruff check` — no lint issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)