### PR TITLE
Add `env_ids` parameter to `Entity.write_ctrl_to_sim`

### DIFF
--- a/src/mjlab/entity/entity.py
+++ b/src/mjlab/entity/entity.py
@@ -599,15 +599,20 @@ class Entity:
     self._data.clear_state(env_ids)
 
   def write_ctrl_to_sim(
-    self, ctrl: torch.Tensor, ctrl_ids: torch.Tensor | slice | None = None
+    self,
+    ctrl: torch.Tensor,
+    ctrl_ids: torch.Tensor | slice | None = None,
+    env_ids: torch.Tensor | slice | None = None,
   ) -> None:
     """Write control inputs to the simulation.
 
     Args:
       ctrl: A tensor of control inputs.
       ctrl_ids: A tensor of control indices.
+      env_ids: Optional tensor or slice specifying which environments to set.
+        If None, all environments are set.
     """
-    self._data.write_ctrl(ctrl, ctrl_ids)
+    self._data.write_ctrl(ctrl, ctrl_ids, env_ids)
 
   def write_root_state_to_sim(
     self, root_state: torch.Tensor, env_ids: torch.Tensor | slice | None = None


### PR DESCRIPTION
## Summary
- Add the missing `env_ids` parameter to `Entity.write_ctrl_to_sim`, bringing it in line with the other `write_*_to_sim` methods
- The underlying `EntityData.write_ctrl` already supports `env_ids` — this just passes it through
- Defaults to `None` (all envs), so existing callers are unaffected

Fixes #566

## Test plan
- [x] `uv run pyright src/mjlab/entity/entity.py` — 0 errors
- [x] `uv run pytest tests/test_entity.py tests/test_entity_data.py` — 47 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)