### PR TITLE
Fix ctrl_ids index error with multiple actuated entities

### DIFF
--- a/src/mjlab/actuator/delayed_actuator.py
+++ b/src/mjlab/actuator/delayed_actuator.py
@@ -104,6 +104,7 @@ class DelayedActuator(Actuator[DelayedActuatorCfg]):
 
     self._target_ids = self._base_actuator._target_ids
     self._ctrl_ids = self._base_actuator._ctrl_ids
+    self._global_ctrl_ids = self._base_actuator._global_ctrl_ids
 
     targets = (
       (self.cfg.delay_target,)

--- a/src/mjlab/envs/mdp/events.py
+++ b/src/mjlab/envs/mdp/events.py
@@ -688,7 +688,7 @@ def randomize_pd_gains(
   ]
 
   for actuator in actuators:
-    ctrl_ids = actuator.ctrl_ids
+    ctrl_ids = actuator.global_ctrl_ids
 
     kp_samples = _sample_distribution(
       distribution,
@@ -788,7 +788,7 @@ def randomize_effort_limits(
     actuators = [actuators]
 
   for actuator in actuators:
-    ctrl_ids = actuator.ctrl_ids
+    ctrl_ids = actuator.global_ctrl_ids
     num_actuators = len(ctrl_ids)
 
     effort_samples = _sample_distribution(

--- a/tests/test_delayed_actuator.py
+++ b/tests/test_delayed_actuator.py
@@ -220,7 +220,7 @@ def test_delayed_actuator_multi_target(device):
   # After 3 steps with lag=2, the delayed targets should be from step 0.
   # Position: [0.1, 0.2], Velocity: [0.01, 0.02]
   # Expected torque: Kp*(0.1 - 0) + Kd*(0.01 - 0) = 80*0.1 + 10*0.01 = 8.1.
-  ctrl_ids = actuator.ctrl_ids
+  ctrl_ids = actuator.global_ctrl_ids
   ctrl = sim.data.ctrl[0, ctrl_ids]
   # [80*0.1 + 10*0.01, 80*0.2 + 10*0.02]
   expected = torch.tensor([8.1, 16.2], device=device)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -129,12 +129,15 @@ def test_randomize_pd_gains(device):
 
   builtin_actuator = Mock(spec=actuator.BuiltinPositionActuator)
   builtin_actuator.ctrl_ids = torch.tensor([0, 1], device=device)
+  builtin_actuator.global_ctrl_ids = torch.tensor([0, 1], device=device)
 
   xml_actuator = Mock(spec=actuator.XmlPositionActuator)
   xml_actuator.ctrl_ids = torch.tensor([2, 3], device=device)
+  xml_actuator.global_ctrl_ids = torch.tensor([2, 3], device=device)
 
   ideal_actuator = Mock(spec=actuator.IdealPdActuator)
   ideal_actuator.ctrl_ids = torch.tensor([4, 5], device=device)
+  ideal_actuator.global_ctrl_ids = torch.tensor([4, 5], device=device)
   ideal_actuator.stiffness = torch.tensor(
     [[100.0, 100.0], [100.0, 100.0]], device=device
   )
@@ -272,12 +275,15 @@ def test_randomize_effort_limits(device):
 
   builtin_actuator = Mock(spec=actuator.BuiltinPositionActuator)
   builtin_actuator.ctrl_ids = torch.tensor([0, 1], device=device)
+  builtin_actuator.global_ctrl_ids = torch.tensor([0, 1], device=device)
 
   xml_actuator = Mock(spec=actuator.XmlPositionActuator)
   xml_actuator.ctrl_ids = torch.tensor([2, 3], device=device)
+  xml_actuator.global_ctrl_ids = torch.tensor([2, 3], device=device)
 
   ideal_actuator = Mock(spec=actuator.IdealPdActuator)
   ideal_actuator.ctrl_ids = torch.tensor([4, 5], device=device)
+  ideal_actuator.global_ctrl_ids = torch.tensor([4, 5], device=device)
   ideal_actuator.force_limit = torch.tensor([[50.0, 50.0], [50.0, 50.0]], device=device)
 
   ideal_actuator.set_effort_limit = actuator.IdealPdActuator.set_effort_limit.__get__(
@@ -368,6 +374,7 @@ def test_randomize_pd_gains_multi_env(device):
 
   mock_actuator = Mock(spec=actuator.BuiltinPositionActuator)
   mock_actuator.ctrl_ids = torch.tensor([0, 1], device=device)
+  mock_actuator.global_ctrl_ids = torch.tensor([0, 1], device=device)
 
   mock_entity = Mock()
   mock_entity.actuators = [mock_actuator]
@@ -413,6 +420,7 @@ def test_randomize_effort_limits_multi_env(device):
 
   mock_actuator = Mock(spec=actuator.BuiltinPositionActuator)
   mock_actuator.ctrl_ids = torch.tensor([0, 1], device=device)
+  mock_actuator.global_ctrl_ids = torch.tensor([0, 1], device=device)
 
   mock_entity = Mock()
   mock_entity.actuators = [mock_actuator]


### PR DESCRIPTION
Actuator.ctrl_ids previously stored global MuJoCo actuator IDs, but write_ctrl() already maps local→global via entity.indexing.ctrl_ids. For a single entity global==local by coincidence, but with multiple entities the second entity's global IDs exceed its local range.

Make ctrl_ids store local indices (consistent with target_ids) and add global_ctrl_ids for code that indexes MuJoCo model arrays directly (e.g., domain randomization events).