### PR TITLE
Upgrade mujoco_warp version references

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,7 +23,7 @@ You can try mjlab *without installing anything* by using `uvx`:
 
    # Run the mjlab demo (no local installation needed)
    uvx --from mjlab \
-       --with "mujoco-warp @ git+https://github.com/google-deepmind/mujoco_warp@1dc288cf1fa819fc3346ec5c9546e2cc2b7be667" \
+       --with "mujoco-warp @ git+https://github.com/google-deepmind/mujoco_warp@7c20a44bfed722e6415235792a1b247ea6b6a6d3" \
        demo
 
 If this runs, your setup is compatible with mjlab *for evaluation*.

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -91,7 +91,7 @@ install. These options are interchangeable: you can switch at any time.
 
       .. code:: bash
 
-         uv add mjlab "mujoco-warp @ git+https://github.com/google-deepmind/mujoco_warp@1dc288cf1fa819fc3346ec5c9546e2cc2b7be667"
+         uv add mjlab "mujoco-warp @ git+https://github.com/google-deepmind/mujoco_warp@7c20a44bfed722e6415235792a1b247ea6b6a6d3"
 
       .. note::
 
@@ -103,7 +103,7 @@ install. These options are interchangeable: you can switch at any time.
 
       .. code:: bash
 
-         uv add "mjlab @ git+https://github.com/mujocolab/mjlab" "mujoco-warp @ git+https://github.com/google-deepmind/mujoco_warp@1dc288cf1fa819fc3346ec5c9546e2cc2b7be667"
+         uv add "mjlab @ git+https://github.com/mujocolab/mjlab" "mujoco-warp @ git+https://github.com/google-deepmind/mujoco_warp@7f89cacecbf0baff92a631671d4a7a45c2b07e20"
 
       .. note::
 
@@ -200,7 +200,7 @@ Install mjlab and dependencies via pip
 
       .. code:: bash
 
-         pip install git+https://github.com/google-deepmind/mujoco_warp@1dc288cf1fa819fc3346ec5c9546e2cc2b7be667
+         pip install git+https://github.com/google-deepmind/mujoco_warp@7c20a44bfed722e6415235792a1b247ea6b6a6d3
          pip install mjlab
 
    .. tab-item:: Source
@@ -209,7 +209,7 @@ Install mjlab and dependencies via pip
 
       .. code:: bash
 
-         pip install git+https://github.com/google-deepmind/mujoco_warp@1dc288cf1fa819fc3346ec5c9546e2cc2b7be667
+         pip install git+https://github.com/google-deepmind/mujoco_warp@7f89cacecbf0baff92a631671d4a7a45c2b07e20
          git clone https://github.com/mujocolab/mjlab.git
          cd mjlab
          pip install -e .

--- a/notebooks/create_new_task.ipynb
+++ b/notebooks/create_new_task.ipynb
@@ -45,7 +45,7 @@
     "id": "dtLMJHzy3Nee"
    },
    "outputs": [],
-   "source": "# Install mujoco-warp\n!pip install git+https://github.com/google-deepmind/mujoco_warp@1dc288cf1fa819fc3346ec5c9546e2cc2b7be667 -q\n\n# Clone the mjlab repository\n!if [ ! -d \"mjlab\" ]; then git clone -q https://github.com/mujocolab/mjlab.git; fi\n%cd /content/mjlab\n\n# Install mjlab in editable mode\n!pip install -e . -q\n\nprint(\"✓ Installation complete!\")"
+   "source": "# Install mujoco-warp\n!pip install git+https://github.com/google-deepmind/mujoco_warp@7f89cacecbf0baff92a631671d4a7a45c2b07e20 -q\n\n# Clone the mjlab repository\n!if [ ! -d \"mjlab\" ]; then git clone -q https://github.com/mujocolab/mjlab.git; fi\n%cd /content/mjlab\n\n# Install mjlab in editable mode\n!pip install -e . -q\n\nprint(\"✓ Installation complete!\")"
   },
   {
    "cell_type": "markdown",

--- a/notebooks/demo.ipynb
+++ b/notebooks/demo.ipynb
@@ -50,7 +50,7 @@
     "outputId": "4c299831-6279-430e-ca8e-f2a58e8f4720"
    },
    "outputs": [],
-   "source": "import subprocess\nimport sys\n\nprocess = subprocess.Popen(\n  [\n    \"uvx\",\n    \"--refresh\",\n    \"--from\",\n    \"mjlab==1.0.0\",\n    \"--with\",\n    \"mujoco-warp @ git+https://github.com/google-deepmind/mujoco_warp@1dc288cf1fa819fc3346ec5c9546e2cc2b7be667\",\n    \"demo\",\n  ],\n  stdout=subprocess.PIPE,\n  stderr=subprocess.STDOUT,\n  universal_newlines=True,\n  bufsize=1,\n)\n\nfor line in process.stdout:\n  print(line, end=\"\")\n  sys.stdout.flush()\n\n  if \"serving\" in line.lower() or \"running on\" in line.lower() or \"8081\" in line:\n    print(\"\\n\" + \"=\" * 50)\n    print(\"✅ Server is running! Execute the next cell to view.\")\n    print(\"=\" * 50)\n    break"
+   "source": "import subprocess\nimport sys\n\nprocess = subprocess.Popen(\n  [\n    \"uvx\",\n    \"--refresh\",\n    \"--from\",\n    \"mjlab==1.0.0\",\n    \"--with\",\n    \"mujoco-warp @ git+https://github.com/google-deepmind/mujoco_warp@7c20a44bfed722e6415235792a1b247ea6b6a6d3\",\n    \"demo\",\n  ],\n  stdout=subprocess.PIPE,\n  stderr=subprocess.STDOUT,\n  universal_newlines=True,\n  bufsize=1,\n)\n\nfor line in process.stdout:\n  print(line, end=\"\")\n  sys.stdout.flush()\n\n  if \"serving\" in line.lower() or \"running on\" in line.lower() or \"8081\" in line:\n    print(\"\\n\" + \"=\" * 50)\n    print(\"✅ Server is running! Execute the next cell to view.\")\n    print(\"=\" * 50)\n    break"
   },
   {
    "cell_type": "code",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,7 +120,7 @@ explicit = true
 warp-lang = { index = "nvidia", marker = "sys_platform != 'darwin'" }
 mujoco = { index = "mujoco" }
 torch = { index = "pytorch-cu128", extra = "cu128", marker = "sys_platform != 'darwin'" }
-mujoco-warp = { git = "https://github.com/google-deepmind/mujoco_warp", rev = "1dc288cf1fa819fc3346ec5c9546e2cc2b7be667" }
+mujoco-warp = { git = "https://github.com/google-deepmind/mujoco_warp", rev = "7f89cacecbf0baff92a631671d4a7a45c2b07e20" }
 
 [tool.ruff]
 src = ["src"]  # Helpful for recognizing first-party imports.

--- a/uv.lock
+++ b/uv.lock
@@ -1297,7 +1297,7 @@ requires-dist = [
     { name = "autodocsumm", marker = "extra == 'docs'" },
     { name = "moviepy" },
     { name = "mujoco", specifier = ">=3.4.0", index = "https://py.mujoco.org/" },
-    { name = "mujoco-warp", git = "https://github.com/google-deepmind/mujoco_warp?rev=1dc288cf1fa819fc3346ec5c9546e2cc2b7be667" },
+    { name = "mujoco-warp", git = "https://github.com/google-deepmind/mujoco_warp?rev=7f89cacecbf0baff92a631671d4a7a45c2b07e20" },
     { name = "myst-parser", marker = "extra == 'docs'", specifier = ">=4.0.1" },
     { name = "onnxscript", specifier = ">=0.5.4" },
     { name = "prettytable" },
@@ -1505,7 +1505,7 @@ wheels = [
 [[package]]
 name = "mujoco-warp"
 version = "0.0.2"
-source = { git = "https://github.com/google-deepmind/mujoco_warp?rev=1dc288cf1fa819fc3346ec5c9546e2cc2b7be667#1dc288cf1fa819fc3346ec5c9546e2cc2b7be667" }
+source = { git = "https://github.com/google-deepmind/mujoco_warp?rev=7f89cacecbf0baff92a631671d4a7a45c2b07e20#7f89cacecbf0baff92a631671d4a7a45c2b07e20" }
 dependencies = [
     { name = "absl-py" },
     { name = "etils", extra = ["epath"] },


### PR DESCRIPTION
## Summary
- Updates mujoco_warp version references across documentation and configuration files
- Source installations now use commit `7f89cacecbf0baff92a631671d4a7a45c2b07e20`
- PyPI installations now use commit `7c20a44bfed722e6415235792a1b247ea6b6a6d3` (matching PyPI release)

## Changes
- Updated `pyproject.toml` and regenerated `uv.lock` with new source hash
- Updated documentation in `docs/source/installation.rst` and `docs/index.rst`
- Updated tutorial notebooks with appropriate hashes for their installation method

## Test plan
- [x] Verified mujoco_warp imports successfully
- [x] Type checking passes (make type)
- [x] Fast tests pass (422 passed, 10 skipped)
- [x] No old hash references remain in codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)