### PR TITLE
Remove deprecated mode parameter from Image.fromarray calls

### DIFF
--- a/src/mjlab/viewer/viser/conversions.py
+++ b/src/mjlab/viewer/viser/conversions.py
@@ -157,13 +157,13 @@ def mujoco_mesh_to_trimesh(
           tex_array = tex_data.reshape(tex_height, tex_width, 3)
           # Flip vertically for GLTF convention.
           tex_array = np.flipud(tex_array)
-          image = Image.fromarray(tex_array.astype(np.uint8), mode="RGB")
+          image = Image.fromarray(tex_array.astype(np.uint8))
         elif tex_nchannel == 4:
           # RGBA.
           tex_array = tex_data.reshape(tex_height, tex_width, 4)
           # Flip vertically for GLTF convention.
           tex_array = np.flipud(tex_array)
-          image = Image.fromarray(tex_array.astype(np.uint8), mode="RGBA")
+          image = Image.fromarray(tex_array.astype(np.uint8))
         else:
           if verbose:
             print(f"Unsupported number of texture channels: {tex_nchannel}")


### PR DESCRIPTION
## Summary
- Removes deprecated `mode` parameter from `Image.fromarray()` calls in viser conversions
- Fixes deprecation warning in `test_viser_conversions::test_merge_mixed_visual_geoms`
- Pillow automatically detects mode from array shape/dtype, making the parameter unnecessary

## Details
The `mode` parameter in `Image.fromarray()` is deprecated and will be removed in Pillow 13 (October 2026). Pillow correctly infers the mode from:
- Arrays with shape (H, W, 3) and uint8 dtype → RGB mode
- Arrays with shape (H, W, 4) and uint8 dtype → RGBA mode

See: https://pillow.readthedocs.io/en/stable/deprecations.html#image-fromarray-mode-parameter

## Test plan
- [x] All tests in `test_viser_conversions.py` pass without warnings
- [x] Verified warning is eliminated

🤖 Generated with [Claude Code](https://claude.com/claude-code)