### PR TITLE
Fix documentation references to correct paths in docs/source/

### DIFF
--- a/notebooks/create_new_task.ipynb
+++ b/notebooks/create_new_task.ipynb
@@ -25,7 +25,7 @@
     "3. **Training** - Train a policy using PPO\n",
     "4. **Evaluation** - Visualize the simulation with the trained policy\n",
     "\n",
-    "> **Note**: This tutorial is created based on the official MJLab documentation [\"Create a New Task\"](https://github.com/mujocolab/mjlab/blob/main/docs/create_new_task.md)."
+    "> **Note**: This tutorial demonstrates how to create a new task in MJLab. For more context, see the [official documentation](https://mujocolab.github.io/mjlab/)."
    ]
   },
   {
@@ -45,7 +45,19 @@
     "id": "dtLMJHzy3Nee"
    },
    "outputs": [],
-   "source": "# Install mujoco-warp\n!pip install git+https://github.com/google-deepmind/mujoco_warp@7f89cacecbf0baff92a631671d4a7a45c2b07e20 -q\n\n# Clone the mjlab repository\n!if [ ! -d \"mjlab\" ]; then git clone -q https://github.com/mujocolab/mjlab.git; fi\n%cd /content/mjlab\n\n# Install mjlab in editable mode\n!pip install -e . -q\n\nprint(\"✓ Installation complete!\")"
+   "source": [
+    "# Install mujoco-warp\n",
+    "!pip install git+https://github.com/google-deepmind/mujoco_warp@7f89cacecbf0baff92a631671d4a7a45c2b07e20 -q\n",
+    "\n",
+    "# Clone the mjlab repository\n",
+    "!if [ ! -d \"mjlab\" ]; then git clone -q https://github.com/mujocolab/mjlab.git; fi\n",
+    "%cd /content/mjlab\n",
+    "\n",
+    "# Install mjlab in editable mode\n",
+    "!pip install -e . -q\n",
+    "\n",
+    "print(\"✓ Installation complete!\")"
+   ]
   },
   {
    "cell_type": "markdown",

--- a/scripts/run_docker.sh
+++ b/scripts/run_docker.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 #
 # Injects useful arguments for running mjlab in docker.
-# See docs/installation_guide.md for usage.
+# See docs/source/installation.rst for usage.
 #
 # Patterned after the uv-in-docker example:
 # https://github.com/astral-sh/uv-docker-example/blob/5748835918ec293d547bbe0e42df34e140aca1eb/run.sh

--- a/src/mjlab/envs/mdp/events.py
+++ b/src/mjlab/envs/mdp/events.py
@@ -846,7 +846,7 @@ def randomize_encoder_bias(
 ) -> None:
   """Randomize encoder bias to simulate joint encoder calibration errors.
 
-  See docs/api/domain_randomization.md for details on how encoder bias works.
+  See docs/source/randomization.rst for details on how encoder bias works.
   """
   asset: Entity = env.scene[asset_cfg.name]
 

--- a/src/mjlab/managers/observation_manager.py
+++ b/src/mjlab/managers/observation_manager.py
@@ -62,7 +62,7 @@ class ObservationTermCfg(ManagerTermBaseCfg):
 
   When True and concatenate_terms=True, uses term-major ordering:
   [A_t0, A_t1, ..., A_tH-1, B_t0, B_t1, ..., B_tH-1, ...]
-  See docs/api/observation_history_delay.md for details on ordering."""
+  See docs/source/observation.rst for details on ordering."""
 
 
 @dataclass


### PR DESCRIPTION
This PR addresses the following:

- Update events.py: docs/api/domain_randomization.md -> docs/source/randomization.rst
- Update observation_manager.py: docs/api/observation_history_delay.md -> docs/source/observation.rst
- Update run_docker.sh: docs/installation_guide.md -> docs/source/installation.rst
- Update create_new_task.ipynb: Remove reference to non-existent create_new_task.md, point to official docs