### PR TITLE
Call sim.forward() unconditionally after decimation loop

### DIFF
--- a/src/mjlab/envs/manager_based_rl_env.py
+++ b/src/mjlab/envs/manager_based_rl_env.py
@@ -327,6 +327,11 @@ class ManagerBasedRlEnv:
       self.sim.step()
       self.scene.update(dt=self.physics_dt)
 
+    # Recompute derived quantities (xpos, xquat, site_xpos, etc.) from the
+    # post-integration qpos/qvel. Without this, these are stale from the
+    # pre-integration forward pass inside mj_step.
+    self.sim.forward()
+
     # Update env counters.
     self.episode_length_buf += 1
     self.common_step_counter += 1


### PR DESCRIPTION
After `mj_step()`, the integrated qpos/qvel are one timestep ahead of the derived quantities like `xpos`, `site_xpos`, etc., because MuJoCo computes forward kinematics before integration (in `mj_step1`), then integrates (in `mj_step2`). So after `step()` returns, positions and orientations are stale relative to the actual generalized state.

In practice the effect is likely small. The staleness is only one physics substep worth of drift, and with typical timesteps the gap between the stale and fresh values is tiny. Most reward and termination functions are also fairly tolerant of small position offsets. But it's still wrong in principle, so worth fixing regardless.

The fix is straightforward: we now add an unconditional `sim.forward()` call after the decimation loop, before termination and reward computation. Previously it only ran inside the reset conditional, which meant termination and rewards always saw stale data, and observations only got refreshed when a reset happened to trigger it.

The conditional `forward()` in the reset block is still needed. After writing the reset state to qpos/qvel, derived quantities go stale again for those envs, so the second call brings them back in sync before observations are computed.

Fixes #588.