### PR TITLE
Move docs dependencies to dependency-groups

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,7 +25,7 @@ jobs:
         uses: astral-sh/setup-uv@v4
 
       - name: Build Sphinx Documentation
-        run: uv run --extra docs sphinx-build docs docs/_build
+        run: uv run --group docs sphinx-build docs docs/_build
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ build:
 
 .PHONY: docs
 docs:
-	uv run --extra docs sphinx-build docs docs/_build
+	uv run --group docs sphinx-build docs docs/_build
 
 .PHONY: docs-watch
 docs-watch:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,24 +69,24 @@ dev = [
   "ruff>=v0.14.14",
   "ty>=v0.0.14",
 ]
+docs = [
+  "myst-parser>=4.0.1",
+  "sphinx>=8.1.3",
+  "sphinx-autodoc-typehints>=3.0.1",
+  "sphinx-autobuild>=2024.10.3",
+  "sphinx-book-theme>=1.1.4",
+  "sphinx-copybutton>=0.5.2",
+  "sphinx-design>=0.6.1",
+  "autodocsumm",
+  "sphinxemoji",
+  "sphinxcontrib.bibtex",
+  "sphinx-icon",
+  "sphinx-tabs",
+  "sphinx_multiversion",
+]
 
 [project.optional-dependencies]
 cu128 = ["torch>=2.7.0"]
-docs = [
-    "myst-parser>=4.0.1",
-    "sphinx>=8.1.3",
-    "sphinx-autobuild>=2024.10.3",
-    "sphinx-autodoc-typehints>=3.0.1",
-    "sphinx-book-theme>=1.1.4",
-    "sphinx-copybutton>=0.5.2",
-    "sphinx-design>=0.6.1",
-    "autodocsumm",
-    "sphinxemoji",
-    "sphinxcontrib.bibtex",
-    "sphinx-icon",
-    "sphinx-tabs",
-    "sphinx_multiversion",
-]
 
 [tool.uv]
 required-environments = [

--- a/uv.lock
+++ b/uv.lock
@@ -1265,6 +1265,16 @@ cu128 = [
     { name = "torch", version = "2.9.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
     { name = "torch", version = "2.9.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform != 'darwin'" },
 ]
+
+[package.dev-dependencies]
+dev = [
+    { name = "ipdb" },
+    { name = "pre-commit" },
+    { name = "pyright" },
+    { name = "pytest" },
+    { name = "ruff" },
+    { name = "ty" },
+]
 docs = [
     { name = "autodocsumm" },
     { name = "myst-parser" },
@@ -1284,37 +1294,14 @@ docs = [
     { name = "sphinxemoji" },
 ]
 
-[package.dev-dependencies]
-dev = [
-    { name = "ipdb" },
-    { name = "pre-commit" },
-    { name = "pyright" },
-    { name = "pytest" },
-    { name = "ruff" },
-    { name = "ty" },
-]
-
 [package.metadata]
 requires-dist = [
-    { name = "autodocsumm", marker = "extra == 'docs'" },
     { name = "moviepy" },
     { name = "mujoco", specifier = ">=3.4.0", index = "https://py.mujoco.org/" },
     { name = "mujoco-warp", git = "https://github.com/google-deepmind/mujoco_warp?rev=7f89cacecbf0baff92a631671d4a7a45c2b07e20" },
-    { name = "myst-parser", marker = "extra == 'docs'", specifier = ">=4.0.1" },
     { name = "onnxscript", specifier = ">=0.5.4" },
     { name = "prettytable" },
     { name = "rsl-rl-lib", specifier = "==3.1.0" },
-    { name = "sphinx", marker = "extra == 'docs'", specifier = ">=8.1.3" },
-    { name = "sphinx-autobuild", marker = "extra == 'docs'", specifier = ">=2024.10.3" },
-    { name = "sphinx-autodoc-typehints", marker = "extra == 'docs'", specifier = ">=3.0.1" },
-    { name = "sphinx-book-theme", marker = "extra == 'docs'", specifier = ">=1.1.4" },
-    { name = "sphinx-copybutton", marker = "extra == 'docs'", specifier = ">=0.5.2" },
-    { name = "sphinx-design", marker = "extra == 'docs'", specifier = ">=0.6.1" },
-    { name = "sphinx-icon", marker = "extra == 'docs'" },
-    { name = "sphinx-multiversion", marker = "extra == 'docs'" },
-    { name = "sphinx-tabs", marker = "extra == 'docs'" },
-    { name = "sphinxcontrib-bibtex", marker = "extra == 'docs'" },
-    { name = "sphinxemoji", marker = "extra == 'docs'" },
     { name = "tensorboard", specifier = ">=2.20.0" },
     { name = "tensordict" },
     { name = "torch", specifier = ">=2.7.0" },
@@ -1329,7 +1316,7 @@ requires-dist = [
     { name = "warp-lang", marker = "sys_platform != 'darwin'", specifier = ">=1.11.0.dev20251211", index = "https://pypi.nvidia.com/" },
     { name = "warp-lang", marker = "sys_platform == 'darwin'", specifier = ">=1.11.0.dev20251211" },
 ]
-provides-extras = ["cu128", "docs"]
+provides-extras = ["cu128"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1339,6 +1326,21 @@ dev = [
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "ruff", specifier = ">=0.14.14" },
     { name = "ty", specifier = ">=0.0.14" },
+]
+docs = [
+    { name = "autodocsumm" },
+    { name = "myst-parser", specifier = ">=4.0.1" },
+    { name = "sphinx", specifier = ">=8.1.3" },
+    { name = "sphinx-autobuild", specifier = ">=2024.10.3" },
+    { name = "sphinx-autodoc-typehints", specifier = ">=3.0.1" },
+    { name = "sphinx-book-theme", specifier = ">=1.1.4" },
+    { name = "sphinx-copybutton", specifier = ">=0.5.2" },
+    { name = "sphinx-design", specifier = ">=0.6.1" },
+    { name = "sphinx-icon" },
+    { name = "sphinx-multiversion" },
+    { name = "sphinx-tabs" },
+    { name = "sphinxcontrib-bibtex" },
+    { name = "sphinxemoji" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Move docs dependencies from `[project.optional-dependencies]` to `[dependency-groups]`, since they are developer tooling and should not be published as a user-facing extra.
- Add `sphinx-autobuild` to the docs group.
- Update Makefile and docs CI workflow to use `--group docs` instead of `--extra docs`.