### PR TITLE
Allow curriculum stages to be defined in iterations instead of raw steps

### DIFF
--- a/src/mjlab/scripts/train.py
+++ b/src/mjlab/scripts/train.py
@@ -11,6 +11,7 @@ from typing import Literal, cast
 import tyro
 
 from mjlab.envs import ManagerBasedRlEnv, ManagerBasedRlEnvCfg
+from mjlab.managers.curriculum_manager import resolve_curriculum_iterations
 from mjlab.rl import MjlabOnPolicyRunner, RslRlOnPolicyRunnerCfg, RslRlVecEnvWrapper
 from mjlab.tasks.registry import list_tasks, load_env_cfg, load_rl_cfg, load_runner_cls
 from mjlab.tasks.tracking.mdp import MotionCommandCfg
@@ -102,6 +103,8 @@ def run_train(task_id: str, cfg: TrainConfig, log_dir: Path) -> None:
 
   if rank == 0:
     print(f"[INFO] Logging experiment in directory: {log_dir}")
+
+  resolve_curriculum_iterations(cfg.env.curriculum, cfg.agent.num_steps_per_env)
 
   env = ManagerBasedRlEnv(
     cfg=cfg.env, device=device, render_mode="rgb_array" if cfg.video else None

--- a/src/mjlab/tasks/manipulation/lift_cube_env_cfg.py
+++ b/src/mjlab/tasks/manipulation/lift_cube_env_cfg.py
@@ -206,9 +206,9 @@ def make_lift_cube_env_cfg() -> ManagerBasedRlEnvCfg:
       params={
         "reward_name": "joint_vel_hinge",
         "weight_stages": [
-          {"step": 0, "weight": -0.01},
-          {"step": 500 * 24, "weight": -0.1},
-          {"step": 1000 * 24, "weight": -1.0},
+          {"iteration": 0, "weight": -0.01},
+          {"iteration": 500, "weight": -0.1},
+          {"iteration": 1000, "weight": -1.0},
         ],
       },
     ),

--- a/src/mjlab/tasks/velocity/velocity_env_cfg.py
+++ b/src/mjlab/tasks/velocity/velocity_env_cfg.py
@@ -351,9 +351,9 @@ def make_velocity_env_cfg() -> ManagerBasedRlEnvCfg:
       params={
         "command_name": "twist",
         "velocity_stages": [
-          {"step": 0, "lin_vel_x": (-1.0, 1.0), "ang_vel_z": (-0.5, 0.5)},
-          {"step": 5000 * 24, "lin_vel_x": (-1.5, 2.0), "ang_vel_z": (-0.7, 0.7)},
-          {"step": 10000 * 24, "lin_vel_x": (-2.0, 3.0)},
+          {"iteration": 0, "lin_vel_x": (-1.0, 1.0), "ang_vel_z": (-0.5, 0.5)},
+          {"iteration": 5000, "lin_vel_x": (-1.5, 2.0), "ang_vel_z": (-0.7, 0.7)},
+          {"iteration": 10000, "lin_vel_x": (-2.0, 3.0)},
         ],
       },
     ),

--- a/tests/test_curriculum_manager.py
+++ b/tests/test_curriculum_manager.py
@@ -1,0 +1,99 @@
+"""Tests for resolve_curriculum_iterations()."""
+
+import copy
+
+import pytest
+
+from mjlab.managers.curriculum_manager import (
+  CurriculumTermCfg,
+  resolve_curriculum_iterations,
+)
+
+
+def _dummy_func(*args, **kwargs):
+  pass
+
+
+def _make_curriculum(stages_key, stages):
+  """Build a minimal curriculum dict with one term."""
+  return {
+    "term": CurriculumTermCfg(
+      func=_dummy_func,
+      params={"some_name": "twist", stages_key: stages},
+    )
+  }
+
+
+def test_converts_iteration_to_step():
+  stages = [
+    {"iteration": 0, "lin_vel_x": (-1.0, 1.0)},
+    {"iteration": 5000, "lin_vel_x": (-2.0, 2.0)},
+  ]
+  curriculum = _make_curriculum("velocity_stages", stages)
+  resolve_curriculum_iterations(curriculum, num_steps_per_env=24)
+
+  resolved = curriculum["term"].params["velocity_stages"]
+  assert resolved[0] == {"step": 0, "lin_vel_x": (-1.0, 1.0)}
+  assert resolved[1] == {"step": 120000, "lin_vel_x": (-2.0, 2.0)}
+  assert all("iteration" not in stage for stage in resolved)
+
+
+def test_leaves_step_based_stages_untouched():
+  stages = [
+    {"step": 0, "weight": -0.01},
+    {"step": 12000, "weight": -1.0},
+  ]
+  curriculum = _make_curriculum("weight_stages", stages)
+  original = copy.deepcopy(curriculum)
+  resolve_curriculum_iterations(curriculum, num_steps_per_env=24)
+
+  assert (
+    curriculum["term"].params["weight_stages"]
+    == original["term"].params["weight_stages"]
+  )
+
+
+def test_leaves_non_stage_params_untouched():
+  curriculum = _make_curriculum(
+    "velocity_stages",
+    [{"iteration": 100, "lin_vel_x": (-1.0, 1.0)}],
+  )
+  resolve_curriculum_iterations(curriculum, num_steps_per_env=24)
+  assert curriculum["term"].params["some_name"] == "twist"
+
+
+def test_raises_on_ambiguous_stage():
+  stages = [{"iteration": 100, "step": 2400, "weight": -1.0}]
+  curriculum = _make_curriculum("weight_stages", stages)
+  with pytest.raises(ValueError, match="both 'iteration' and 'step'"):
+    resolve_curriculum_iterations(curriculum, num_steps_per_env=24)
+
+
+def test_velocity_env_cfg_stages_resolve():
+  """End-to-end: velocity config's command_vel stages resolve correctly."""
+  from mjlab.tasks.velocity.velocity_env_cfg import make_velocity_env_cfg
+
+  env_cfg = make_velocity_env_cfg()
+  resolve_curriculum_iterations(env_cfg.curriculum, num_steps_per_env=24)
+
+  stages = env_cfg.curriculum["command_vel"].params["velocity_stages"]
+  assert stages[0]["step"] == 0
+  assert stages[1]["step"] == 5000 * 24
+  assert stages[2]["step"] == 10000 * 24
+  assert all("iteration" not in stage for stage in stages)
+
+
+def test_lift_cube_env_cfg_stages_resolve():
+  """End-to-end: lift cube config's weight stages resolve correctly."""
+  from mjlab.tasks.manipulation.lift_cube_env_cfg import (
+    make_lift_cube_env_cfg,
+  )
+
+  env_cfg = make_lift_cube_env_cfg()
+  resolve_curriculum_iterations(env_cfg.curriculum, num_steps_per_env=24)
+
+  stages = env_cfg.curriculum["joint_vel_hinge_weight"].params["weight_stages"]
+  assert stages[0]["step"] == 0
+  assert stages[1]["step"] == 500 * 24
+  assert stages[2]["step"] == 1000 * 24
+  assert all("iteration" not in stage for stage in stages)


### PR DESCRIPTION
Alternative to #605. Curriculum configs can now use `"iteration"` instead of `"step"` in stage dicts (e.g. `{"iteration": 5000}` vs `{"step": 5000 * 24}`), which is more intuitive and doesn't require knowing `num_steps_per_env`.

Rather than propagating `num_steps_per_env` into the env config and duplicating conversion logic across curriculum functions, this resolves `"iteration"` → `"step"` once at config time in `train.py` before the env is created. Curriculum functions remain unchanged.