### PR TITLE
Upgrade mjwarp to 0828fb0 and fix curriculum in play

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -113,7 +113,7 @@ install. These options are interchangeable: you can switch at any time.
 
       .. code:: bash
 
-         uv add "mjlab @ git+https://github.com/mujocolab/mjlab" "mujoco-warp @ git+https://github.com/google-deepmind/mujoco_warp@b75f85b4dbc60f2d6e9277d345953aa1f1dd1611"
+         uv add "mjlab @ git+https://github.com/mujocolab/mjlab" "mujoco-warp @ git+https://github.com/google-deepmind/mujoco_warp@0828fb0b57d7baf734dd71fa164d092cb17e635b"
 
       .. note::
 
@@ -224,7 +224,7 @@ Install mjlab and dependencies via pip
 
       .. code:: bash
 
-         pip install git+https://github.com/google-deepmind/mujoco_warp@b75f85b4dbc60f2d6e9277d345953aa1f1dd1611
+         pip install git+https://github.com/google-deepmind/mujoco_warp@0828fb0b57d7baf734dd71fa164d092cb17e635b
          git clone https://github.com/mujocolab/mjlab.git
          cd mjlab
          pip install -e .

--- a/notebooks/create_new_task.ipynb
+++ b/notebooks/create_new_task.ipynb
@@ -45,19 +45,7 @@
     "id": "dtLMJHzy3Nee"
    },
    "outputs": [],
-   "source": [
-    "# Install mujoco-warp\n",
-    "!pip install git+https://github.com/google-deepmind/mujoco_warp@b75f85b4dbc60f2d6e9277d345953aa1f1dd1611 -q\n",
-    "\n",
-    "# Clone the mjlab repository\n",
-    "!if [ ! -d \"mjlab\" ]; then git clone -q https://github.com/mujocolab/mjlab.git; fi\n",
-    "%cd /content/mjlab\n",
-    "\n",
-    "# Install mjlab in editable mode\n",
-    "!pip install -e . -q\n",
-    "\n",
-    "print(\"✓ Installation complete!\")"
-   ]
+   "source": "# Install mujoco-warp\n!pip install git+https://github.com/google-deepmind/mujoco_warp@0828fb0b57d7baf734dd71fa164d092cb17e635b -q\n\n# Clone the mjlab repository\n!if [ ! -d \"mjlab\" ]; then git clone -q https://github.com/mujocolab/mjlab.git; fi\n%cd /content/mjlab\n\n# Install mjlab in editable mode\n!pip install -e . -q\n\nprint(\"✓ Installation complete!\")"
   },
   {
    "cell_type": "markdown",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,7 @@ explicit = true
 warp-lang = { index = "nvidia", marker = "sys_platform != 'darwin'" }
 mujoco = { index = "mujoco" }
 torch = { index = "pytorch-cu128", extra = "cu128", marker = "sys_platform != 'darwin'" }
-mujoco-warp = { git = "https://github.com/google-deepmind/mujoco_warp", rev = "b75f85b4dbc60f2d6e9277d345953aa1f1dd1611" }
+mujoco-warp = { git = "https://github.com/google-deepmind/mujoco_warp", rev = "0828fb0b57d7baf734dd71fa164d092cb17e635b" }
 
 [tool.ruff]
 src = ["src"]  # Helpful for recognizing first-party imports.

--- a/src/mjlab/scripts/play.py
+++ b/src/mjlab/scripts/play.py
@@ -11,6 +11,7 @@ import tyro
 from rsl_rl.runners import OnPolicyRunner
 
 from mjlab.envs import ManagerBasedRlEnv
+from mjlab.managers.curriculum_manager import resolve_curriculum_iterations
 from mjlab.rl import RslRlVecEnvWrapper
 from mjlab.tasks.registry import list_tasks, load_env_cfg, load_rl_cfg, load_runner_cls
 from mjlab.tasks.tracking.mdp import MotionCommandCfg
@@ -147,6 +148,8 @@ def run_play(task_id: str, cfg: PlayConfig):
     env_cfg.viewer.height = cfg.video_height
   if cfg.video_width is not None:
     env_cfg.viewer.width = cfg.video_width
+
+  resolve_curriculum_iterations(env_cfg.curriculum, agent_cfg.num_steps_per_env)
 
   render_mode = "rgb_array" if (TRAINED_MODE and cfg.video) else None
   if cfg.video and DUMMY_MODE:

--- a/src/mjlab/sensor/sensor_context.py
+++ b/src/mjlab/sensor/sensor_context.py
@@ -263,8 +263,7 @@ class SensorContext:
     with wp.ScopedDevice(self.wp_device):
       self._ctx = mjwarp.create_render_context(
         mjm=mj_model,
-        m=self._model.struct,  # type: ignore[attr-defined]
-        d=self._data.struct,  # type: ignore[attr-defined]
+        nworld=self._data.nworld,
         cam_res=cam_res,
         render_rgb=render_rgb,
         render_depth=render_depth,

--- a/uv.lock
+++ b/uv.lock
@@ -1298,7 +1298,7 @@ docs = [
 requires-dist = [
     { name = "moviepy" },
     { name = "mujoco", specifier = ">=3.4.0", index = "https://py.mujoco.org/" },
-    { name = "mujoco-warp", git = "https://github.com/google-deepmind/mujoco_warp?rev=b75f85b4dbc60f2d6e9277d345953aa1f1dd1611" },
+    { name = "mujoco-warp", git = "https://github.com/google-deepmind/mujoco_warp?rev=0828fb0b57d7baf734dd71fa164d092cb17e635b" },
     { name = "onnxscript", specifier = ">=0.5.4" },
     { name = "prettytable" },
     { name = "rsl-rl-lib", specifier = "==4.0.1" },
@@ -1510,7 +1510,7 @@ wheels = [
 [[package]]
 name = "mujoco-warp"
 version = "0.0.2"
-source = { git = "https://github.com/google-deepmind/mujoco_warp?rev=b75f85b4dbc60f2d6e9277d345953aa1f1dd1611#b75f85b4dbc60f2d6e9277d345953aa1f1dd1611" }
+source = { git = "https://github.com/google-deepmind/mujoco_warp?rev=0828fb0b57d7baf734dd71fa164d092cb17e635b#0828fb0b57d7baf734dd71fa164d092cb17e635b" }
 dependencies = [
     { name = "absl-py" },
     { name = "etils", extra = ["epath"] },


### PR DESCRIPTION
## Summary

- Upgrades `mujoco-warp` to [`0828fb0`](https://github.com/google-deepmind/mujoco_warp/commit/0828fb0b57d7baf734dd71fa164d092cb17e635b), which removes the `m`/`d` params from `create_render_context` in favor of `nworld`. Updates the call site in `sensor_context.py` accordingly.
- Fixes a bug where `resolve_curriculum_iterations` was only called in `train.py` but not `play.py`, causing a `KeyError: 'step'` when playing envs with iteration-based curriculum stages (introduced in #606).
- Updates source-install hashes in docs and `create_new_task.ipynb`. PyPI install hashes are preserved.

## Test plan

- [x] `make test-fast` passes (467/467)
- [x] `uv run play Mjlab-Lift-Cube-Yam-Rgb --agent zero --viewer viser --num-envs 1` no longer crashes
- [x] Verify camera/raycast sensors work with the new `create_render_context` signature

🤖 Generated with [Claude Code](https://claude.com/claude-code)