### PR TITLE
Skip CI for doc-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
     paths-ignore:
       - '**.md'
+      - '**.rst'
+      - 'docs/**'
       - 'Makefile'
       - 'LICENSE'
       - 'scripts/benchmarks/**'
@@ -12,6 +14,8 @@ on:
     branches: [main]
     paths-ignore:
       - '**.md'
+      - '**.rst'
+      - 'docs/**'
       - 'Makefile'
       - 'LICENSE'
       - 'scripts/benchmarks/**'


### PR DESCRIPTION
## Summary
- Add `**.rst` and `docs/**` to `paths-ignore` in CI workflow
- Documentation-only PRs (changelog, rst files, anything under `docs/`) no longer trigger the full test/lint/typecheck matrix
- The existing `docs.yml` workflow already handles doc builds separately

## Test plan
- [x] Verify CI does not run on the current PR (it only touches `.github/workflows/ci.yml`, which is not ignored — so CI will run this time, confirming the workflow file itself is valid)
- [ ] Future doc-only PRs should show skipped CI checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)