### PR TITLE
Remove unsafe body fields from domain randomization

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,10 @@ make docs       # Build documentation
 
 Before creating a PR, ensure all checks pass with `make test`.
 
+When making user-facing changes, add an entry to `docs/source/changelog.rst`
+under the "Upcoming version (not yet released)" section using
+Added/Changed/Fixed categories.
+
 Some style guidelines to follow:
 - Line length limit is 88 columns. This applies to code, comments, and docstrings.
 - Avoid local imports unless they are strictly necessary (e.g. circular imports).

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -22,6 +22,14 @@ Fixed
   ``cnn_cfg`` keyword argument. Contribution by
   `@griffinaddison <https://github.com/griffinaddison>`_.
 
+Changed
+^^^^^^^
+
+- Removed ``body_mass``, ``body_inertia``, ``body_pos``, and ``body_quat``
+  from ``FIELD_SPECS`` in domain randomization. These fields have derived
+  quantities that require ``set_const`` to recompute; without that call,
+  randomizing them silently breaks physics.
+
 .. figure:: _static/changelog/native_reward.png
    :width: 80%
 

--- a/src/mjlab/envs/mdp/events.py
+++ b/src/mjlab/envs/mdp/events.py
@@ -383,12 +383,8 @@ FIELD_SPECS = {
   "jnt_range": FieldSpec("joint"),
   "jnt_stiffness": FieldSpec("joint"),
   # Body - uses IDs directly.
-  "body_mass": FieldSpec("body"),
   "body_ipos": FieldSpec("body", default_axes=[0, 1, 2]),
   "body_iquat": FieldSpec("body", default_axes=[0, 1, 2, 3]),
-  "body_inertia": FieldSpec("body"),
-  "body_pos": FieldSpec("body", default_axes=[0, 1, 2]),
-  "body_quat": FieldSpec("body", default_axes=[0, 1, 2, 3]),
   # Geom - uses IDs directly.
   "geom_friction": FieldSpec("geom", default_axes=[0], valid_axes=[0, 1, 2]),
   "geom_pos": FieldSpec("geom", default_axes=[0, 1, 2]),
@@ -418,7 +414,7 @@ def randomize_field(
   Args:
     env: The environment.
     env_ids: Environment IDs to randomize.
-    field: Field name (e.g., "geom_friction", "body_mass").
+    field: Field name (e.g., "geom_friction", "dof_damping").
     ranges: Either (min, max) for all axes, or {axis: (min, max)} for specific axes.
     distribution: Distribution type.
     operation: How to apply randomization. For "scale" and "add" operations,

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -99,7 +99,7 @@ def test_class_based_event_with_domain_randomization(device):
       mode="reset",
       func=events.randomize_field,
       domain_randomization=True,
-      params={"field": "body_mass", "ranges": (0.8, 1.2)},
+      params={"field": "dof_damping", "ranges": (0.1, 0.5)},
     ),
     # Non-DR term should not be tracked.
     "regular_event": EventTermCfg(
@@ -113,7 +113,7 @@ def test_class_based_event_with_domain_randomization(device):
 
   # Verify that DR fields are tracked.
   assert "geom_friction" in manager.domain_randomization_fields
-  assert "body_mass" in manager.domain_randomization_fields
+  assert "dof_damping" in manager.domain_randomization_fields
 
   # Verify that non-DR event is not tracked.
   assert len(manager.domain_randomization_fields) == 2


### PR DESCRIPTION
Removes `body_mass`, `body_inertia`, `body_pos`, and `body_quat` from `FIELD_SPECS` in domain randomization. These fields have derived quantities (e.g. `body_subtreemass`, `dof_invweight0`) that require `set_const` to recompute, and without that call, randomizing them silently produces inconsistent physics. `body_ipos` and `body_iquat` are kept since they feed into `xipos`/`ximat` which are recomputed every kinematics step. Until we integrate `set_const` into the randomization pipeline, exposing these fields is a footgun that leads to bad training results.