### PR TITLE
Height scan sensor out of range behaviour

### DIFF
--- a/src/mjlab/envs/mdp/observations.py
+++ b/src/mjlab/envs/mdp/observations.py
@@ -122,4 +122,10 @@ def height_scan(
     Tensor of shape [B, N] where B is num_envs and N is num_rays.
   """
   sensor: RayCastSensor = env.scene[sensor_name]
-  return sensor.data.pos_w[:, 2].unsqueeze(1) - sensor.data.hit_pos_w[..., 2] - offset
+  height = sensor.data.pos_w[:, 2].unsqueeze(1) - sensor.data.hit_pos_w[..., 2]
+  # hit_pos_w returns sensor coords if ray out of range, making height == 0 at these locations
+  # Height 0 should mean there is an object directly in front of the sensor, which is not the case here
+  # Instead, set these readings to max sensor distance to show that it is out of range
+  height[sensor.data.distances == -1] = sensor.cfg.max_distance
+  height -= offset
+  return height

--- a/src/mjlab/tasks/velocity/velocity_env_cfg.py
+++ b/src/mjlab/tasks/velocity/velocity_env_cfg.py
@@ -36,6 +36,17 @@ def make_velocity_env_cfg() -> ManagerBasedRlEnvCfg:
   # Observations
   ##
 
+  terrain_scan = RayCastSensorCfg(
+    name="terrain_scan",
+    frame=ObjRef(type="body", name="", entity="robot"),  # Set per-robot.
+    ray_alignment="yaw",
+    pattern=GridPatternCfg(size=(1.6, 1.0), resolution=0.1),
+    max_distance=3.0,
+    exclude_parent_body=True,
+    debug_vis=True,
+    viz=RayCastSensorCfg.VizCfg(show_normals=True),
+  )
+
   actor_terms = {
     "base_lin_vel": ObservationTermCfg(
       func=mdp.builtin_sensor,
@@ -68,7 +79,7 @@ def make_velocity_env_cfg() -> ManagerBasedRlEnvCfg:
       func=envs_mdp.height_scan,
       params={"sensor_name": "terrain_scan"},
       noise=Unoise(n_min=-0.1, n_max=0.1),
-      clip=(-1.0, 1.0),
+      scale=1 / terrain_scan.max_distance,
     ),
   }
 
@@ -77,7 +88,7 @@ def make_velocity_env_cfg() -> ManagerBasedRlEnvCfg:
     "height_scan": ObservationTermCfg(
       func=envs_mdp.height_scan,
       params={"sensor_name": "terrain_scan"},
-      clip=(-1.0, 1.0),
+      scale=1 / terrain_scan.max_distance,
     ),
     "foot_height": ObservationTermCfg(
       func=mdp.foot_height,
@@ -362,17 +373,6 @@ def make_velocity_env_cfg() -> ManagerBasedRlEnvCfg:
   ##
   # Assemble and return
   ##
-
-  terrain_scan = RayCastSensorCfg(
-    name="terrain_scan",
-    frame=ObjRef(type="body", name="", entity="robot"),  # Set per-robot.
-    ray_alignment="yaw",
-    pattern=GridPatternCfg(size=(1.6, 1.0), resolution=0.1),
-    max_distance=5.0,
-    exclude_parent_body=True,
-    debug_vis=True,
-    viz=RayCastSensorCfg.VizCfg(show_normals=True),
-  )
 
   return ManagerBasedRlEnvCfg(
     scene=SceneCfg(

--- a/tests/test_raycast_sensor.py
+++ b/tests/test_raycast_sensor.py
@@ -906,7 +906,7 @@ def test_height_scan_hits(robot_with_floor_xml, device):
 
 
 def test_height_scan_misses(device):
-  """height_scan reports ~0 for rays that miss (no ground)."""
+  """height_scan reports sensor max_distance for rays that miss (no ground)."""
 
   no_floor_xml = """
     <mujoco>
@@ -940,4 +940,6 @@ def test_height_scan_misses(device):
   heights = height_scan(env, "terrain_scan")  # type: ignore[invalid-argument-type]
 
   # Misses: hit_pos_w == ray origin, so height ≈ 0.
-  assert torch.allclose(heights, torch.zeros_like(heights), atol=1e-5)
+  assert torch.allclose(
+    heights, torch.full_like(heights, raycast_cfg.max_distance), atol=1e-5
+  )


### PR DESCRIPTION
When training a locomotion policy for a discrete environment with out-of-range raycast readings (pictured), I made a couple of changes to aid training.
- For an out of range ray, instead of returning 0 (which intuitively means an object directly in front of of the sensor), return **maximum sensor distance**. This seems more consistent with what a real depth sensor might show, and preserves physical consistency - as the ground gets further away, the reading increases up to its maximum, instead of jumping back to 0.
- On the Unitree G1 velocity tracking task
  - The height scan reading was clipped from (-1,1), truncating readings more than a metre away - sensor max_distance should determine this instead
  - I normalised the readings in the range [0, 1] by dividing by max_distance for stabler training
  - Reduced max_distance to 3m to increase resolution - the humanoid will probably have a hard time dealing with any drop over 3m anyway.

Feel free to take any or all of these tweaks as you see fit! Can update the changelog with whatever changes are agreed upon.

<img width="980" height="664" alt="Screenshot 2026-02-15 at 20 46 33" src="https://github.com/user-attachments/assets/72f5e6e4-3e78-42bc-b482-fad17ea9e10f" />
