### PR TITLE
Fix ghost mesh rendering for fixed-base entities by supporting mocap

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -12,6 +12,13 @@ Changed
   separate ``delta_pos_scale`` and ``delta_ori_scale`` for independent scaling
   of position and orientation components.
 
+Fixed
+^^^^^
+
+- Fixed ghost mesh visualization for fixed-base entities by extending
+  ``DebugVisualizer.add_ghost_mesh`` to optionally accept ``mocap_pos`` and
+  ``mocap_quat``.
+
 Version 1.1.1 (February 14, 2026)
 ---------------------------------
 

--- a/src/mjlab/viewer/debug_visualizer.py
+++ b/src/mjlab/viewer/debug_visualizer.py
@@ -76,6 +76,8 @@ class DebugVisualizer(ABC):
     self,
     qpos: np.ndarray | torch.Tensor,
     model: mujoco.MjModel,
+    mocap_pos: np.ndarray | torch.Tensor | None = None,
+    mocap_quat: np.ndarray | torch.Tensor | None = None,
     alpha: float = 0.5,
     label: str | None = None,
   ) -> None:
@@ -84,6 +86,8 @@ class DebugVisualizer(ABC):
     Args:
       qpos: Joint positions for the ghost pose.
       model: MuJoCo model with pre-configured appearance (geom_rgba for colors).
+      mocap_pos: Optional mocap position(s) for fixed-base entities.
+      mocap_quat: Optional mocap quaternion(s) for fixed-base entities.
       alpha: Transparency override (0=transparent, 1=opaque). May not be supported by
         all implementations.
       label: Optional label for this ghost.
@@ -186,7 +190,16 @@ class NullDebugVisualizer:
   def add_arrow(self, start, end, color, width=0.015, label=None) -> None:
     pass
 
-  def add_ghost_mesh(self, qpos, model, alpha=0.5, label=None) -> None:
+  def add_ghost_mesh(
+    self,
+    qpos,
+    model,
+    mocap_pos=None,
+    mocap_quat=None,
+    alpha=0.5,
+    label=None,
+  ) -> None:
+    del mocap_pos, mocap_quat
     pass
 
   def add_frame(


### PR DESCRIPTION
`DebugVisualizer.add_ghost_mesh` previously only accepted `qpos`, which is insufficient for fixed-base/mocap-driven entities where base pose comes from `mocap_pos` / `mocap_quat`.

This PR extends the ghost mesh API with optional mocap inputs and applies them in both viewer backends before forward kinematics.

Fixes #644.