### PR TITLE
Fix height_scan returning ~0 for missed rays

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -15,6 +15,10 @@ Changed
 Fixed
 ^^^^^
 
+- Fixed ``height_scan`` returning ~0 for missed rays; now defaults to
+  ``max_distance``. Replaced ``clip=(-1, 1)`` with ``scale`` normalization
+  in the velocity task config. Thanks to `@eufrizz <https://github.com/eufrizz>`_
+  for reporting and the initial fix (`#642 <https://github.com/mujocolab/mjlab/pull/642>`_).
 - Fixed ghost mesh visualization for fixed-base entities by extending
   ``DebugVisualizer.add_ghost_mesh`` to optionally accept ``mocap_pos`` and
   ``mocap_quat``.

--- a/src/mjlab/tasks/velocity/velocity_env_cfg.py
+++ b/src/mjlab/tasks/velocity/velocity_env_cfg.py
@@ -33,6 +33,21 @@ def make_velocity_env_cfg() -> ManagerBasedRlEnvCfg:
   """Create base velocity tracking task configuration."""
 
   ##
+  # Sensors
+  ##
+
+  terrain_scan = RayCastSensorCfg(
+    name="terrain_scan",
+    frame=ObjRef(type="body", name="", entity="robot"),  # Set per-robot.
+    ray_alignment="yaw",
+    pattern=GridPatternCfg(size=(1.6, 1.0), resolution=0.1),
+    max_distance=5.0,
+    exclude_parent_body=True,
+    debug_vis=True,
+    viz=RayCastSensorCfg.VizCfg(show_normals=True),
+  )
+
+  ##
   # Observations
   ##
 
@@ -68,7 +83,7 @@ def make_velocity_env_cfg() -> ManagerBasedRlEnvCfg:
       func=envs_mdp.height_scan,
       params={"sensor_name": "terrain_scan"},
       noise=Unoise(n_min=-0.1, n_max=0.1),
-      clip=(-1.0, 1.0),
+      scale=1 / terrain_scan.max_distance,
     ),
   }
 
@@ -77,7 +92,7 @@ def make_velocity_env_cfg() -> ManagerBasedRlEnvCfg:
     "height_scan": ObservationTermCfg(
       func=envs_mdp.height_scan,
       params={"sensor_name": "terrain_scan"},
-      clip=(-1.0, 1.0),
+      scale=1 / terrain_scan.max_distance,
     ),
     "foot_height": ObservationTermCfg(
       func=mdp.foot_height,
@@ -362,17 +377,6 @@ def make_velocity_env_cfg() -> ManagerBasedRlEnvCfg:
   ##
   # Assemble and return
   ##
-
-  terrain_scan = RayCastSensorCfg(
-    name="terrain_scan",
-    frame=ObjRef(type="body", name="", entity="robot"),  # Set per-robot.
-    ray_alignment="yaw",
-    pattern=GridPatternCfg(size=(1.6, 1.0), resolution=0.1),
-    max_distance=5.0,
-    exclude_parent_body=True,
-    debug_vis=True,
-    viz=RayCastSensorCfg.VizCfg(show_normals=True),
-  )
 
   return ManagerBasedRlEnvCfg(
     scene=SceneCfg(

--- a/tests/test_raycast_sensor.py
+++ b/tests/test_raycast_sensor.py
@@ -906,7 +906,7 @@ def test_height_scan_hits(robot_with_floor_xml, device):
 
 
 def test_height_scan_misses(device):
-  """height_scan reports ~0 for rays that miss (no ground)."""
+  """height_scan reports max_distance for rays that miss (no ground)."""
 
   no_floor_xml = """
     <mujoco>
@@ -939,5 +939,7 @@ def test_height_scan_misses(device):
   env = _FakeEnv(scene)
   heights = height_scan(env, "terrain_scan")  # type: ignore[invalid-argument-type]
 
-  # Misses: hit_pos_w == ray origin, so height ≈ 0.
-  assert torch.allclose(heights, torch.zeros_like(heights), atol=1e-5)
+  # Misses default to sensor max_distance.
+  assert torch.allclose(
+    heights, torch.full_like(heights, raycast_cfg.max_distance), atol=1e-5
+  )


### PR DESCRIPTION
Closes #642

- Fix `height_scan` returning ~0 for missed rays; defaults to `max_distance` instead, with a configurable `miss_value` parameter.
- Replace `clip=(-1, 1)` with `scale=1/max_distance` normalization in velocity task config to preserve full sensor range.