### PR TITLE
Bundle ffmpeg for mediapy via imageio-ffmpeg

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -15,6 +15,9 @@ Changed
 Fixed
 ^^^^^
 
+- Bundled ``ffmpeg`` for ``mediapy`` via ``imageio-ffmpeg``, removing the
+  requirement for a system ``ffmpeg`` install. Thanks to
+  `@rdeits-bd <https://github.com/rdeits-bd>`_ for the suggestion.
 - Fixed ``height_scan`` returning ~0 for missed rays; now defaults to
   ``max_distance``. Replaced ``clip=(-1, 1)`` with ``scale`` normalization
   in the velocity task config. Thanks to `@eufrizz <https://github.com/eufrizz>`_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
   "trimesh>=4.8.3",
   "viser>=1.0.21",
   "mediapy>=1.2.6",
+  "imageio-ffmpeg",
   "tensordict",
   "rsl-rl-lib==4.0.1",
   "tensorboard>=2.20.0",

--- a/src/mjlab/__init__.py
+++ b/src/mjlab/__init__.py
@@ -46,5 +46,14 @@ def _import_registered_packages() -> None:
       print(f"[WARN] Failed to load task package {entry_point.name}: {e}")
 
 
+def _configure_mediapy() -> None:
+  """Point mediapy at the bundled imageio-ffmpeg binary."""
+  import imageio_ffmpeg
+  import mediapy
+
+  mediapy.set_ffmpeg(imageio_ffmpeg.get_ffmpeg_exe())
+
+
 _configure_warp()
+_configure_mediapy()
 _import_registered_packages()

--- a/tests/test_video_recorder.py
+++ b/tests/test_video_recorder.py
@@ -1,17 +1,11 @@
 """Tests for video recording with mediapy."""
 
-import shutil
 from pathlib import Path
 from unittest.mock import Mock
 
 import mediapy as media
 import numpy as np
-import pytest
 import torch
-
-pytestmark = pytest.mark.skipif(
-  shutil.which("ffmpeg") is None, reason="ffmpeg not installed"
-)
 
 
 def _make_mock_env(num_envs: int = 1):

--- a/uv.lock
+++ b/uv.lock
@@ -939,6 +939,20 @@ wheels = [
 ]
 
 [[package]]
+name = "imageio-ffmpeg"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/44/bd/c3343c721f2a1b0c9fc71c1aebf1966a3b7f08c2eea8ed5437a2865611d6/imageio_ffmpeg-0.6.0.tar.gz", hash = "sha256:e2556bed8e005564a9f925bb7afa4002d82770d6b08825078b7697ab88ba1755", size = 25210, upload-time = "2025-01-16T21:34:32.747Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/58/87ef68ac83f4c7690961bce288fd8e382bc5f1513860fc7f90a9c1c1c6bf/imageio_ffmpeg-0.6.0-py3-none-macosx_10_9_intel.macosx_10_9_x86_64.whl", hash = "sha256:9d2baaf867088508d4a3458e61eeb30e945c4ad8016025545f66c4b5aaef0a61", size = 24932969, upload-time = "2025-01-16T21:34:20.464Z" },
+    { url = "https://files.pythonhosted.org/packages/40/5c/f3d8a657d362cc93b81aab8feda487317da5b5d31c0e1fdfd5e986e55d17/imageio_ffmpeg-0.6.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b1ae3173414b5fc5f538a726c4e48ea97edc0d2cdc11f103afee655c463fa742", size = 21113891, upload-time = "2025-01-16T21:34:00.277Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e7/1925bfbc563c39c1d2e82501d8372734a5c725e53ac3b31b4c2d081e895b/imageio_ffmpeg-0.6.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:1d47bebd83d2c5fc770720d211855f208af8a596c82d17730aa51e815cdee6dc", size = 25632706, upload-time = "2025-01-16T21:33:53.475Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/2d/43c8522a2038e9d0e7dbdf3a61195ecc31ca576fb1527a528c877e87d973/imageio_ffmpeg-0.6.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:c7e46fcec401dd990405049d2e2f475e2b397779df2519b544b8aab515195282", size = 29498237, upload-time = "2025-01-16T21:34:13.726Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/13/59da54728351883c3c1d9fca1710ab8eee82c7beba585df8f25ca925f08f/imageio_ffmpeg-0.6.0-py3-none-win32.whl", hash = "sha256:196faa79366b4a82f95c0f4053191d2013f4714a715780f0ad2a68ff37483cc2", size = 19652251, upload-time = "2025-01-16T21:34:06.812Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c6/fa760e12a2483469e2bf5058c5faff664acf66cadb4df2ad6205b016a73d/imageio_ffmpeg-0.6.0-py3-none-win_amd64.whl", hash = "sha256:02fa47c83703c37df6bfe4896aab339013f62bf02c5ebf2dce6da56af04ffc0a", size = 31246824, upload-time = "2025-01-16T21:34:28.6Z" },
+]
+
+[[package]]
 name = "imagesize"
 version = "1.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1583,6 +1597,7 @@ name = "mjlab"
 version = "1.1.1"
 source = { editable = "." }
 dependencies = [
+    { name = "imageio-ffmpeg" },
     { name = "mediapy" },
     { name = "mujoco" },
     { name = "mujoco-warp" },
@@ -1638,6 +1653,7 @@ docs = [
 
 [package.metadata]
 requires-dist = [
+    { name = "imageio-ffmpeg" },
     { name = "mediapy", specifier = ">=1.2.6" },
     { name = "mujoco", specifier = ">=3.5.0", index = "https://py.mujoco.org/" },
     { name = "mujoco-warp", git = "https://github.com/google-deepmind/mujoco_warp?rev=fc9158989525538db53a2a8c3c0f156cbfeca911" },


### PR DESCRIPTION
## Summary

- Adds `imageio-ffmpeg` as a dependency and configures `mediapy` to use its bundled ffmpeg binary at init, removing the need for a system ffmpeg install.

Thanks to @rdeits-bd for the suggestion in #637.