### PR TITLE
Use WarpBridge data for viser scene update

### DIFF
--- a/src/mjlab/viewer/viser/viewer.py
+++ b/src/mjlab/viewer/viser/viewer.py
@@ -224,7 +224,7 @@ class ViserPlayViewer(BaseViewer):
     def update_scene() -> None:
       with self._sim_lock:
         with self._server.atomic():
-          self._scene.update(sim.wp_data)
+          self._scene.update(sim.data)
           self._server.flush()
 
     self._threadpool.submit(update_scene)


### PR DESCRIPTION
## Summary
- Pass `sim.data` (WarpBridge) instead of `sim.wp_data` (raw mjwarp.Data) to the viser scene update
- Raw warp arrays lack `.cpu()`, which was added in #652, causing a silent AttributeError and blank viser screen

## Test plan
- [x] `uv run play Mjlab-Lift-Cube-Yam --viewer viser --agent zero` renders correctly
- [x] `make format` passes
- [x] `make type` passes
- [x] `make test-fast` passes (475 tests)