### PR TITLE
Add upload_model option to gate W&B model file uploads

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -5,6 +5,13 @@ Changelog
 Upcoming version (not yet released)
 -----------------------------------
 
+Added
+^^^^^
+
+- Added ``upload_model`` option to ``RslRlBaseRunnerCfg`` to control W&B model
+  file uploads (``.pt`` and ``.onnx``) while keeping metric logging enabled
+  (:gh:`654`).
+
 Changed
 ^^^^^^^
 

--- a/src/mjlab/rl/config.py
+++ b/src/mjlab/rl/config.py
@@ -111,6 +111,9 @@ class RslRlBaseRunnerCfg:
   """
   clip_actions: float | None = None
   """The clipping range for action values. If None (default), no clipping is applied."""
+  upload_model: bool = True
+  """Whether to upload model files (.pt, .onnx) to W&B on save. Set to
+  False to keep metric logging but avoid storage usage. Default is True."""
 
 
 @dataclass

--- a/src/mjlab/tasks/tracking/rl/runner.py
+++ b/src/mjlab/tasks/tracking/rl/runner.py
@@ -108,7 +108,7 @@ class MotionTrackingOnPolicyRunner(MjlabOnPolicyRunner):
       }
     )
     attach_metadata_to_onnx(os.path.join(policy_path, filename), metadata)
-    if self.logger.logger_type in ["wandb"]:
+    if self.logger.logger_type in ["wandb"] and self.cfg["upload_model"]:
       wandb.save(policy_path + filename, base_path=os.path.dirname(policy_path))
       if self.registry_name is not None:
         wandb.run.use_artifact(self.registry_name)  # type: ignore

--- a/src/mjlab/tasks/velocity/rl/runner.py
+++ b/src/mjlab/tasks/velocity/rl/runner.py
@@ -24,5 +24,5 @@ class VelocityOnPolicyRunner(MjlabOnPolicyRunner):
     onnx_path = os.path.join(policy_path, filename)
     metadata = get_base_metadata(self.env.unwrapped, run_name)
     attach_metadata_to_onnx(onnx_path, metadata)
-    if self.logger.logger_type in ["wandb"]:
+    if self.logger.logger_type in ["wandb"] and self.cfg["upload_model"]:
       wandb.save(policy_path + filename, base_path=os.path.dirname(policy_path))


### PR DESCRIPTION
Add `upload_model` flag to `RslRlBaseRunnerCfg` (default True) so users can disable W&B checkpoint uploads while keeping metric logging. Gates `.pt` uploads in `MjlabOnPolicyRunner` and `.onnx` uploads in the velocity and tracking task runners. Closes #654.