### PR TITLE
Add contributing guide and /update-mjwarp command

### DIFF
--- a/.claude/commands/update-mjwarp.md
+++ b/.claude/commands/update-mjwarp.md
@@ -1,0 +1,18 @@
+---
+allowed-tools: Bash(uv lock), Bash(git checkout:*), Bash(git add:*), Bash(git status:*), Bash(git push:*), Bash(git commit:*), Bash(gh pr create:*), Edit, Read
+description: Update the mujoco-warp dependency to a given commit
+---
+
+Update the mujoco-warp dependency to commit $ARGUMENTS.
+
+Steps:
+1. Read `pyproject.toml` and find the `mujoco-warp` line under `[tool.uv.sources]`.
+2. Use Edit to replace the current `rev = "..."` value with `rev = "$ARGUMENTS"` on that line.
+3. Run `uv lock` to regenerate the lockfile.
+4. Create and switch to a new branch named `update-mjwarp/<first-8-chars-of-hash>` (e.g. `update-mjwarp/e28c6038`).
+5. Stage `pyproject.toml` and `uv.lock`, then commit with message: `Update mujoco-warp to <first-8-chars-of-hash>`.
+6. Push the branch and open a PR with title `Update mujoco-warp to <first-8-chars-of-hash>`.
+
+Important:
+- The commit hash is required. If `$ARGUMENTS` is empty, ask the user for a commit hash.
+- Do NOT modify anything else in `pyproject.toml`.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -69,6 +69,7 @@ Table of Contents
 
    source/motivation
    source/faq
+   source/contributing
    source/changelog
 
 .. toctree::

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -17,6 +17,8 @@ Upcoming version (not yet released)
 Added
 ^^^^^
 
+- Contributing guide with documentation for shared Claude Code commands
+  (``/update-mjwarp``, ``/commit-push-pr``).
 - New ``dr`` module (``mjlab.envs.mdp.dr``) replacing ``randomize_field``
   with typed per-field domain randomization functions. Each function
   automatically recomputes derived fields via ``set_const``. Highlights:

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -1,0 +1,31 @@
+Contributing
+============
+
+See `CONTRIBUTING.md <https://github.com/mujocolab/mjlab/blob/main/CONTRIBUTING.md>`_
+for the general contribution workflow, including forking, testing, and changelog
+conventions.
+
+CLAUDE.md
+---------
+
+The repository includes a ``CLAUDE.md`` file at the project root. This file
+defines development conventions, style guidelines, and common commands for
+`Claude Code <https://claude.com/claude-code>`_. It is also a useful reference
+for human contributors since it captures the same rules enforced in CI.
+
+Claude Code Commands
+--------------------
+
+The project includes shared Claude Code commands in ``.claude/commands/``.
+Any contributor with Claude Code installed can invoke them as slash commands.
+
+``/update-mjwarp <commit-hash>``
+   Update the ``mujoco-warp`` dependency to a specific commit. This edits
+   ``pyproject.toml``, runs ``uv lock``, and opens a PR in one step.
+
+   .. code-block:: text
+
+      /update-mjwarp e28c6038cdf8a353b4146974e4cf37e74dda809a
+
+``/commit-push-pr``
+   Stage current changes, commit, push, and open a PR.


### PR DESCRIPTION
## Summary
- Add a contributing docs page with development setup and shared Claude Code commands
- Add the `/update-mjwarp` slash command that automates bumping the mujoco-warp dependency (edits pyproject.toml, locks, branches, commits, and opens a PR)
- Document both `/update-mjwarp` and `/commit-push-pr` on the new page

## Test plan
- [x] `make docs` builds without warnings
- [x] Contributing page renders correctly
- [x] `/update-mjwarp <hash>` works end to end

🤖 Generated with [Claude Code](https://claude.com/claude-code)