### PR TITLE
Implement mat_rgba randomization.

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -42,6 +42,10 @@ Added
     anywhere a string is accepted. Built-in instances (``dr.abs``,
     ``dr.scale``, ``dr.add``, ``dr.uniform``, ``dr.log_uniform``,
     ``dr.gaussian``) are exported from the ``dr`` module.
+  - ``dr.mat_rgba`` for per-world material color randomization. Tints
+    the texture color, useful for randomizing appearance of textured
+    surfaces. Material names are now supported in ``SceneEntityCfg``
+    (``material_names``).
   - Fixed ``dr.effort_limits`` drifting on repeated randomization.
   - Fixed ``dr.body_com_offset`` not triggering ``set_const``.
 
@@ -54,6 +58,14 @@ Added
   Inertia boxes (press ``I``) and camera frustums (press ``Q``) update
   correctly when the corresponding fields are randomized. See
   :doc:`randomization` for viewer-specific caveats.
+
+- ``MaterialCfg.geom_names_expr`` for assigning materials to geoms by
+  name pattern during ``edit_spec``.
+
+- ``TerrainEntityCfg`` now exposes ``textures``, ``materials``, and
+  ``lights`` as configurable fields (previously hardcoded). Set
+  ``textures=()``, ``materials=()`` to use flat ``dr.geom_rgba``
+  instead of the default checker texture.
 
 - ``DebugVisualizer`` now supports ellipsoid visualization via
   ``add_ellipsoid``.

--- a/docs/source/randomization.rst
+++ b/docs/source/randomization.rst
@@ -214,6 +214,21 @@ and ``dr.body_ipos`` are the same function).
      - Light direction vector
      -
 
+.. rubric:: Material fields
+
+.. list-table::
+   :header-rows: 1
+   :widths: 28 18 34 20
+
+   * - Function
+     - MuJoCo field
+     - Description
+     - Notes
+   * - ``dr.mat_rgba``
+     - ``mat_rgba``
+     - Material RGBA color (tints textures)
+     -
+
 .. rubric:: Tendon fields
 
 .. list-table::
@@ -600,8 +615,8 @@ don't have one yet. We will add them as demand arises.
        ``actuator_ctrlrange``, ``actuator_actrange``
      - ``pd_gains`` and ``effort_limits`` cover common cases.
    * - Material
-     - ``mat_rgba``, ``mat_texrepeat``
-     - Continuous per-world fields. Requires material-level entity
+     - ``mat_texrepeat``
+     - Continuous per-world field. Requires material-level entity
        indexing (selecting by material name).
 
 Better as custom code
@@ -1166,6 +1181,7 @@ The native viewer syncs per-world model fields from the GPU to a local
 toggles then work correctly against the randomized model:
 
 - Geom appearance (``geom_rgba``, ``geom_size``, ``geom_pos``, ``geom_quat``)
+- Material color (``mat_rgba``): tints textured surfaces
 - Body and site poses (``body_pos``, ``body_quat``, ``body_ipos``,
   ``site_pos``, ``site_quat``)
 - Inertia (``body_inertia``, ``body_iquat``, ``body_mass``): press ``I``
@@ -1197,10 +1213,14 @@ toggles then work correctly against the randomized model:
 
 .. note::
 
-   ``cam_fovy`` has no effect on the frustum visualization for cameras that
-   use intrinsic parameters (``sensorsize`` / ``focal`` set in XML). MuJoCo
-   draws those frustums from ``cam_intrinsic`` and ``cam_sensorsize``
-   instead. Use ``dr.cam_intrinsic`` to vary the frustum for such cameras.
+   ``cam_fovy`` has no effect on cameras that use intrinsic parameters
+   (``sensorsize`` / ``focal`` set in XML). This applies to both rendered
+   images and the frustum visualization. MuJoCo computes the projection
+   from ``cam_intrinsic`` and ``cam_sensorsize`` instead. Use
+   ``dr.cam_intrinsic`` to randomize the field of view for such cameras.
+   See the `MuJoCo camera documentation
+   <https://mujoco.readthedocs.io/en/stable/XMLreference.html#body-camera>`_
+   for details on how intrinsic parameters interact with ``fovy``.
 
 **Viser**
 

--- a/src/mjlab/envs/mdp/dr/__init__.py
+++ b/src/mjlab/envs/mdp/dr/__init__.py
@@ -69,6 +69,10 @@ from .camera import cam_quat as cam_quat
 from .light import light_dir as light_dir
 from .light import light_pos as light_pos
 
+# Material.
+# isort: split
+from .material import mat_rgba as mat_rgba
+
 # Actuator.
 # isort: split
 from .actuator import effort_limits as effort_limits

--- a/src/mjlab/envs/mdp/dr/_core.py
+++ b/src/mjlab/envs/mdp/dr/_core.py
@@ -38,6 +38,7 @@ _ENTITY_NAMES_ATTR: dict[str, str] = {
   "tendon": "tendon_names",
   "camera": "camera_names",
   "light": "light_names",
+  "material": "material_names",
 }
 
 # Private engine.
@@ -92,10 +93,11 @@ def _randomize_model_field(
   else:
     env_ids = env_ids.to(env.device, dtype=torch.int)
 
-  model_field = getattr(env.sim.model, field)
   entity_indices = _get_entity_indices(
     asset.indexing, asset_cfg, entity_type, use_address
   )
+
+  model_field = getattr(env.sim.model, field)
   target_axes = _determine_target_axes(
     model_field, axes, narrowed_ranges, default_axes, valid_axes
   )
@@ -210,6 +212,8 @@ def _get_entity_indices(
       return indexing.cam_ids[asset_cfg.camera_ids]
     case "light":
       return indexing.light_ids[asset_cfg.light_ids]
+    case "material":
+      return indexing.mat_ids[asset_cfg.material_ids]
     case _:
       raise ValueError(f"Unknown entity type: {entity_type}")
 

--- a/src/mjlab/envs/mdp/dr/material.py
+++ b/src/mjlab/envs/mdp/dr/material.py
@@ -1,0 +1,53 @@
+"""Domain randomization functions for material fields."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from mjlab.managers.event_manager import requires_model_fields
+from mjlab.managers.scene_entity_config import SceneEntityCfg
+
+from ._core import _DEFAULT_ASSET_CFG, _randomize_model_field
+from ._types import Distribution, Operation
+
+if TYPE_CHECKING:
+  import torch
+
+  from mjlab.envs import ManagerBasedRlEnv
+
+
+@requires_model_fields("mat_rgba")
+def mat_rgba(
+  env: ManagerBasedRlEnv,
+  env_ids: torch.Tensor | None,
+  ranges: tuple[float, float] | dict[int, tuple[float, float]],
+  asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
+  distribution: Distribution | str = "uniform",
+  operation: Operation | str = "abs",
+  axes: list[int] | None = None,
+) -> None:
+  """Randomize material RGBA color.
+
+  Args:
+    env: The environment instance.
+    env_ids: Environment indices to randomize. ``None`` means all.
+    ranges: Value range(s) for sampling.
+    asset_cfg: Entity and material selection. Use
+      ``SceneEntityCfg("entity", material_names=(...))`` to target
+      specific materials.
+    distribution: Sampling distribution.
+    operation: How to combine sampled values with the base.
+    axes: Which RGBA channels to randomize. Defaults to ``[0, 1, 2, 3]``.
+  """
+  _randomize_model_field(
+    env,
+    env_ids,
+    "mat_rgba",
+    entity_type="material",
+    ranges=ranges,
+    distribution=distribution,
+    operation=operation,
+    asset_cfg=asset_cfg,
+    axes=axes,
+    default_axes=[0, 1, 2, 3],
+  )

--- a/src/mjlab/managers/scene_entity_config.py
+++ b/src/mjlab/managers/scene_entity_config.py
@@ -40,6 +40,13 @@ _FIELD_CONFIGS = [
     "num_lights",
     "light",
   ),
+  _FieldConfig(
+    "material_names",
+    "material_ids",
+    "find_materials",
+    "num_materials",
+    "material",
+  ),
 ]
 
 
@@ -102,6 +109,12 @@ class SceneEntityCfg:
 
   light_ids: list[int] | slice = field(default_factory=lambda: slice(None))
   """IDs of lights to include. Can be a list or slice."""
+
+  material_names: str | tuple[str, ...] | None = None
+  """Names of materials to include. Can be a single string or tuple."""
+
+  material_ids: list[int] | slice = field(default_factory=lambda: slice(None))
+  """IDs of materials to include. Can be a list or slice."""
 
   preserve_order: bool = False
   """If True, maintains the order of components as specified."""

--- a/src/mjlab/sim/sim.py
+++ b/src/mjlab/sim/sim.py
@@ -259,7 +259,7 @@ class Simulation:
     self._model_bridge.clear_cache()
 
     if self._sensor_context is not None:
-      self._sensor_context.recreate(self._mj_model)
+      self._sensor_context.recreate(self._mj_model, self._expanded_fields)
 
     # Field expansion allocates new arrays and replaces them via setattr. The
     # CUDA graph captured the old memory addresses, so we must recreate it.

--- a/src/mjlab/viewer/native/viewer.py
+++ b/src/mjlab/viewer/native/viewer.py
@@ -223,6 +223,7 @@ class NativeMujocoViewer(BaseViewer):
       "geom_size",
       "geom_pos",
       "geom_quat",
+      "mat_rgba",
       "site_pos",
       "site_quat",
       "body_pos",

--- a/tests/test_spec_config.py
+++ b/tests/test_spec_config.py
@@ -221,3 +221,36 @@ def test_camera_cfg():
 
   camera = spec.camera("test_camera")
   assert camera.name == "test_camera"
+
+
+def test_material_cfg_geom_assignment():
+  """MaterialCfg.geom_names_expr assigns material to matching geoms."""
+  spec = mujoco.MjSpec()
+  body = spec.worldbody.add_body(name="test_body")
+  body.add_geom(
+    name="link1_visual",
+    type=mujoco.mjtGeom.mjGEOM_BOX,
+    size=[0.1, 0.1, 0.1],
+  )
+  body.add_geom(
+    name="link2_visual",
+    type=mujoco.mjtGeom.mjGEOM_BOX,
+    size=[0.1, 0.1, 0.1],
+  )
+  body.add_geom(
+    name="arm_collision",
+    type=mujoco.mjtGeom.mjGEOM_BOX,
+    size=[0.1, 0.1, 0.1],
+  )
+
+  mat_cfg = MaterialCfg(
+    name="my_mat",
+    texuniform=True,
+    texrepeat=(1, 1),
+    geom_names_expr=(r".*_visual$",),
+  )
+  mat_cfg.edit_spec(spec)
+
+  assert spec.geom("link1_visual").material == "my_mat"
+  assert spec.geom("link2_visual").material == "my_mat"
+  assert spec.geom("arm_collision").material == ""


### PR DESCRIPTION
- Add `dr.mat_rgba` for per-world material color randomization
- Add `MaterialCfg.geom_names_expr` for assigning materials to geoms by name pattern
- `TerrainEntityCfg` now exposes `textures`, `materials`, `lights` as configurable fields
- Fix `cam_intrinsic` / `cam_fovy` DR having no effect on rendered camera images (precomputed rays were not recomputed after field expansion)