### PR TITLE
Fix checker material being applied to procedural terrain geoms

### DIFF
--- a/src/mjlab/terrains/terrain_entity.py
+++ b/src/mjlab/terrains/terrain_entity.py
@@ -31,7 +31,7 @@ _DEFAULT_PLANE_MATERIAL = spec_cfg.MaterialCfg(
   texrepeat=(4, 4),
   reflectance=0.2,
   texture="groundplane",
-  geom_names_expr=("terrain",),
+  geom_names_expr=("terrain$",),
 )
 
 


### PR DESCRIPTION
## Summary

- `re.match` anchors at the start but not the end, so `geom_names_expr=("terrain",)` matched all `terrain_N` geoms produced by the terrain generator, causing the checker material to appear on rough terrains
- Fix: anchor the end with `$` → `"terrain$"`, so only the flat plane geom named exactly `"terrain"` is matched

## Test plan

- [x] Run `visualize_terrain` with a rough terrain — checker material should no longer appear
- [x] Run `visualize_terrain` with a flat plane — checker material should still appear correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)