### PR TITLE
fix types of default values

### DIFF
--- a/src/mjlab/utils/spec_config.py
+++ b/src/mjlab/utils/spec_config.py
@@ -271,13 +271,13 @@ class LightCfg(SpecCfg):
   """Light type ("spot" or "directional")."""
   castshadow: bool = True
   """Whether light casts shadows."""
-  pos: tuple[float, float, float] = (0, 0, 0)
+  pos: tuple[float, float, float] = (0.0, 0.0, 0.0)
   """Light position (x, y, z)."""
-  dir: tuple[float, float, float] = (0, 0, -1)
+  dir: tuple[float, float, float] = (0.0, 0.0, -1.0)
   """Light direction vector (x, y, z)."""
-  cutoff: float = 45
+  cutoff: float = 45.0
   """Spot light cutoff angle in degrees."""
-  exponent: float = 10
+  exponent: float = 10.0
   """Spot light exponent."""
 
   def edit_spec(self, spec: mujoco.MjSpec) -> None:
@@ -314,11 +314,11 @@ class CameraCfg(SpecCfg):
   """Camera mode ("fixed", "track", "trackcom", "targetbody", "targetbodycom")."""
   target: str | None = None
   """Target body for tracking modes (optional)."""
-  fovy: float = 45
+  fovy: float = 45.0
   """Field of view in degrees."""
-  pos: tuple[float, float, float] = (0, 0, 0)
+  pos: tuple[float, float, float] = (0.0, 0.0, 0.0)
   """Camera position (x, y, z)."""
-  quat: tuple[float, float, float, float] = (1, 0, 0, 0)
+  quat: tuple[float, float, float, float] = (1.0, 0.0, 0.0, 0.0)
   """Camera orientation quaternion (w, x, y, z)."""
 
   def edit_spec(self, spec: mujoco.MjSpec) -> None:


### PR DESCRIPTION
When using the default plane config I got the following error:

```
╭─ Invalid input to tyro.cli() ────────────────────────────────────────────────╮
│ The default value of the env.scene.terrain field could not be matched to any │
│ of its subcommands.                                                          │
│ ──────────────────────────────────────────────────────────────────────────── │
│                                                                              │
│ env.scene.terrain:terrain-entity-cfg was not a match because:                │
│ • Field lights has invalid default                                           │
│ • Field lights.0 has invalid default                                         │
│ • Field lights.0.cutoff has invalid default                                  │
│ • Default value 45 with type int does not match type <class 'float'>         │
│                                                                              │
│ env.scene.terrain:none was not a match because:                              │
│ • Default type <class 'mjlab.terrains.terrain_entity.TerrainEntityCfg'> is   │
│   not None                                                                   │
│                                                                              │
│ ──────────────────────────────────────────────────────────────────────────── │
│ Debugging: check that the field default matches a member of the union type.  │
╰──────────────────────────────────────────────────────────────────────────────╯ 
```

The scene was configured as follows:
```python
    scene = SceneCfg(
        entities={"robot": get_x02_robot_cfg()},
        sensors=(feet_contact_sensor_cfg, self_collision_cfg),
        env_spacing=0.0,
        terrain=TerrainEntityCfg(terrain_type="plane"),
    )
```


This PR fixes this problem.