### PR TITLE
Add CI workflow to build Docker

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -1,0 +1,98 @@
+name: Docker - Build MJlab Docker Image
+
+on:
+  workflow_dispatch:
+    inputs: {}
+
+  push:
+    branches:
+      - "main"
+
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+      - converted_to_draft
+      - labeled
+      - unlabeled
+
+concurrency:
+  group: ${{ github.repository }}-${{ github.workflow }}-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || ''}}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  FORCE_COLOR: 1
+  REGISTRY: ghcr.io
+  IMAGE_NAME: mujocolab/mjlab
+  DOCKERFILE_PATH: ./Dockerfile
+
+permissions:
+  id-token: write
+  packages: write
+  contents: write
+  pull-requests: write
+
+jobs:
+  check_paths:
+    runs-on: ubuntu-22.04
+    outputs:
+      build: ${{ steps.filter.outputs.any }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          list-files: shell
+          filters: |
+            any:
+              - ".github/workflows/build_docker.yml"
+              - "Dockerfile"
+
+  build_docker_mjlab:
+    name: docker_mjlab
+    needs: check_paths
+    if: ${{ needs.check_paths.outputs.build == 'true' }}
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log into registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push MJlab Docker image
+        id: build-container
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ env.DOCKERFILE_PATH }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: |
+            type=gha
+            type=registry,ref=ghcr.io/mujocolab/mjlab/mjlab:buildcache
+          cache-to: |
+            type=gha,mode=max
+            type=registry,ref=ghcr.io/mujocolab/mjlab/mjlab:buildcache,mode=max
+          platforms: linux/amd64


### PR DESCRIPTION
Add CI workflow to build Docker. See built package here: https://github.com/jiuguangw/mjlab/pkgs/container/mjlab

Workflow currently lacks permission: `ERROR: failed to build: failed to solve: failed to push ghcr.io/mujocolab/mjlab:pr-685: denied: installation not allowed to Create organization package`