### PR TITLE
Tag Docker image as :latest on push to main

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -71,6 +71,9 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -208,7 +208,7 @@ Prerequisites:
       .. code-block:: bash
 
          docker run --rm --runtime=nvidia --gpus all \
-           ghcr.io/mujocolab/mjlab:main uv run demo
+           ghcr.io/mujocolab/mjlab uv run demo
 
       The image is rebuilt on every push to ``main``.
 

--- a/scripts/cloud/train-docker.yaml
+++ b/scripts/cloud/train-docker.yaml
@@ -34,13 +34,13 @@ setup: |
     sleep 3  # Wait for the daemon to be ready before pulling.
   fi
 
-  sudo docker pull ghcr.io/mujocolab/mjlab:main
+  sudo docker pull ghcr.io/mujocolab/mjlab:latest
 
 run: |
   sudo docker run --rm --runtime=nvidia --gpus all \
     -v "$HOME/.netrc:/root/.netrc:ro" \
     -e MUJOCO_GL=egl \
-    ghcr.io/mujocolab/mjlab:main \
+    ghcr.io/mujocolab/mjlab:latest \
     uv run --no-dev train "$TASK" \
       --env.scene.num-envs "$NUM_ENVS" \
       --agent.max-iterations "$MAX_ITERATIONS" \


### PR DESCRIPTION
- Configure Docker metadata action to also tag `:latest` on pushes to main
- Update installation docs and `train-docker.yaml` to use `:latest` instead of `:main`