### PR TITLE
Fix viewer FPS drop caused by physics stepping loop

### DIFF
--- a/src/mjlab/viewer/base.py
+++ b/src/mjlab/viewer/base.py
@@ -247,16 +247,17 @@ class BaseViewer(ABC):
 
     wall_dt = self._timer.tick()
 
-    # Step physics based on accumulated sim-time budget.
+    # Step physics based on accumulated sim-time budget.  At most one
+    # env.step() per tick so that physics never starves the renderer.
+    # The budget is allowed to accumulate across ticks for catch-up, but
+    # is capped to avoid a spiral of death after long stalls.
     if not self._is_paused:
       step_dt = self.env.unwrapped.step_dt
       self._sim_time_budget += wall_dt * self._time_multiplier
-      # Cap budget to prevent spiral of death after long stalls.
       self._sim_time_budget = min(self._sim_time_budget, step_dt * 10)
 
       if self._sim_time_budget >= step_dt:
         self.sync_viewer_to_env()
-      while self._sim_time_budget >= step_dt:
         self.step_simulation()
         self._sim_time_budget -= step_dt
 


### PR DESCRIPTION
The physics/render decoupling in #663 introduced a while loop that drains the full sim-time budget in a single tick() call. At 1x speed this means multiple `env.step()` calls back-to-back per frame, starving the renderer and dropping FPS from ~30 to ~4 (on my M3 macbook at least, on a 5090 it was around 20-25!).

I fixed this by replacing the while loop with a single if statement, so at most one `env.step()` runs per `tick()` call. 
The catch-up still works, because when the budget exceeds `step_dt`, every subsequent `tick()` (~1ms apart in the `run()` loop) steps immediately until the budget is drained. 

The difference is that each step yields back to `run()`, giving the renderer a chance to check `time_until_next_render` between steps, instead of holding the entire frame hostage.

Before|After
--|--
![before](https://github.com/user-attachments/assets/cbc8c0a6-888b-41b7-8f21-0a2ee5ee9c00)|![after](https://github.com/user-attachments/assets/53dd6160-2f74-4ec1-a761-279ce31e9ba1)
