### PR TITLE
Fix viewer FPS drop with two-clock physics/render decoupling

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -103,6 +103,10 @@ Changed
 Fixed
 ^^^^^
 
+- Fixed viewer physics loop starving the renderer by replacing the single
+  sim-time budget with a two-clock design (tracked vs actual sim time).
+  Physics now self-corrects after overshooting, keeping FPS smooth at all
+  speed multipliers.
 - Bundled ``ffmpeg`` for ``mediapy`` via ``imageio-ffmpeg``, removing the
   requirement for a system ``ffmpeg`` install. Thanks to
   `@rdeits-bd <https://github.com/rdeits-bd>`_ for the suggestion.

--- a/tests/test_viewer_tick.py
+++ b/tests/test_viewer_tick.py
@@ -1,0 +1,96 @@
+"""Tests for the two-clock physics/render decoupling in BaseViewer.tick()."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from mjlab.viewer.base import BaseViewer
+
+
+class FakeViewer(BaseViewer):
+  """Minimal concrete viewer with controllable timing."""
+
+  def __init__(self, step_dt: float = 0.01, frame_rate: float = 60.0):
+    env = MagicMock()
+    env.unwrapped.step_dt = step_dt
+    env.cfg.viewer = MagicMock()
+    super().__init__(env, MagicMock(return_value=MagicMock()), frame_rate=frame_rate)
+    self.sim_step_count = 0
+
+  def setup(self) -> None: ...
+  def sync_env_to_viewer(self) -> None: ...
+  def sync_viewer_to_env(self) -> None: ...
+  def close(self) -> None: ...
+  def is_running(self) -> bool:
+    return True
+
+  def step_simulation(self) -> None:
+    self.sim_step_count += 1
+    self._step_count += 1
+    self._sps_accum_steps += 1
+
+  def inject_tick(self, wall_dt: float, step_wall_time: float | None = None) -> bool:
+    """Call tick() with controlled wall_dt and optional step_wall_time."""
+    self._timer.tick = lambda: wall_dt  # type: ignore[assignment]
+    if step_wall_time is not None:
+      self._step_wall_time = step_wall_time
+    return self.tick()
+
+
+def test_tick_stepping():
+  """Physics steps match sim-time budget: 1 step, 3 steps, then 0."""
+  v = FakeViewer(step_dt=0.01)
+  v.inject_tick(wall_dt=0.01, step_wall_time=0.0)
+  assert v.sim_step_count == 1
+
+  v.inject_tick(wall_dt=0.03, step_wall_time=0.0)
+  assert v.sim_step_count == 4
+
+  v.inject_tick(wall_dt=0.0, step_wall_time=0.0)
+  assert v.sim_step_count == 4  # No budget → no steps
+
+
+def test_budget_cap():
+  """Large wall_dt is capped to 10 steps (spiral-of-death prevention)."""
+  v = FakeViewer(step_dt=0.01)
+  v.inject_tick(wall_dt=1.0)
+  assert v.sim_step_count == 10
+
+
+def test_pause_and_resume():
+  """Pausing stops physics; resuming resyncs clocks (no catch-up burst)."""
+  v = FakeViewer(step_dt=0.01)
+  v.inject_tick(wall_dt=0.03, step_wall_time=0.0)
+  assert v.sim_step_count == 3
+
+  v.pause()
+  v.inject_tick(wall_dt=0.5)
+  assert v.sim_step_count == 3  # No steps while paused
+
+  v.resume()
+  v.inject_tick(wall_dt=0.01, step_wall_time=0.0)
+  assert v.sim_step_count == 4  # Exactly 1, no burst
+
+
+def test_step_wall_time_excluded_from_budget():
+  """Slow physics wall time is subtracted to prevent feedback spiral."""
+  v = FakeViewer(step_dt=0.01)
+  v.inject_tick(wall_dt=0.01, step_wall_time=0.0)
+  assert v.sim_step_count == 1
+
+  # wall_dt=15ms but 5ms was step time → idle_dt=10ms → 1 step, not 2.
+  v.inject_tick(wall_dt=0.015, step_wall_time=0.005)
+  assert v.sim_step_count == 2
+
+  # Stable: stays at 1 step/tick instead of spiraling.
+  v.inject_tick(wall_dt=0.015, step_wall_time=0.005)
+  assert v.sim_step_count == 3
+
+
+def test_render_independent_of_physics():
+  """Render timing follows frame_rate, not physics stepping."""
+  v = FakeViewer(step_dt=0.01, frame_rate=60.0)
+
+  assert v.inject_tick(wall_dt=0.001) is True  # First tick always renders
+  assert v.inject_tick(wall_dt=0.001) is False  # Too soon
+  assert v.inject_tick(wall_dt=1.0 / 60.0) is True  # Frame time elapsed


### PR DESCRIPTION
## Summary

Supersedes #693. Fixes the FPS drop introduced by the `while` loop in #663.

- Replace the single `_sim_time_budget` accumulator with two clocks (`_tracked_sim_time` vs `_actual_sim_time`), inspired by dm_control's viewer design.
- Subtract step execution wall time from the next tick's budget to break the feedback spiral where slow physics inflates `wall_dt` → more steps → even larger `wall_dt`.
- Add float tolerance (`1e-10`) to the deficit comparison to avoid missed steps from IEEE 754 rounding.
- Reset both clocks on `resume()` (prevents catch-up burst) and `reset_environment()`.

The `while` loop is kept but is now self-limiting: when physics overshoots a frame budget, the next tick(s) naturally run zero iterations, giving the renderer time to breathe.

**Before:** ~3 FPS on M3 MacBook (physics starves renderer every tick)
**After:** ~27 FPS (physics and render share wall time fairly)

## Test plan

- [x] `uv run pytest tests/test_viewer_tick.py -v` — 5 new tests (stepping, budget cap, pause/resume, feedback spiral prevention, render independence)
- [x] `make check` — format, lint, type checks pass
- [x] Manual: `uv run mjpython src/mjlab/scripts/demo.py --viewer native` — smooth FPS at 1x and slow-mo