### PR TITLE
Add research page with publications and projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,100 +83,11 @@ uv run play Mjlab-Your-Task-Id --agent random  # Sends uniform random actions
 When running motion-tracking tasks, add `--registry-name your-org/motions/motion-name` to the command.
 
 
-## Community Projects
+## Research
 
-mjlab is used for research and robotics applications around the world. Examples:
+mjlab is used in published research and open-source robotics projects around the world. See the [Research](https://mujocolab.github.io/mjlab/main/source/research.html) page for publications and projects.
 
-<table>
-  <tr>
-    <td>
-      <a href="https://github.com/menloresearch/asimov-mjlab">
-        menloresearch/asimov-mjlab
-        <br /><img
-          alt="GitHub stars"
-          src="https://img.shields.io/github/stars/menloresearch/asimov-mjlab?style=social"
-        />
-      </a>
-    </td>
-    <td>Locomotion fork for the Asimov bipedal robot.</td>
-  </tr>
-  <tr>
-    <td>
-      <a href="http://husky-humanoid.github.io/">
-        HUSKY
-      </a>
-      <br />
-      <a href="https://github.com/mujocolab/mjlab/discussions/572">#572</a>
-      ·
-      <a href="https://arxiv.org/abs/2602.03205">Paper</a>
-    </td>
-    <td>
-      Humanoid skateboarding with dynamic balance control.
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <a href="https://github.com/Nagi-ovo/mjlab-homierl">
-        Nagi-ovo/mjlab-homierl
-        <br /><img
-          alt="GitHub stars"
-          src="https://img.shields.io/github/stars/Nagi-ovo/mjlab-homierl?style=social"
-        />
-      </a>
-    </td>
-    <td>Multi-task H1 locomotion (walk/squat/stand) with upper-body disturbance robustness.</td>
-  </tr>
-  <tr>
-    <td>
-      <a href="https://github.com/MyoHub/mjlab_myosuite">
-        MyoHub/mjlab_myosuite
-        <br /><img
-          alt="GitHub stars"
-          src="https://img.shields.io/github/stars/MyoHub/mjlab_myosuite?style=social"
-        />
-      </a>
-    </td>
-    <td>Musculoskeletal simulation integration with MyoSuite.</td>
-  </tr>
-  <tr>
-    <td>
-      <a href="https://github.com/MarcDcls/mjlab_upkie">
-        MarcDcls/mjlab_upkie
-        <br /><img
-          alt="GitHub stars"
-          src="https://img.shields.io/github/stars/MarcDcls/mjlab_upkie?style=social"
-        />
-      </a>
-    </td>
-    <td>Velocity control for the Upkie wheeled biped.</td>
-  </tr>
-  <tr>
-    <td>
-      <a href="https://github.com/unitreerobotics/unitree_rl_mjlab">
-        unitreerobotics/unitree_rl_mjlab
-        <br /><img
-          alt="GitHub stars"
-          src="https://img.shields.io/github/stars/unitreerobotics/unitree_rl_mjlab?style=social"
-        />
-      </a>
-    </td>
-    <td>Official Unitree RL environments for Go2, G1, and H1_2.</td>
-  </tr>
-  <tr>
-    <td>
-      <a href="https://github.com/Msornerrrr/in-hand-rotation-mjlab">
-        Msornerrrr/in-hand-rotation-mjlab
-        <br /><img
-          alt="GitHub stars"
-          src="https://img.shields.io/github/stars/Msornerrrr/in-hand-rotation-mjlab?style=social"
-        />
-      </a>
-    </td>
-    <td>Sim-to-real RL for in-hand cube rotation with the LEAP Hand.</td>
-  </tr>
-</table>
-
-Want to share your project? Post in [Show and Tell](https://github.com/mujocolab/mjlab/discussions/categories/show-and-tell)!
+Want to share your work? Post in [Show and Tell](https://github.com/mujocolab/mjlab/discussions/categories/show-and-tell)!
 
 ## Documentation
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -95,6 +95,7 @@ Table of Contents
    source/motivation
    source/migration_isaac_lab
    source/faq
+   source/research
    source/changelog
 
 License & citation

--- a/docs/source/research.rst
+++ b/docs/source/research.rst
@@ -1,0 +1,65 @@
+.. _research:
+
+Research
+========
+
+Citing mjlab
+------------
+
+If you use mjlab in your research, please cite:
+
+.. code-block:: bibtex
+
+    @article{Zakka_mjlab_A_Lightweight_2026,
+        author = {Zakka, Kevin and Liao, Qiayuan and Yi, Brent and Le Lay, Louis and Sreenath, Koushil and Abbeel, Pieter},
+        title = {{mjlab: A Lightweight Framework for GPU-Accelerated Robot Learning}},
+        url = {https://arxiv.org/abs/2601.22074},
+        year = {2026}
+    }
+
+Publications
+------------
+
+Papers that use mjlab. To add your work, open a pull request or post in
+`Show and Tell <https://github.com/mujocolab/mjlab/discussions/categories/show-and-tell>`_.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 60 30 10
+
+   * - Title
+     - Authors
+     - Year
+   * - `HUSKY: Humanoid Skateboarding System via Physics-Aware Whole-Body Control
+       <https://arxiv.org/abs/2602.03205>`_
+     - Han, Wang, Zhang, Liu, Luo, Bai, Li
+     - 2026
+   * - `DynaRetarget: Dynamically-Feasible Retargeting using Sampling-Based
+       Trajectory Optimization <https://arxiv.org/abs/2602.06827>`_
+     - Dhedin, Taouil, Omar, Yu, Tao, Dai, Khadiv
+     - 2026
+
+Projects
+--------
+
+Projects built on mjlab. To add yours, open a pull request or post in
+`Show and Tell <https://github.com/mujocolab/mjlab/discussions/categories/show-and-tell>`_.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 65
+
+   * - Project
+     - Description
+   * - `menloresearch/asimov-mjlab <https://github.com/menloresearch/asimov-mjlab>`_
+     - Locomotion fork for the Asimov bipedal robot.
+   * - `Nagi-ovo/mjlab-homierl <https://github.com/Nagi-ovo/mjlab-homierl>`_
+     - H1 locomotion across multiple tasks with robustness to upper body disturbances.
+   * - `MyoHub/mjlab_myosuite <https://github.com/MyoHub/mjlab_myosuite>`_
+     - Musculoskeletal simulation integration with MyoSuite.
+   * - `MarcDcls/mjlab_upkie <https://github.com/MarcDcls/mjlab_upkie>`_
+     - Velocity control for the Upkie wheeled biped.
+   * - `unitreerobotics/unitree_rl_mjlab <https://github.com/unitreerobotics/unitree_rl_mjlab>`_
+     - Official Unitree RL environments for Go2, G1, and H1\_2.
+   * - `Msornerrrr/in-hand-rotation-mjlab <https://github.com/Msornerrrr/in-hand-rotation-mjlab>`_
+     - Sim to real RL for in hand cube rotation with the LEAP Hand.


### PR DESCRIPTION
## Summary

- Adds `docs/source/research.rst` with a Publications table (papers citing mjlab), a Projects table (community repos), and a BibTeX citation block for mjlab itself
- Replaces the HTML projects table in the README with a clean two-line section linking to the new page
- Adds the research page to the docs table of contents under Further Reading

## Test plan

- [ ] Build docs locally with `make docs` and verify the research page renders correctly
- [ ] Check that the publications and projects tables display as expected
- [ ] Verify the README link resolves once docs are deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)