### PR TITLE
Fix viewer physics loop starving renderer and debug overlay blinking

### DIFF
--- a/src/mjlab/viewer/base.py
+++ b/src/mjlab/viewer/base.py
@@ -351,12 +351,17 @@ class BaseViewer(ABC):
       deficit = self._tracked_sim_time - self._actual_sim_time
       if deficit >= step_dt - 1e-10:
         self.sync_viewer_to_env()
+        physics_start = time.perf_counter()
         while deficit >= step_dt - 1e-10:
           step_ok = self.step_simulation()
           if not step_ok:
             break
           self._actual_sim_time += step_dt
           deficit -= step_dt
+          # Yield to rendering after one frame-time of wall clock so
+          # physics doesn't starve the render loop on slow hardware.
+          if time.perf_counter() - physics_start > self.frame_time:
+            break
     else:
       self._forward_paused()
 

--- a/src/mjlab/viewer/viser/viewer.py
+++ b/src/mjlab/viewer/viser/viewer.py
@@ -14,7 +14,12 @@ import viser
 from typing_extensions import override
 
 from mjlab.sim.sim import Simulation
-from mjlab.viewer.base import BaseViewer, EnvProtocol, PolicyProtocol, VerbosityLevel
+from mjlab.viewer.base import (
+  BaseViewer,
+  EnvProtocol,
+  PolicyProtocol,
+  VerbosityLevel,
+)
 from mjlab.viewer.viser.overlays import (
   ViserCameraOverlays,
   ViserContactOverlays,
@@ -193,10 +198,15 @@ class ViserPlayViewer(BaseViewer):
     self._camera_update_last_ms = (time.perf_counter() - t0) * 1000.0
 
   def _queue_debug_visualizers(self) -> None:
-    """Queue environment-specific debug draw calls into the scene."""
+    """Queue environment-specific debug draw calls into the scene.
+
+    Acquires ``_sim_lock`` so the clear+requeue is atomic with respect
+    to the background thread that reads the queues in ``scene.update``.
+    """
     t0 = time.perf_counter()
     if self._debug_overlays:
-      self._debug_overlays.queue()
+      with self._sim_lock:
+        self._debug_overlays.queue()
     self._debug_queue_last_ms = (time.perf_counter() - t0) * 1000.0
 
   def _submit_scene_update_if_needed(
@@ -275,7 +285,14 @@ class ViserPlayViewer(BaseViewer):
     self._update_env_dependent_plots()
     has_pending_updates = bool(self._pending_update_reasons) or self._scene.needs_update
     self._update_camera_feeds(sim, has_pending_updates)
-    self._queue_debug_visualizers()
+    # Queue debug visualizers only when a scene update will actually be
+    # submitted.  Clearing the queues on skipped ticks creates a race
+    # with the background thread that causes debug overlays to blink.
+    will_submit = self._should_submit_scene_update(
+      self._counter, self._is_paused, has_pending_updates
+    )
+    if will_submit:
+      self._queue_debug_visualizers()
     self._submit_scene_update_if_needed(sim, has_pending_updates)
     self._maybe_log_debug_timings()
 


### PR DESCRIPTION
Add a wall time deadline to the physics loop so it yields to the renderer after one frame_time of wall clock. On slow hardware the old code would batch up to max_steps_per_tick (10) physics steps before rendering, causing 2 FPS even though the step rate was 20/s.

Fix debug visualization blinking in viser by only clearing and requeueing debug overlays on ticks that will actually submit a scene update, and by holding _sim_lock around the clear+requeue so the background thread cannot see a half cleared state.