### PR TITLE
Simplify viewer base class timing model

### DIFF
--- a/src/mjlab/viewer/base.py
+++ b/src/mjlab/viewer/base.py
@@ -1,8 +1,74 @@
-"""Base class for environment viewers."""
+"""Base class for environment viewers.
+
+The viewer runs a policy against an RL environment and displays the
+result in real time.
+
+The Problem
+===========
+
+Each call to ``env.step()`` advances the simulation by a fixed amount
+of sim time (``step_dt``, set by the env config). The simplest viewer
+would call ``env.step()`` once per loop iteration, but iterations take
+however long the hardware needs. A fast machine loops 67 times per
+second and the simulation runs too fast; a slow machine loops 30 times
+and it runs too slow. Playback speed would depend on hardware.
+
+The viewer needs to answer a different question: given how much real
+time just elapsed, how many calls to ``env.step()`` will keep the
+simulation advancing at the right pace?
+
+Budget Accumulator
+==================
+
+A single variable, ``_sim_budget``, tracks how much sim time has
+accumulated but not yet been simulated. Each tick of the main loop:
+
+  1. Measure real time elapsed since the last tick.
+  2. Multiply by the speed setting and add to the budget.
+  3. Call ``env.step()`` in a loop, subtracting ``step_dt`` from the
+     budget each time, until the budget is less than one step.
+  4. Carry the leftover to the next tick.
+
+Example at 1x speed, step_dt = 0.02s (50 Hz control), 60 fps::
+
+  tick 1:  +0.0167s  ->  budget = 0.0167  ->  no step (< 0.02)
+  tick 2:  +0.0167s  ->  budget = 0.0334  ->  1 step, 0.0134 left
+  tick 3:  +0.0167s  ->  budget = 0.0301  ->  1 step, 0.0101 left
+  ...
+
+This averages to 50 steps per second on any hardware. At 2x speed the
+elapsed time is doubled before adding to the budget, so steps happen
+twice as often. At 0.5x, half as often.
+
+Rendering is independent: the display refreshes at ``frame_rate``
+(e.g. 60 Hz) whether or not a new step happened. Some frames will
+re-display the same state.
+
+If physics is too slow to keep up, the budget grows without bound. A
+real time deadline (one frame period) caps each burst so the renderer
+always gets a turn. Leftover budget is dropped and ``_was_capped`` is
+set.
+
+Main Loop
+=========
+
+::
+
+  run()
+    setup()
+    while running:
+      tick()                    -> True if a frame was produced
+        _process_actions()      drain UI action queue
+        _step_physics(dt)       accumulate budget, step until spent
+        sync_env_to_viewer()    push state to display (at frame_rate)
+      sleep(1ms)                yield CPU when no frame is due
+
+Subclasses implement setup(), sync_env_to_viewer(), sync_viewer_to_env(),
+close(), and is_running().
+"""
 
 from __future__ import annotations
 
-import contextlib
 import time
 import traceback
 from abc import ABC, abstractmethod
@@ -21,28 +87,6 @@ class VerbosityLevel(IntEnum):
   SILENT = 0
   INFO = 1
   DEBUG = 2
-
-
-class Timer:
-  def __init__(self):
-    self._previous_time = time.time()
-    self._measured_time = 0.0
-
-  def tick(self):
-    curr_time = time.time()
-    self._measured_time = curr_time - self._previous_time
-    self._previous_time = curr_time
-    return self._measured_time
-
-  @contextlib.contextmanager
-  def measure_time(self):
-    start_time = time.time()
-    yield
-    self._measured_time = time.time() - start_time
-
-  @property
-  def measured_time(self):
-    return self._measured_time
 
 
 class EnvProtocol(Protocol):
@@ -118,48 +162,32 @@ class BaseViewer(ABC):
     self.verbosity = VerbosityLevel(verbosity)
     self.cfg = env.cfg.viewer
 
-    # Loop state.
+    # State.
     self._is_paused = False
     self._step_count = 0
     self._last_error: str | None = None
-    self._max_steps_per_tick: int = 10
 
-    # Timing.
-    self._timer = Timer()
-    self._sim_timer = Timer()
-    self._render_timer = Timer()
-    self._tracked_sim_time = 0.0  # Expected sim time (wall_dt * multiplier)
-    self._actual_sim_time = 0.0  # Real sim time (advances by step_dt)
-    self._time_until_next_render = 0.0
-
+    # Speed.
     self._speed_index = self.SPEED_MULTIPLIERS.index(1.0)
     self._time_multiplier = self.SPEED_MULTIPLIERS[self._speed_index]
 
-    # Perf tracking.
-    self._frame_count = 0
-    self._last_fps_log_time = 0.0
-    self._accumulated_sim_time = 0.0
-    self._accumulated_render_time = 0.0
+    # Physics accumulator and render timer.
+    self._sim_budget = 0.0
+    self._time_until_next_render = 0.0
+    self._last_tick_time = 0.0
+    self._was_capped = False
 
-    # FPS and realtime tracking.
-    self._smoothed_fps: float = 0.0
-    self._smoothed_sps: float = 0.0
-    self._fps_accum_frames: int = 0
-    self._sps_accum_steps: int = 0
-    self._fps_accum_time: float = 0.0
-    self._fps_last_frame_time: Optional[float] = None
-    self._fps_update_interval: float = 0.5
-    self._fps_alpha: float = 0.35
+    # Windowed stats, updated every 0.5s.
+    self._stats_frames = 0
+    self._stats_steps = 0
+    self._stats_last_time = 0.0
+    self._fps = 0.0
+    self._sps = 0.0
 
-    # Capped indicator: true when max_steps_per_tick was hit recently.
-    self._capped_ticks: int = 0
-    self._capped_window: int = 0
-    self._is_capped: bool = False
-
-    # Thread-safe action queue (drained in main loop).
+    # Action queue, drained on main thread each tick.
     self._actions: deque[tuple[ViewerAction, Optional[Any]]] = deque()
 
-  # Abstract hooks every concrete viewer must implement.
+  # Abstract hooks.
 
   @abstractmethod
   def setup(self) -> None: ...
@@ -172,13 +200,20 @@ class BaseViewer(ABC):
   @abstractmethod
   def is_running(self) -> bool: ...
 
+  def _forward_paused(self) -> None:  # noqa: B027
+    """Hook for subclasses to run forward kinematics while paused."""
+
+  def _handle_custom_action(self, action: ViewerAction, payload: Optional[Any]) -> bool:
+    del action, payload
+    return False
+
   # Logging.
 
   def log(self, message: str, level: VerbosityLevel = VerbosityLevel.INFO) -> None:
     if self.verbosity >= level:
       print(message)
 
-  # Public controls.
+  # Thread-safe action requests.
 
   def request_reset(self) -> None:
     self._actions.append((ViewerAction.RESET, None))
@@ -199,33 +234,61 @@ class BaseViewer(ABC):
     self._actions.append((ViewerAction.RESET_SPEED, None))
 
   def request_action(self, name: str, payload: Optional[Any] = None) -> None:
-    """Viewer-specific actions (e.g., PREV_ENV/NEXT_ENV for native)."""
     try:
       action = ViewerAction[name]
     except KeyError:
       action = ViewerAction.CUSTOM
     self._actions.append((action, payload))
 
+  # Speed controls.
+
+  def increase_speed(self) -> None:
+    if self._speed_index < len(self.SPEED_MULTIPLIERS) - 1:
+      self._speed_index += 1
+      self._time_multiplier = self.SPEED_MULTIPLIERS[self._speed_index]
+
+  def decrease_speed(self) -> None:
+    if self._speed_index > 0:
+      self._speed_index -= 1
+      self._time_multiplier = self.SPEED_MULTIPLIERS[self._speed_index]
+
+  def reset_speed(self) -> None:
+    self._speed_index = self.SPEED_MULTIPLIERS.index(1.0)
+    self._time_multiplier = 1.0
+
+  # Pause and resume.
+
+  def pause(self) -> None:
+    self._is_paused = True
+    self.log("[INFO] Simulation paused", VerbosityLevel.INFO)
+
+  def resume(self) -> None:
+    self._is_paused = False
+    self._last_error = None
+    self._sim_budget = 0.0
+    self._last_tick_time = time.perf_counter()
+    self.log("[INFO] Simulation resumed", VerbosityLevel.INFO)
+
+  def toggle_pause(self) -> None:
+    if self._is_paused:
+      self.resume()
+    else:
+      self.pause()
+
   # Core loop.
 
   def _execute_step(self) -> bool:
-    """Run one obs/policy/step cycle. No pause check.
+    """Run one obs/policy/step cycle.
 
     Returns True on success, False if step failed.
     """
-    # Wrap in no_grad mode to prevent gradient accumulation and memory leaks.
-    # NOTE: Using torch.inference_mode() causes a "RuntimeError: Inplace update to
-    # inference tensor outside InferenceMode is not allowed" inside the command
-    # manager when resetting the env with a key callback.
     try:
       with torch.no_grad():
-        with self._sim_timer.measure_time():
-          obs = self.env.get_observations()
-          actions = self.policy(obs)
-          self.env.step(actions)
-          self._step_count += 1
-          self._sps_accum_steps += 1
-        self._accumulated_sim_time += self._sim_timer.measured_time
+        obs = self.env.get_observations()
+        actions = self.policy(obs)
+        self.env.step(actions)
+        self._step_count += 1
+        self._stats_steps += 1
         return True
     except Exception:
       self._last_error = traceback.format_exc()
@@ -236,49 +299,47 @@ class BaseViewer(ABC):
       self.pause()
       return False
 
-  def step_simulation(self) -> bool:
-    if self._is_paused:
-      return False
-    return self._execute_step()
+  def _step_physics(self, dt: float) -> None:
+    """Run physics steps for this frame's sim-time budget."""
+    step_dt = self.env.unwrapped.step_dt
+    self._sim_budget += dt * self._time_multiplier
+    self._was_capped = False
+
+    if self._sim_budget < step_dt:
+      return
+
+    self.sync_viewer_to_env()
+    hit_deadline = False
+    deadline = time.perf_counter() + self.frame_time
+    while self._sim_budget >= step_dt:
+      if not self._execute_step():
+        self._sim_budget = 0.0
+        return
+      self._sim_budget -= step_dt
+      if time.perf_counter() > deadline:
+        hit_deadline = True
+        break
+
+    if hit_deadline:
+      # Only report capped if we actually had to drop remaining work. A transient stall
+      # (GC pause) during a single step triggers the deadline but leaves no remaining
+      # budget, so it's not a real cap.
+      self._was_capped = self._sim_budget >= step_dt
+      self._sim_budget = min(self._sim_budget, step_dt)
 
   def _single_step(self) -> None:
     """Advance exactly one step while paused."""
     if not self._is_paused:
       return
     self.sync_viewer_to_env()
-    step_ok = self._execute_step()
-    if not step_ok:
-      return
-    step_dt = self.env.unwrapped.step_dt
-    self._actual_sim_time += step_dt
-    self._tracked_sim_time = self._actual_sim_time
+    self._execute_step()
 
   def reset_environment(self) -> None:
     self.env.reset()
     self._step_count = 0
-    self._tracked_sim_time = 0.0
-    self._actual_sim_time = 0.0
+    self._sim_budget = 0.0
     self._last_error = None
-    self._timer.tick()
-
-  def pause(self) -> None:
-    self._is_paused = True
-    self._fps_last_frame_time = None
-    self.log("[INFO] Simulation paused", VerbosityLevel.INFO)
-
-  def resume(self) -> None:
-    self._is_paused = False
-    self._last_error = None
-    self._tracked_sim_time = self._actual_sim_time  # Prevent catch-up burst
-    self._timer.tick()
-    self._fps_last_frame_time = time.time()
-    self.log("[INFO] Simulation resumed", VerbosityLevel.INFO)
-
-  def toggle_pause(self) -> None:
-    if self._is_paused:
-      self.resume()
-    else:
-      self.pause()
+    self._last_tick_time = time.perf_counter()
 
   def _process_actions(self) -> None:
     """Drain action queue. Runs on the main loop thread."""
@@ -297,71 +358,26 @@ class BaseViewer(ABC):
       elif action == ViewerAction.SPEED_DOWN:
         self.decrease_speed()
       else:
-        # Hook for subclasses to handle PREV_ENV/NEXT_ENV or CUSTOM actions
         _ = self._handle_custom_action(action, payload)
 
-  def _handle_custom_action(self, action: ViewerAction, payload: Optional[Any]) -> bool:
-    del action, payload  # Unused.
-    return False
-
-  def _forward_paused(self) -> None:  # noqa: B027
-    """Hook for subclasses to run forward kinematics while paused."""
-
   def tick(self) -> bool:
-    """Advance the viewer by one tick.
-
-    Physics and rendering are decoupled: physics steps are governed by a
-    sim-time budget (accumulated from wall time * speed multiplier), while
-    rendering always happens at the configured ``frame_rate``. This keeps
-    the display smooth even at slow playback speeds.
+    """Advance one tick: drain actions, step physics, maybe render.
 
     Returns True when a render frame was produced, False otherwise.
     """
+    now = time.perf_counter()
+    dt = now - self._last_tick_time
+    self._last_tick_time = now
+
     self._process_actions()
 
-    wall_dt = self._timer.tick()
-
-    # Step physics using two-clock decoupling: tracked time (where sim
-    # *should* be) vs actual time (where it *is*).  When physics overshoots
-    # a frame budget the next tick naturally runs zero iterations, giving
-    # the renderer a chance to breathe.
-    if not self._is_paused:
-      step_dt = self.env.unwrapped.step_dt
-
-      self._tracked_sim_time += wall_dt * self._time_multiplier
-
-      # Cap: don't let tracked time race more than N steps ahead.
-      max_lead = step_dt * self._max_steps_per_tick
-      hit_cap = self._tracked_sim_time - self._actual_sim_time > max_lead
-      if hit_cap:
-        self._tracked_sim_time = self._actual_sim_time + max_lead
-
-      # Track whether the cap is hit repeatedly (over a sliding window).
-      self._capped_window += 1
-      if hit_cap:
-        self._capped_ticks += 1
-      if self._capped_window >= 30:
-        self._is_capped = self._capped_ticks > self._capped_window // 2
-        self._capped_ticks = 0
-        self._capped_window = 0
-
-      # Step physics until actual time catches up to tracked time.
-      # Use a small tolerance to avoid missing steps due to float rounding
-      # (e.g. 0.015 - 0.005 = 0.009999… instead of 0.01).
-      deficit = self._tracked_sim_time - self._actual_sim_time
-      if deficit >= step_dt - 1e-10:
-        self.sync_viewer_to_env()
-        while deficit >= step_dt - 1e-10:
-          step_ok = self.step_simulation()
-          if not step_ok:
-            break
-          self._actual_sim_time += step_dt
-          deficit -= step_dt
-    else:
+    if self._is_paused:
       self._forward_paused()
+    else:
+      self._step_physics(dt)
 
-    # Render at fixed frame rate, independent of physics speed.
-    self._time_until_next_render -= wall_dt
+    # Render at fixed frame rate.
+    self._time_until_next_render -= dt
     if self._time_until_next_render > 0:
       return False
 
@@ -369,51 +385,60 @@ class BaseViewer(ABC):
     if self._time_until_next_render < -self.frame_time:
       self._time_until_next_render = 0.0
 
-    with self._render_timer.measure_time():
-      self.sync_env_to_viewer()
-    self._accumulated_render_time += self._render_timer.measured_time
-    self._frame_count += 1
-    self._update_fps()
-
-    if self.verbosity >= VerbosityLevel.DEBUG:
-      now = time.time()
-      if now - self._last_fps_log_time >= 1.0:
-        self.log_performance()
-        self._last_fps_log_time = now
-        self._frame_count = 0
-        self._accumulated_sim_time = 0.0
-        self._accumulated_render_time = 0.0
-
+    self.sync_env_to_viewer()
+    self._stats_frames += 1
     return True
 
   def run(self, num_steps: Optional[int] = None) -> None:
     self.setup()
-    self._last_fps_log_time = time.time()
-    self._timer.tick()
-    self._fps_last_frame_time = time.time()
+    now = time.perf_counter()
+    self._stats_last_time = now
+    self._last_tick_time = now
     try:
       while self.is_running() and (num_steps is None or self._step_count < num_steps):
         if not self.tick():
           time.sleep(0.001)
+        self._update_stats()
     finally:
       self.close()
 
+  # Stats.
+
+  def _update_stats(self) -> None:
+    if self._is_paused:
+      return
+    now = time.perf_counter()
+    dt = now - self._stats_last_time
+    if dt >= 0.5:
+      self._fps = self._stats_frames / dt
+      self._sps = self._stats_steps / dt
+      self._stats_frames = 0
+      self._stats_steps = 0
+      self._stats_last_time = now
+
+      if self.verbosity >= VerbosityLevel.DEBUG:
+        status = self.get_status()
+        print(
+          f"[{'PAUSED' if status.paused else 'RUNNING'}] "
+          f"Step {status.step_count} | "
+          f"FPS: {status.smoothed_fps:.0f} | "
+          f"Speed: {status.speed_label} | "
+          f"RTF: {status.actual_realtime:.2f}x / "
+          f"{status.target_realtime:.2f}x"
+        )
+
   @property
   def target_realtime(self) -> float:
-    """Target realtime factor based on the current speed multiplier."""
     return self._time_multiplier
 
   @property
   def actual_realtime(self) -> float:
-    """Actual realtime factor based on smoothed steps per second."""
-    return self._smoothed_sps * self.env.unwrapped.step_dt
+    return self._sps * self.env.unwrapped.step_dt
 
   @staticmethod
   def _format_speed(multiplier: float) -> str:
-    """Format speed multiplier as a human-readable string (e.g. '1/4x')."""
     if multiplier == 1.0:
       return "1x"
-    # Check for clean power-of-2 fractions.
     inv = 1.0 / multiplier
     inv_rounded = round(inv)
     if abs(inv - inv_rounded) < 1e-9 and inv_rounded > 0:
@@ -421,7 +446,6 @@ class BaseViewer(ABC):
     return f"{multiplier:.3g}x"
 
   def get_status(self) -> ViewerStatus:
-    """Build a read-only status snapshot for viewer UIs."""
     return ViewerStatus(
       paused=self._is_paused,
       step_count=self._step_count,
@@ -429,62 +453,7 @@ class BaseViewer(ABC):
       speed_label=self._format_speed(self._time_multiplier),
       target_realtime=self.target_realtime,
       actual_realtime=self.actual_realtime,
-      smoothed_fps=self._smoothed_fps,
-      capped=self._is_capped,
+      smoothed_fps=self._fps,
+      capped=self._was_capped,
       last_error=self._last_error,
     )
-
-  def log_performance(self) -> None:
-    if self._frame_count > 0:
-      status = self.get_status()
-      avg_sim_ms = self._accumulated_sim_time / self._frame_count * 1000
-      avg_render_ms = self._accumulated_render_time / self._frame_count * 1000
-      total_ms = avg_sim_ms + avg_render_ms
-      print(
-        f"[{'PAUSED' if status.paused else 'RUNNING'}] "
-        f"Step {status.step_count} | FPS: {self._frame_count:.1f} | "
-        f"Speed: {status.speed_label} | Sim: {avg_sim_ms:.1f}ms | "
-        f"Render: {avg_render_ms:.1f}ms | "
-        f"Total: {total_ms:.1f}ms"
-      )
-
-  def increase_speed(self) -> None:
-    if self._speed_index < len(self.SPEED_MULTIPLIERS) - 1:
-      self._speed_index += 1
-      self._time_multiplier = self.SPEED_MULTIPLIERS[self._speed_index]
-
-  def decrease_speed(self) -> None:
-    if self._speed_index > 0:
-      self._speed_index -= 1
-      self._time_multiplier = self.SPEED_MULTIPLIERS[self._speed_index]
-
-  def reset_speed(self) -> None:
-    self._speed_index = self.SPEED_MULTIPLIERS.index(1.0)
-    self._time_multiplier = 1.0
-
-  def _update_fps(self) -> None:
-    if self._is_paused:
-      return
-    now = time.time()
-    if self._fps_last_frame_time is None:
-      self._fps_last_frame_time = now
-      return
-    dt = now - self._fps_last_frame_time
-    self._fps_last_frame_time = now
-    if dt <= 0:
-      return
-    self._fps_accum_frames += 1
-    self._fps_accum_time += dt
-    if self._fps_accum_time >= self._fps_update_interval:
-      alpha = self._fps_alpha
-      inst_fps = self._fps_accum_frames / self._fps_accum_time
-      inst_sps = self._sps_accum_steps / self._fps_accum_time
-      if self._smoothed_fps == 0.0:
-        self._smoothed_fps = inst_fps
-        self._smoothed_sps = inst_sps
-      else:
-        self._smoothed_fps = alpha * inst_fps + (1 - alpha) * self._smoothed_fps
-        self._smoothed_sps = alpha * inst_sps + (1 - alpha) * self._smoothed_sps
-      self._fps_accum_frames = 0
-      self._sps_accum_steps = 0
-      self._fps_accum_time = 0.0

--- a/src/mjlab/viewer/viser/viewer.py
+++ b/src/mjlab/viewer/viser/viewer.py
@@ -14,7 +14,12 @@ import viser
 from typing_extensions import override
 
 from mjlab.sim.sim import Simulation
-from mjlab.viewer.base import BaseViewer, EnvProtocol, PolicyProtocol, VerbosityLevel
+from mjlab.viewer.base import (
+  BaseViewer,
+  EnvProtocol,
+  PolicyProtocol,
+  VerbosityLevel,
+)
 from mjlab.viewer.viser.overlays import (
   ViserCameraOverlays,
   ViserContactOverlays,
@@ -193,10 +198,15 @@ class ViserPlayViewer(BaseViewer):
     self._camera_update_last_ms = (time.perf_counter() - t0) * 1000.0
 
   def _queue_debug_visualizers(self) -> None:
-    """Queue environment-specific debug draw calls into the scene."""
+    """Queue environment-specific debug draw calls into the scene.
+
+    Acquires ``_sim_lock`` so the clear+requeue is atomic with respect
+    to the background thread that reads the queues in ``scene.update``.
+    """
     t0 = time.perf_counter()
     if self._debug_overlays:
-      self._debug_overlays.queue()
+      with self._sim_lock:
+        self._debug_overlays.queue()
     self._debug_queue_last_ms = (time.perf_counter() - t0) * 1000.0
 
   def _submit_scene_update_if_needed(
@@ -275,7 +285,14 @@ class ViserPlayViewer(BaseViewer):
     self._update_env_dependent_plots()
     has_pending_updates = bool(self._pending_update_reasons) or self._scene.needs_update
     self._update_camera_feeds(sim, has_pending_updates)
-    self._queue_debug_visualizers()
+    # Queue debug visualizers only when a scene update will actually be
+    # submitted.  Clearing the queues on skipped ticks creates a race
+    # with the background thread that causes debug overlays to blink.
+    will_submit = self._should_submit_scene_update(
+      self._counter, self._is_paused, has_pending_updates
+    )
+    if will_submit:
+      self._queue_debug_visualizers()
     self._submit_scene_update_if_needed(sim, has_pending_updates)
     self._maybe_log_debug_timings()
 

--- a/tests/test_viewer_tick.py
+++ b/tests/test_viewer_tick.py
@@ -1,14 +1,15 @@
-"""Tests for the two-clock physics/render decoupling in BaseViewer.tick()."""
+"""Tests for the single-accumulator BaseViewer in base_alt.py."""
 
 from __future__ import annotations
 
+import time
 from unittest.mock import MagicMock
 
 from mjlab.viewer.base import BaseViewer
 
 
 class FakeViewer(BaseViewer):
-  """Minimal concrete viewer with controllable timing."""
+  """Minimal concrete viewer for testing."""
 
   def __init__(self, step_dt: float = 0.01, frame_rate: float = 60.0):
     env = MagicMock()
@@ -16,9 +17,14 @@ class FakeViewer(BaseViewer):
     env.cfg.viewer = MagicMock()
     super().__init__(env, MagicMock(return_value=MagicMock()), frame_rate=frame_rate)
     self.sim_step_count = 0
+    self.render_count = 0
+    self._last_tick_time = time.perf_counter()
 
   def setup(self) -> None: ...
-  def sync_env_to_viewer(self) -> None: ...
+
+  def sync_env_to_viewer(self) -> None:
+    self.render_count += 1
+
   def sync_viewer_to_env(self) -> None: ...
   def close(self) -> None: ...
   def is_running(self) -> bool:
@@ -27,152 +33,158 @@ class FakeViewer(BaseViewer):
   def _execute_step(self) -> bool:
     self.sim_step_count += 1
     self._step_count += 1
-    self._sps_accum_steps += 1
+    self._stats_steps += 1
     return True
 
-  def inject_tick(self, wall_dt: float) -> bool:
-    """Call tick() with controlled wall_dt."""
-    self._timer.tick = lambda: wall_dt  # type: ignore[assignment]
+  def inject_tick(self, dt: float) -> bool:
+    """Call tick() with a controlled dt."""
+    now = time.perf_counter()
+    self._last_tick_time = now - dt
     return self.tick()
 
 
-def test_tick_stepping():
-  """Physics steps match sim-time budget: 1 step, 3 steps, then 0."""
+# Physics stepping.
+
+
+def test_stepping():
+  """Physics steps match sim-time budget."""
   v = FakeViewer(step_dt=0.01)
-  v.inject_tick(wall_dt=0.01)
+  v.inject_tick(dt=0.01)
   assert v.sim_step_count == 1
 
-  v.inject_tick(wall_dt=0.03)
+  v.inject_tick(dt=0.03)
   assert v.sim_step_count == 4
 
-  v.inject_tick(wall_dt=0.0)
-  assert v.sim_step_count == 4  # No budget → no steps
+  v.inject_tick(dt=0.0)
+  assert v.sim_step_count == 4
 
 
-def test_budget_cap():
-  """Large wall_dt is capped to max_steps_per_tick (spiral-of-death prevention)."""
+def test_accumulator_carries():
+  """Fractional budget carries across ticks."""
   v = FakeViewer(step_dt=0.01)
-  v.inject_tick(wall_dt=1.0)
-  assert v.sim_step_count == 10
+  v.inject_tick(dt=0.01)
+  assert v.sim_step_count == 1
 
-  # Also works with a custom cap.
-  v2 = FakeViewer(step_dt=0.01)
-  v2._max_steps_per_tick = 5
-  v2.inject_tick(wall_dt=1.0)
-  assert v2.sim_step_count == 5
+  v.inject_tick(dt=0.015)
+  assert v.sim_step_count == 2  # 0.015 budget, 1 step, 0.005 carry
+
+  v.inject_tick(dt=0.015)
+  assert v.sim_step_count == 4  # 0.005+0.015=0.02, 2 steps
 
 
-def test_pause_and_resume():
-  """Pausing stops physics; resuming resyncs clocks and clears errors."""
+def test_high_speed():
+  v = FakeViewer(step_dt=0.01, frame_rate=60.0)
+  v._speed_index = v.SPEED_MULTIPLIERS.index(8.0)
+  v._time_multiplier = 8.0
+  v.inject_tick(dt=1.0 / 60.0)
+  assert v.sim_step_count == 13
+
+
+def test_slow_speed():
+  v = FakeViewer(step_dt=0.01, frame_rate=60.0)
+  v._speed_index = 0
+  v._time_multiplier = 1 / 32
+  for _ in range(19):
+    v.inject_tick(dt=1.0 / 60.0)
+  assert v.sim_step_count == 0
+  for _ in range(3):
+    v.inject_tick(dt=1.0 / 60.0)
+  assert v.sim_step_count >= 1
+
+
+# Render timing.
+
+
+def test_render_at_frame_rate():
+  v = FakeViewer(step_dt=0.01, frame_rate=60.0)
+  assert v.inject_tick(dt=0.001) is True  # First tick renders.
+  assert v.inject_tick(dt=0.001) is False  # Too soon.
+  assert v.inject_tick(dt=1.0 / 60.0) is True  # Frame time elapsed.
+
+
+# Pause and resume.
+
+
+def test_pause_stops_physics():
   v = FakeViewer(step_dt=0.01)
-  v.inject_tick(wall_dt=0.03)
-  assert v.sim_step_count == 3
+  v.inject_tick(dt=0.02)
+  before = v.sim_step_count
+
+  v.pause()
+  v.inject_tick(dt=0.5)
+  assert v.sim_step_count == before
+
+
+def test_resume_no_burst():
+  v = FakeViewer(step_dt=0.01)
+  v.inject_tick(dt=0.03)
+  count_before = v.sim_step_count
 
   v.pause()
   v._last_error = "some error"
-  v.inject_tick(wall_dt=0.5)
-  assert v.sim_step_count == 3  # No steps while paused
 
   v.resume()
-  assert v._last_error is None  # Error cleared on resume
-  v.inject_tick(wall_dt=0.01)
-  assert v.sim_step_count == 4  # Exactly 1, no burst
+  assert v._last_error is None
+  assert v._sim_budget == 0.0
+
+  v.inject_tick(dt=0.01)
+  assert v.sim_step_count - count_before == 1
 
 
-def test_full_wall_time_used_for_budget():
-  """Full wall time feeds the sim budget (max_steps_per_tick caps spirals).
-
-  With step_dt=0.01:
-    tick 1: tracked=0.010, deficit=0.010 → 1 step,  actual=0.01
-    tick 2: tracked=0.025, deficit=0.015 → 1 step,  actual=0.02  (5ms carry)
-    tick 3: tracked=0.040, deficit=0.020 → 2 steps, actual=0.04  (carry consumed)
-    tick 4: tracked=0.055, deficit=0.015 → 1 step,  actual=0.05  (5ms carry)
-
-  Over 4 ticks (55ms wall), 50ms sim time → RTF=0.91x, approaching 1.0 as
-  the half-step carry oscillation averages out.
-  """
-  v = FakeViewer(step_dt=0.01)
-  v.inject_tick(wall_dt=0.01)
-  assert v.sim_step_count == 1
-
-  v.inject_tick(wall_dt=0.015)
-  assert v.sim_step_count == 2
-
-  v.inject_tick(wall_dt=0.015)
-  assert v.sim_step_count == 4  # 2 steps (carry from tick 2 consumed)
-
-  v.inject_tick(wall_dt=0.015)
-  assert v.sim_step_count == 5
-
-
-def test_render_independent_of_physics():
-  """Render timing follows frame_rate, not physics stepping."""
-  v = FakeViewer(step_dt=0.01, frame_rate=60.0)
-
-  assert v.inject_tick(wall_dt=0.001) is True  # First tick always renders
-  assert v.inject_tick(wall_dt=0.001) is False  # Too soon
-  assert v.inject_tick(wall_dt=1.0 / 60.0) is True  # Frame time elapsed
+# Single step.
 
 
 def test_single_step_while_paused():
-  """Single-step advances exactly one step and updates sim time."""
   v = FakeViewer(step_dt=0.01)
   v.pause()
 
   v.request_single_step()
-  v.inject_tick(wall_dt=0.0)
+  v.inject_tick(dt=0.0)
 
   assert v.sim_step_count == 1
-  assert v._is_paused  # Still paused after single step
-  assert abs(v._actual_sim_time - 0.01) < 1e-10
-  assert abs(v._tracked_sim_time - v._actual_sim_time) < 1e-10
+  assert v._is_paused
 
 
 def test_single_step_ignored_when_running():
-  """Single-step does nothing when not paused."""
   v = FakeViewer(step_dt=0.01)
-  v.inject_tick(wall_dt=0.01)
-  assert v.sim_step_count == 1
+  v.inject_tick(dt=0.02)
+  before = v.sim_step_count
 
   v.request_single_step()
-  v.inject_tick(wall_dt=0.0)
-  assert v.sim_step_count == 1
+  v.inject_tick(dt=0.02)
+  assert v.sim_step_count > before
 
 
-def test_error_recovery_pauses_and_reset_clears():
-  """Exception during step pauses and stores error; reset clears it."""
+# Error recovery.
+
+
+def test_error_pauses():
   v = FakeViewer(step_dt=0.01)
   v._execute_step = BaseViewer._execute_step.__get__(v, FakeViewer)  # type: ignore[attr-defined]
   v.policy = MagicMock(side_effect=RuntimeError("test error"))
 
-  v.inject_tick(wall_dt=0.01)
+  v.inject_tick(dt=0.02)
 
   assert v._is_paused
   assert v._last_error is not None
   assert "test error" in v._last_error
-  assert abs(v._actual_sim_time) < 1e-10
 
-  # Reset clears the error.
+
+def test_reset_clears():
+  v = FakeViewer(step_dt=0.01)
+  v.inject_tick(dt=0.02)
+  v._last_error = "err"
+
   v.reset_environment()
+  assert v._step_count == 0
+  assert v._sim_budget == 0.0
   assert v._last_error is None
 
 
-def test_single_step_failure_does_not_advance_sim_time():
-  """Single-step failure should not advance sim clocks."""
-  v = FakeViewer(step_dt=0.01)
-  v._execute_step = BaseViewer._execute_step.__get__(v, FakeViewer)  # type: ignore[attr-defined]
-  v.policy = MagicMock(side_effect=RuntimeError("single-step error"))
-  v.pause()
-
-  v.request_single_step()
-  v.inject_tick(wall_dt=0.0)
-
-  assert abs(v._actual_sim_time) < 1e-10
-  assert abs(v._tracked_sim_time) < 1e-10
+# Formatting and status.
 
 
 def test_format_speed():
-  """_format_speed produces human-readable fraction strings."""
   assert BaseViewer._format_speed(1.0) == "1x"
   assert BaseViewer._format_speed(0.5) == "1/2x"
   assert BaseViewer._format_speed(0.25) == "1/4x"
@@ -180,16 +192,60 @@ def test_format_speed():
 
 
 def test_status_snapshot():
-  """Status snapshot exposes actual_realtime = smoothed_sps * step_dt."""
   v = FakeViewer(step_dt=0.01)
-  v._smoothed_fps = 60.0
-  v._smoothed_sps = 50.0
-  v._is_capped = True
+  v._fps = 60.0
+  v._sps = 50.0
   v._last_error = "err"
 
   status = v.get_status()
-
   assert abs(status.actual_realtime - 0.5) < 1e-10
   assert status.speed_label == "1x"
-  assert status.capped is True
   assert status.last_error == "err"
+
+
+def test_capped_clears_each_tick():
+  """Capped resets to False each tick; only True when deadline hit."""
+  v = FakeViewer(step_dt=0.01)
+  v.inject_tick(dt=0.02)
+  assert not v._was_capped
+
+  # Force capped state, then verify next tick clears it.
+  v._was_capped = True
+  v.inject_tick(dt=0.02)
+  assert not v._was_capped
+
+
+def test_capped_false_when_no_remaining_budget():
+  """Deadline hit with no remaining budget is NOT capped (transient stall)."""
+  v = FakeViewer(step_dt=0.01, frame_rate=60.0)
+  # dt=0.01 at 1x: budget=0.01, exactly 1 step, budget goes to 0.
+  # Even if deadline fires (via GC), no remaining work to drop.
+  v.inject_tick(dt=0.01)
+  assert not v._was_capped
+
+
+# Spiral protection.
+
+
+def test_no_spiral():
+  v = FakeViewer(step_dt=0.01, frame_rate=60.0)
+  v._speed_index = v.SPEED_MULTIPLIERS.index(8.0)
+  v._time_multiplier = 8.0
+
+  original = v._execute_step
+
+  def slow_step() -> bool:
+    time.sleep(0.005)
+    return original()
+
+  v._execute_step = slow_step  # type: ignore[assignment]
+
+  start = time.perf_counter()
+  v.inject_tick(dt=1.0 / 60.0)
+  elapsed = time.perf_counter() - start
+
+  assert elapsed < 0.05
+  assert v.sim_step_count < 13
+  assert v.sim_step_count >= 1
+  # Capped because slow steps + large budget means remaining work was dropped.
+  assert v._was_capped


### PR DESCRIPTION
Simplify the viewer base class by replacing the two clock timing model with a single accumulator and a wall time deadline. Subsumes #704.

- Replace `_tracked_sim_time` / `_actual_sim_time` with a single `_sim_budget` accumulator. The two clock model was inherited from dm_control where the viewer passively observes an external physics engine; since mjlab's viewer owns the step loop directly, a single accumulator is equivalent and easier to reason about.
- Add a wall time deadline (`time.perf_counter() + frame_time`) to the physics loop so rendering is never starved on slow hardware. Replaces the fixed `max_steps_per_tick` cap which could still batch 500ms of physics before yielding.
- Fix debug overlay blinking in the Viser viewer by only clearing and requeuing debug draw calls on ticks where a scene update will actually be submitted, and holding the sim lock during the clear/requeue to prevent races with the background render thread.
- Remove `Timer` class, EMA smoothed FPS tracking, and sliding window capped detector in favor of simpler equivalents (~15 instance variables down from ~30).