### PR TITLE
xml actuator target match

### DIFF
--- a/src/mjlab/actuator/xml_actuator.py
+++ b/src/mjlab/actuator/xml_actuator.py
@@ -58,7 +58,7 @@ class XmlActuator(Actuator[XmlActuatorCfgT], Generic[XmlActuatorCfgT]):
   ) -> mujoco.MjsActuator | None:
     """Find an actuator that targets the given target (joint, tendon, or site)."""
     for actuator in spec.actuators:
-      if actuator.target == target_name:
+      if actuator.target == target_name or actuator.target.endswith("/" + target_name):
         return actuator
     return None
 


### PR DESCRIPTION
https://github.com/mujocolab/mjlab/blob/177cede03ff43d082e283decd25ee66fc039b096/src/mjlab/actuator/xml_actuator.py#L60-L61

`_find_actuator_for_target` doesnt match with the target if is is inside an `<attach prefix="...">`. Spec stores full prefixed name but `Entity.find_tendon` strip prefixes and return local names. 

the PR fix is not ideal btw since it's ambiguous if sub-models share a similar local target name.