### PR TITLE
Document that action history stores raw policy output

### DIFF
--- a/src/mjlab/envs/mdp/rewards.py
+++ b/src/mjlab/envs/mdp/rewards.py
@@ -56,14 +56,20 @@ def joint_acc_l2(
 
 
 def action_rate_l2(env: ManagerBasedRlEnv) -> torch.Tensor:
-  """Penalize the rate of change of the actions using L2 squared kernel."""
+  """Penalize the rate of change of the actions using L2 squared kernel.
+
+  Operates on raw policy output (before per-term scale/offset).
+  """
   return torch.sum(
     torch.square(env.action_manager.action - env.action_manager.prev_action), dim=1
   )
 
 
 def action_acc_l2(env: ManagerBasedRlEnv) -> torch.Tensor:
-  """Penalize the acceleration of the actions using L2 squared kernel."""
+  """Penalize the acceleration of the actions using L2 squared kernel.
+
+  Operates on raw policy output (before per-term scale/offset).
+  """
   action_acc = (
     env.action_manager.action
     - 2 * env.action_manager.prev_action

--- a/src/mjlab/managers/action_manager.py
+++ b/src/mjlab/managers/action_manager.py
@@ -111,14 +111,20 @@ class ActionManager(ManagerBase):
 
   @property
   def action(self) -> torch.Tensor:
+    """Raw policy output from the current step, before per-term
+    scale/offset. Shape: ``(num_envs, total_action_dim)``."""
     return self._action
 
   @property
   def prev_action(self) -> torch.Tensor:
+    """Raw policy output from the previous step, before per-term
+    scale/offset. Shape: ``(num_envs, total_action_dim)``."""
     return self._prev_action
 
   @property
   def prev_prev_action(self) -> torch.Tensor:
+    """Raw policy output from two steps ago, before per-term
+    scale/offset. Shape: ``(num_envs, total_action_dim)``."""
     return self._prev_prev_action
 
   @property
@@ -143,14 +149,24 @@ class ActionManager(ManagerBase):
     return {}
 
   def process_action(self, action: torch.Tensor) -> None:
+    """Store the raw policy output and route slices to each action term.
+
+    Called once per policy step. The raw action tensor is saved into the
+    history buffers (``action``, ``prev_action``, ``prev_prev_action``) *before*
+    any per-term scale/offset is applied. Each term then receives its slice and
+    independently applies its own affine transformation via
+    :meth:`ActionTerm.process_actions`.
+    """
     if self.total_action_dim != action.shape[1]:
       raise ValueError(
-        f"Invalid action shape, expected: {self.total_action_dim}, received: {action.shape[1]}."
+        f"Invalid action shape, expected: {self.total_action_dim},"
+        f" received: {action.shape[1]}."
       )
+    # Shift history: prev_prev ← prev ← current ← new.
     self._prev_prev_action[:] = self._prev_action
     self._prev_action[:] = self._action
     self._action[:] = action.to(self.device)
-    # Split and apply.
+    # Split the flat action vector and route each slice to its term.
     idx = 0
     for term in self._terms.values():
       term_actions = action[:, idx : idx + term.action_dim]
@@ -158,6 +174,11 @@ class ActionManager(ManagerBase):
       idx += term.action_dim
 
   def apply_action(self) -> None:
+    """Write processed actions to entity actuator targets.
+
+    Called on every decimation substep (physics step), not just once per policy
+    step. Each term writes its most recently processed targets to the simulation.
+    """
     for term in self._terms.values():
       term.apply_actions()
 


### PR DESCRIPTION
## Summary

- Added docstrings to `ActionManager.action`, `prev_action`, and `prev_prev_action` clarifying they store raw policy output (before per-term scale/offset) with shape info.
- Added docstrings to `process_action()` and `apply_action()` documenting the data flow and call frequency (once per policy step vs every decimation substep).
- Clarified in `action_rate_l2` and `action_acc_l2` that they operate on raw (pre-scale/offset) actions.
- Fixed overlong ValueError line in `process_action()`.

## Test plan

- [x] Docstring-only changes — verify `make check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)