### PR TITLE
Fix actuator target resolution for entities with internal attach prefixes

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -119,6 +119,9 @@ Changed
 Fixed
 ^^^^^
 
+- Fixed actuator target resolution for entities whose ``spec_fn`` uses
+  internal ``MjSpec.attach(prefix=...)``
+  (`#709 <https://github.com/mujocolab/mjlab/issues/709>`_).
 - Fixed viewer physics loop starving the renderer by replacing the single
   sim-time budget with a two-clock design (tracked vs actual sim time).
   Physics now self-corrects after overshooting, keeping FPS smooth at all

--- a/src/mjlab/actuator/actuator.py
+++ b/src/mjlab/actuator/actuator.py
@@ -151,8 +151,10 @@ class Actuator(ABC, Generic[ActuatorCfgT]):
 
     Args:
       spec: The entity's MjSpec to edit.
-      target_names: Names of targets (joints, tendons, or sites) controlled by
-        this actuator.
+      target_names: Names of targets (joints, tendons, or sites) as they
+        appear in the spec. When the entity's ``spec_fn`` uses internal
+        ``MjSpec.attach(prefix=...)``, these will include the prefix
+        (e.g., ``"left/elbow"`` rather than ``"elbow"``).
     """
     raise NotImplementedError
 

--- a/src/mjlab/actuator/xml_actuator.py
+++ b/src/mjlab/actuator/xml_actuator.py
@@ -40,7 +40,8 @@ class XmlActuator(Actuator[XmlActuatorCfgT], Generic[XmlActuatorCfgT]):
       if actuator is not None:
         self._mjs_actuators.append(actuator)
         filtered_target_ids.append(self._target_ids_list[i])
-        filtered_target_names.append(target_name)
+        # Store the user-facing (stripped) name, not the spec name.
+        filtered_target_names.append(self._target_names[i])
 
     if len(filtered_target_names) == 0:
       raise ValueError(

--- a/src/mjlab/entity/entity.py
+++ b/src/mjlab/entity/entity.py
@@ -171,10 +171,13 @@ class Entity:
       # Find targets based on transmission type.
       if actuator_cfg.transmission_type == TransmissionType.JOINT:
         target_ids, target_names = self.find_joints(actuator_cfg.target_names_expr)
+        target_spec_names = [self._non_free_joints[i].name for i in target_ids]
       elif actuator_cfg.transmission_type == TransmissionType.TENDON:
         target_ids, target_names = self.find_tendons(actuator_cfg.target_names_expr)
+        target_spec_names = [self._spec.tendons[i].name for i in target_ids]
       elif actuator_cfg.transmission_type == TransmissionType.SITE:
         target_ids, target_names = self.find_sites(actuator_cfg.target_names_expr)
+        target_spec_names = [self.spec.sites[i].name for i in target_ids]
       else:
         raise ValueError(
           f"Invalid transmission_type: {actuator_cfg.transmission_type}. "
@@ -187,7 +190,7 @@ class Entity:
           f"expressions: {actuator_cfg.target_names_expr}"
         )
       actuator_instance = actuator_cfg.build(self, target_ids, target_names)
-      actuator_instance.edit_spec(self._spec, target_names)
+      actuator_instance.edit_spec(self._spec, target_spec_names)
       self._actuators.append(actuator_instance)
 
   def _add_initial_state_keyframe(self) -> None:

--- a/tests/test_actuator.py
+++ b/tests/test_actuator.py
@@ -1,5 +1,6 @@
 """Tests for actuator module."""
 
+import mujoco
 import pytest
 import torch
 from conftest import (
@@ -10,9 +11,12 @@ from conftest import (
 )
 
 from mjlab.actuator import (
+  BuiltinMotorActuatorCfg,
   BuiltinPositionActuatorCfg,
   IdealPdActuatorCfg,
+  XmlMotorActuatorCfg,
 )
+from mjlab.entity import Entity, EntityArticulationInfoCfg, EntityCfg
 
 
 @pytest.fixture(scope="module")
@@ -84,3 +88,65 @@ def test_targets_cleared_on_reset(device, robot_xml):
   assert torch.allclose(
     entity.data.joint_effort_target, torch.zeros(1, 2, device=device)
   )
+
+
+# ---------------------------------------------------------------------------
+# Internal attach prefix tests (issue #709)
+# ---------------------------------------------------------------------------
+
+
+def _make_arm_spec() -> mujoco.MjSpec:
+  """Helper: single-joint arm with a motor actuator."""
+  spec = mujoco.MjSpec()
+  body = spec.worldbody.add_body(name="link")
+  body.add_joint(name="elbow", type=mujoco.mjtJoint.mjJNT_HINGE)
+  body.add_geom(type=mujoco.mjtGeom.mjGEOM_SPHERE, size=[0.1, 0, 0])
+  act = spec.add_actuator(name="motor_elbow", target="elbow")
+  act.trntype = mujoco.mjtTrn.mjTRN_JOINT
+  act.gainprm[:] = [1] + [0] * 9
+  return spec
+
+
+def _prefixed_entity_spec() -> mujoco.MjSpec:
+  """Entity spec that composes a sub-model via internal attach."""
+  root = mujoco.MjSpec()
+  root.worldbody.add_geom(type=mujoco.mjtGeom.mjGEOM_PLANE, size=[1, 1, 0.01])
+  frame = root.worldbody.add_frame()
+  root.attach(_make_arm_spec(), prefix="arm/", frame=frame)
+  return root
+
+
+def test_builtin_actuator_with_internal_attach_prefix(device):
+  """Builtin actuator resolves joints through internal attach prefix."""
+  cfg = EntityCfg(
+    spec_fn=_prefixed_entity_spec,
+    articulation=EntityArticulationInfoCfg(
+      actuators=(
+        BuiltinMotorActuatorCfg(target_names_expr=("elbow",), effort_limit=100.0),
+      )
+    ),
+  )
+  entity = Entity(cfg)
+
+  # User-facing names should be stripped.
+  assert entity.joint_names == ("elbow",)
+
+  entity, _ = initialize_entity(entity, device)
+
+  assert len(entity.actuators) == 1
+  assert entity.actuators[0].target_names == ["elbow"]
+
+
+def test_xml_actuator_with_internal_attach_prefix(device):
+  """XML actuator matches targets through internal attach prefix."""
+  cfg = EntityCfg(
+    spec_fn=_prefixed_entity_spec,
+    articulation=EntityArticulationInfoCfg(
+      actuators=(XmlMotorActuatorCfg(target_names_expr=("elbow",)),)
+    ),
+  )
+  entity = Entity(cfg)
+  entity, sim = initialize_entity(entity, device)
+
+  assert len(entity.actuators) == 1
+  assert entity.actuators[0].target_names == ["elbow"]


### PR DESCRIPTION
When an entity's `spec_fn` uses `MjSpec.attach(prefix=...)` internally (e.g., composing a robot from sub-assemblies), all actuator types failed to resolve their targets:

- **Builtin actuators** hit a MuJoCo compile error (`unknown transmission target 'elbow'`) because `spec.add_actuator(target="elbow")` couldn't find the joint actually named `"arm/elbow"` in the spec.
- **XML actuators** found no matching actuators because `_find_actuator_for_target` compared `actuator.target` (`"arm/elbow"`) against the stripped name (`"elbow"`).

**Root cause:** `_add_actuators` passed stripped names (from `find_joints` etc.) to `edit_spec`, but MuJoCo's spec APIs need the full names including any internal attach prefixes.

**Fix:** `_add_actuators` now resolves full spec names from the element references via `target_ids` and passes those to `edit_spec`. User-facing names (`actuator.target_names`, `entity.joint_names`) remain stripped.

Closes #709.