### PR TITLE
Reorganize Viser Controls tab and add velocity joystick GUI

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -77,6 +77,13 @@ Added
 - ``DebugVisualizer`` now supports ellipsoid visualization via
   ``add_ellipsoid``.
 
+- Interactive velocity joystick sliders in the Viser viewer. Enable the
+  joystick under Commands/Twist to override velocity commands with manual
+  sliders for ``lin_vel_x``, ``lin_vel_y``, and ``ang_vel_z``
+  (`#666 <https://github.com/mujocolab/mjlab/issues/666>`_).
+- Per-term debug visualization toggles in the Viser viewer. Individual
+  command term visualizers (e.g. velocity arrows) can now be toggled
+  independently under Scene/Debug Viz.
 - Viewer single-step mode: press RIGHT arrow (native) or click "Step"
   (Viser) to advance exactly one physics step while paused.
 - Viewer error recovery: exceptions during stepping now pause the viewer
@@ -104,6 +111,13 @@ Added
 Changed
 ^^^^^^^
 
+- Reorganized the Viser Controls tab into a cleaner folder hierarchy:
+  Info, Simulation, Commands, Scene (with Environment, Camera, Debug Viz,
+  Contacts sub-folders), and Camera Feeds. The Environment folder is
+  hidden for single-env tasks and the Commands folder is hidden when no
+  command terms are active.
+- Viser camera tracking is now enabled by default so the agent stays in
+  frame on launch.
 - Self collision and illegal contact sensors now use ``history_length`` to
   catch contacts across decimation substeps. Reward and termination functions
   read ``force_history`` with a configurable ``force_threshold``.

--- a/src/mjlab/managers/command_manager.py
+++ b/src/mjlab/managers/command_manager.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import abc
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Sequence
 
@@ -12,6 +13,8 @@ from prettytable import PrettyTable
 from mjlab.managers.manager_base import ManagerBase, ManagerTermBase
 
 if TYPE_CHECKING:
+  import viser
+
   from mjlab.envs.manager_based_rl_env import ManagerBasedRlEnv
   from mjlab.viewer.debug_visualizer import DebugVisualizer
 
@@ -52,13 +55,29 @@ class CommandTerm(ManagerTermBase):
     self.command_counter = torch.zeros(
       self.num_envs, device=self.device, dtype=torch.long
     )
+    self._debug_vis_enabled: bool = True
 
   def debug_vis(self, visualizer: "DebugVisualizer") -> None:
-    if self.cfg.debug_vis:
+    if self.cfg.debug_vis and self._debug_vis_enabled:
       self._debug_vis_impl(visualizer)
 
   def _debug_vis_impl(self, visualizer: "DebugVisualizer") -> None:
     pass
+
+  def create_gui(
+    self,
+    name: str,
+    server: "viser.ViserServer",
+    get_env_idx: Callable[[], int],
+  ) -> None:
+    """Create interactive GUI controls for this command term.
+
+    Override in subclasses to add task-specific controls (e.g., velocity
+    sliders) to the Viser viewer. Called once during viewer setup.
+
+    The *name* argument is the term's key in the command manager config
+    (e.g., ``"twist"``).
+    """
 
   @property
   @abc.abstractmethod
@@ -140,6 +159,31 @@ class CommandManager(ManagerBase):
     for term in self._terms.values():
       term.debug_vis(visualizer)
 
+  def create_gui(
+    self,
+    server: "viser.ViserServer",
+    get_env_idx: Callable[[], int],
+  ) -> None:
+    """Let each command term create its GUI controls."""
+    for name, term in self._terms.items():
+      term.create_gui(name, server, get_env_idx)
+
+  def create_debug_vis_gui(self, server: "viser.ViserServer") -> None:
+    """Add per-term debug visualization checkboxes."""
+    vis_terms = {name: term for name, term in self._terms.items() if term.cfg.debug_vis}
+    if not vis_terms:
+      return
+    for name, term in vis_terms.items():
+      cb = server.gui.add_checkbox(
+        name.capitalize(),
+        initial_value=term._debug_vis_enabled,
+      )
+
+      def _on_update(_ev, _term: CommandTerm = term, _cb=cb) -> None:
+        _term._debug_vis_enabled = _cb.value
+
+      cb.on_update(_on_update)
+
   # Properties.
 
   @property
@@ -206,6 +250,16 @@ class NullCommandManager:
     return "NullCommandManager()"
 
   def debug_vis(self, visualizer: "DebugVisualizer") -> None:
+    pass
+
+  def create_gui(
+    self,
+    server: "viser.ViserServer",
+    get_env_idx: Callable[[], int],
+  ) -> None:
+    pass
+
+  def create_debug_vis_gui(self, server: "viser.ViserServer") -> None:
     pass
 
   def get_active_iterable_terms(

--- a/src/mjlab/tasks/velocity/mdp/velocity_command.py
+++ b/src/mjlab/tasks/velocity/mdp/velocity_command.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
@@ -15,6 +16,8 @@ from mjlab.utils.lab_api.math import (
 )
 
 if TYPE_CHECKING:
+  import viser
+
   from mjlab.envs.manager_based_rl_env import ManagerBasedRlEnv
   from mjlab.viewer.debug_visualizer import DebugVisualizer
 
@@ -42,6 +45,11 @@ class UniformVelocityCommand(CommandTerm):
 
     self.metrics["error_vel_xy"] = torch.zeros(self.num_envs, device=self.device)
     self.metrics["error_vel_yaw"] = torch.zeros(self.num_envs, device=self.device)
+
+    # Set by create_gui() when the viewer is active.
+    self._joystick_enabled: viser.GuiCheckboxHandle | None = None
+    self._joystick_sliders: list[viser.GuiSliderHandle] = []
+    self._joystick_get_env_idx: Callable[[], int] | None = None
 
   @property
   def command(self) -> torch.Tensor:
@@ -98,6 +106,72 @@ class UniformVelocityCommand(CommandTerm):
       )
     standing_env_ids = self.is_standing_env.nonzero(as_tuple=False).flatten()
     self.vel_command_b[standing_env_ids, :] = 0.0
+
+  # GUI.
+
+  def create_gui(
+    self,
+    name: str,
+    server: "viser.ViserServer",
+    get_env_idx: Callable[[], int],
+  ) -> None:
+    """Create velocity joystick sliders in the Viser viewer."""
+    from viser import Icon
+
+    ranges = self.cfg.ranges
+
+    axes = [
+      ("lin_vel_x", ranges.lin_vel_x[1]),
+      ("lin_vel_y", ranges.lin_vel_y[1]),
+      ("ang_vel_z", ranges.ang_vel_z[1]),
+    ]
+    sliders: list = []
+
+    with server.gui.add_folder(name.capitalize()):
+      enabled = server.gui.add_checkbox("Enable", initial_value=False)
+
+      for label, max_val in axes:
+        max_input = server.gui.add_slider(
+          f"Max {label}",
+          initial_value=max_val,
+          step=0.1,
+          min=0.1,
+          max=10.0,
+        )
+        slider = server.gui.add_slider(
+          label,
+          min=-max_val,
+          max=max_val,
+          step=0.05,
+          initial_value=0.0,
+        )
+
+        @max_input.on_update
+        def _(_ev, _s=slider, _m=max_input) -> None:
+          _s.min = -_m.value
+          _s.max = _m.value
+
+        sliders.append(slider)
+
+      zero_btn = server.gui.add_button("Zero", icon=Icon.SQUARE_X)
+
+      @zero_btn.on_click
+      def _(_) -> None:
+        for s in sliders:
+          s.value = 0.0
+
+    # Store GUI state for compute() override.
+    self._joystick_enabled = enabled
+    self._joystick_sliders = sliders
+    self._joystick_get_env_idx = get_env_idx
+
+  def compute(self, dt: float) -> None:
+    super().compute(dt)
+    if self._joystick_enabled is not None and self._joystick_enabled.value:
+      assert self._joystick_get_env_idx is not None
+      idx = self._joystick_get_env_idx()
+      for i, s in enumerate(self._joystick_sliders):
+        self.vel_command_b[idx, i] = s.value
 
   # Visualization.
 

--- a/src/mjlab/viewer/viser/overlays.py
+++ b/src/mjlab/viewer/viser/overlays.py
@@ -111,6 +111,13 @@ class ViserCameraOverlays:
   mj_model: mujoco.MjModel
   camera_viewers: list[ViserCameraViewer] | None = None
 
+  @property
+  def has_cameras(self) -> bool:
+    """Whether the environment has any camera sensors."""
+    return any(
+      isinstance(s, CameraSensor) for s in self.env.unwrapped.scene.sensors.values()
+    )
+
   def setup_controls(self) -> None:
     """Create camera feed controls under the active GUI folder."""
     camera_sensors = [

--- a/src/mjlab/viewer/viser/scene.py
+++ b/src/mjlab/viewer/viser/scene.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
 
 import mujoco
@@ -106,7 +107,7 @@ class ViserMujocoScene(DebugVisualizer):
 
   # Visualization settings (set directly or automatically updated by create_options_gui).
   env_idx: int = 0  # Current environment index (DebugVisualizer protocol).
-  camera_tracking_enabled: bool = False
+  camera_tracking_enabled: bool = True
   show_only_selected: bool = False
   geom_groups_visible: list[bool] = field(
     default_factory=lambda: [True, True, True, False, False, False]
@@ -275,6 +276,7 @@ class ViserMujocoScene(DebugVisualizer):
     camera_azimuth: float = 45.0,
     camera_elevation: float = 30.0,
     show_debug_viz_control: bool = True,
+    debug_viz_extra_gui: Callable[[], None] | None = None,
   ) -> None:
     """Add standard GUI controls that automatically update this scene's settings.
 
@@ -283,30 +285,12 @@ class ViserMujocoScene(DebugVisualizer):
       camera_azimuth: Default camera azimuth angle in degrees.
       camera_elevation: Default camera elevation angle in degrees.
       show_debug_viz_control: Whether to show the debug visualization checkbox.
+      debug_viz_extra_gui: Optional callback invoked inside the Debug Viz
+        folder to add extra controls (e.g., per-term toggles).
     """
-    with self.server.gui.add_folder("Visualization"):
-      slider_fov = self.server.gui.add_slider(
-        "FOV (°)",
-        min=_DEFAULT_FOV_MIN,
-        max=_DEFAULT_FOV_MAX,
-        step=1,
-        initial_value=_DEFAULT_FOV_DEGREES,
-        hint="Vertical FOV of viewer camera, in degrees.",
-      )
-
-      @slider_fov.on_update
-      def _(_) -> None:
-        for client in self.server.get_clients().values():
-          client.camera.fov = np.radians(slider_fov.value)
-
-      @self.server.on_client_connect
-      def _(client: viser.ClientHandle) -> None:
-        client.camera.fov = np.radians(slider_fov.value)
-
     # Environment selection (only if multiple environments).
-    with self.server.gui.add_folder("Environment"):
-      # Environment selection slider (if multiple envs).
-      if self.num_envs > 1:
+    if self.num_envs > 1:
+      with self.server.gui.add_folder("Environment"):
         env_slider = self.server.gui.add_slider(
           "Select",
           min=0,
@@ -332,7 +316,22 @@ class ViserMujocoScene(DebugVisualizer):
           self.show_only_selected = show_only_cb.value
           self._request_update()
 
-      # Camera tracking controls.
+    # Precompute default camera position for tracking snap.
+    _az_rad = np.deg2rad(camera_azimuth)
+    _el_rad = np.deg2rad(camera_elevation)
+    _default_camera_pos = (
+      -np.array(
+        [
+          np.cos(_el_rad) * np.cos(_az_rad),
+          np.cos(_el_rad) * np.sin(_az_rad),
+          np.sin(_el_rad),
+        ]
+      )
+      * camera_distance
+    )
+
+    # Camera controls.
+    with self.server.gui.add_folder("Camera"):
       cb_camera_tracking = self.server.gui.add_checkbox(
         "Track camera",
         initial_value=self.camera_tracking_enabled,
@@ -342,121 +341,126 @@ class ViserMujocoScene(DebugVisualizer):
       @cb_camera_tracking.on_update
       def _(_) -> None:
         self.camera_tracking_enabled = cb_camera_tracking.value
-        # Snap camera to default view when enabling tracking.
         if self.camera_tracking_enabled:
-          # Convert to radians and calculate camera position.
-          azimuth_rad = np.deg2rad(camera_azimuth)
-          elevation_rad = np.deg2rad(camera_elevation)
-
-          # Calculate forward vector from spherical coordinates.
-          forward = np.array(
-            [
-              np.cos(elevation_rad) * np.cos(azimuth_rad),
-              np.cos(elevation_rad) * np.sin(azimuth_rad),
-              np.sin(elevation_rad),
-            ]
-          )
-
-          # Camera position is origin - forward * distance.
-          camera_pos = -forward * camera_distance
-
-          # Snap all connected clients to this view.
           for client in self.server.get_clients().values():
-            client.camera.position = camera_pos
+            client.camera.position = _default_camera_pos
             client.camera.look_at = np.zeros(3)
-
         self._request_update()
 
-      # Debug visualization controls (only show if requested).
-      if show_debug_viz_control:
-        with self.server.gui.add_folder("Debug Viz"):
-          cb_debug_vis = self.server.gui.add_checkbox(
-            "Enabled",
-            initial_value=self.debug_visualization_enabled,
-            hint="Show debug arrows and ghost meshes.",
-          )
+      slider_fov = self.server.gui.add_slider(
+        "FOV (°)",
+        min=_DEFAULT_FOV_MIN,
+        max=_DEFAULT_FOV_MAX,
+        step=1,
+        initial_value=_DEFAULT_FOV_DEGREES,
+        hint="Vertical FOV of viewer camera, in degrees.",
+      )
 
-          @cb_debug_vis.on_update
-          def _(_) -> None:
-            self.debug_visualization_enabled = cb_debug_vis.value
-            # Clear visualizer if hiding.
-            if not self.debug_visualization_enabled:
-              self.clear_debug_all()
-            self._request_update()
+      @slider_fov.on_update
+      def _(_) -> None:
+        for client in self.server.get_clients().values():
+          client.camera.fov = np.radians(slider_fov.value)
 
-          cb_show_all_envs = self.server.gui.add_checkbox(
-            "All envs",
-            initial_value=self.show_all_envs,
-            hint="Show debug visualization for all environments.",
-          )
+      @self.server.on_client_connect
+      def _(client: viser.ClientHandle) -> None:
+        client.camera.fov = np.radians(slider_fov.value)
+        if self.camera_tracking_enabled:
+          client.camera.position = _default_camera_pos
+          client.camera.look_at = np.zeros(3)
 
-          @cb_show_all_envs.on_update
-          def _(_) -> None:
-            self.show_all_envs = cb_show_all_envs.value
-            # Clear ghosts when switching from all envs to single env
-            if not self.show_all_envs:
-              self.clear_debug_all()
-            self._request_update()
-
-      # Contact visualization settings.
-      with self.server.gui.add_folder("Contacts"):
-        cb_contact_points = self.server.gui.add_checkbox(
-          "Points",
-          initial_value=False,
-          hint="Toggle contact point visualization.",
-        )
-        contact_point_color = self.server.gui.add_rgb(
-          "Points Color", initial_value=self.contact_point_color
-        )
-        cb_contact_forces = self.server.gui.add_checkbox(
-          "Forces",
-          initial_value=False,
-          hint="Toggle contact force visualization.",
-        )
-        contact_force_color = self.server.gui.add_rgb(
-          "Forces Color", initial_value=self.contact_force_color
-        )
-        meansize_input = self.server.gui.add_number(
-          "Scale",
-          step=self.mj_model.stat.meansize * 0.01,
-          initial_value=self.mj_model.stat.meansize,
+    # Debug visualization controls (only show if requested).
+    if show_debug_viz_control:
+      with self.server.gui.add_folder("Debug Viz"):
+        cb_debug_vis = self.server.gui.add_checkbox(
+          "Enabled",
+          initial_value=self.debug_visualization_enabled,
+          hint="Show debug arrows and ghost meshes.",
         )
 
-        @cb_contact_points.on_update
+        @cb_debug_vis.on_update
         def _(_) -> None:
-          self.show_contact_points = cb_contact_points.value
-          self._sync_visibilities()
+          self.debug_visualization_enabled = cb_debug_vis.value
+          # Clear visualizer if hiding.
+          if not self.debug_visualization_enabled:
+            self.clear_debug_all()
           self._request_update()
 
-        @contact_point_color.on_update
+        cb_show_all_envs = self.server.gui.add_checkbox(
+          "All envs",
+          initial_value=self.show_all_envs,
+          hint="Show debug visualization for all environments.",
+        )
+
+        @cb_show_all_envs.on_update
         def _(_) -> None:
-          self.contact_point_color = contact_point_color.value
-          if self.contact_point_handle is not None:
-            self.contact_point_handle.remove()
-            self.contact_point_handle = None
+          self.show_all_envs = cb_show_all_envs.value
+          # Clear ghosts when switching from all envs to single env
+          if not self.show_all_envs:
+            self.clear_debug_all()
           self._request_update()
 
-        @cb_contact_forces.on_update
-        def _(_) -> None:
-          self.show_contact_forces = cb_contact_forces.value
-          self._sync_visibilities()
-          self._request_update()
+        if debug_viz_extra_gui is not None:
+          debug_viz_extra_gui()
 
-        @contact_force_color.on_update
-        def _(_) -> None:
-          self.contact_force_color = contact_force_color.value
-          if self.contact_force_shaft_handle is not None:
-            self.contact_force_shaft_handle.remove()
-            self.contact_force_shaft_handle = None
-          if self.contact_force_head_handle is not None:
-            self.contact_force_head_handle.remove()
-            self.contact_force_head_handle = None
-          self._request_update()
+    # Contact visualization settings.
+    with self.server.gui.add_folder("Contacts"):
+      cb_contact_points = self.server.gui.add_checkbox(
+        "Points",
+        initial_value=False,
+        hint="Toggle contact point visualization.",
+      )
+      contact_point_color = self.server.gui.add_rgb(
+        "Points Color", initial_value=self.contact_point_color
+      )
+      cb_contact_forces = self.server.gui.add_checkbox(
+        "Forces",
+        initial_value=False,
+        hint="Toggle contact force visualization.",
+      )
+      contact_force_color = self.server.gui.add_rgb(
+        "Forces Color", initial_value=self.contact_force_color
+      )
+      meansize_input = self.server.gui.add_number(
+        "Scale",
+        step=self.mj_model.stat.meansize * 0.01,
+        initial_value=self.mj_model.stat.meansize,
+      )
 
-        @meansize_input.on_update
-        def _(_) -> None:
-          self.meansize_override = meansize_input.value
-          self._request_update()
+      @cb_contact_points.on_update
+      def _(_) -> None:
+        self.show_contact_points = cb_contact_points.value
+        self._sync_visibilities()
+        self._request_update()
+
+      @contact_point_color.on_update
+      def _(_) -> None:
+        self.contact_point_color = contact_point_color.value
+        if self.contact_point_handle is not None:
+          self.contact_point_handle.remove()
+          self.contact_point_handle = None
+        self._request_update()
+
+      @cb_contact_forces.on_update
+      def _(_) -> None:
+        self.show_contact_forces = cb_contact_forces.value
+        self._sync_visibilities()
+        self._request_update()
+
+      @contact_force_color.on_update
+      def _(_) -> None:
+        self.contact_force_color = contact_force_color.value
+        if self.contact_force_shaft_handle is not None:
+          self.contact_force_shaft_handle.remove()
+          self.contact_force_shaft_handle = None
+        if self.contact_force_head_handle is not None:
+          self.contact_force_head_handle.remove()
+          self.contact_force_head_handle = None
+        self._request_update()
+
+      @meansize_input.on_update
+      def _(_) -> None:
+        self.meansize_override = meansize_input.value
+        self._request_update()
 
   def create_groups_gui(self, tabs) -> None:
     """Add unified groups tab with geoms and sites folders.

--- a/src/mjlab/viewer/viser/viewer.py
+++ b/src/mjlab/viewer/viser/viewer.py
@@ -135,16 +135,28 @@ class ViserPlayViewer(BaseViewer):
           else:
             self.request_speed_up()
 
-      self._camera_overlays = ViserCameraOverlays(self._server, self.env, sim.mj_model)
-      with self._server.gui.add_folder("Camera Feeds"):
-        self._camera_overlays.setup_controls()
+      # Let command terms create their own GUI controls.
+      env = self.env.unwrapped
+      if env.command_manager.active_terms:
+        with self._server.gui.add_folder("Commands"):
+          env.command_manager.create_gui(self._server, lambda: self._scene.env_idx)
 
-      # Add standard visualization options from ViserMujocoScene (Environment, Visualization, Contacts, Camera Tracking, Debug Visualization).
-      self._scene.create_visualization_gui(
-        camera_distance=self.cfg.distance,
-        camera_azimuth=self.cfg.azimuth,
-        camera_elevation=self.cfg.elevation,
-      )
+      # Add standard visualization options from ViserMujocoScene.
+      def _debug_viz_extra() -> None:
+        env.command_manager.create_debug_vis_gui(self._server)
+
+      with self._server.gui.add_folder("Scene"):
+        self._scene.create_visualization_gui(
+          camera_distance=self.cfg.distance,
+          camera_azimuth=self.cfg.azimuth,
+          camera_elevation=self.cfg.elevation,
+          debug_viz_extra_gui=_debug_viz_extra,
+        )
+
+      self._camera_overlays = ViserCameraOverlays(self._server, self.env, sim.mj_model)
+      if self._camera_overlays.has_cameras:
+        with self._server.gui.add_folder("Camera Feeds"):
+          self._camera_overlays.setup_controls()
 
     self._prev_env_idx = self._scene.env_idx
 


### PR DESCRIPTION
- Reorganize the Controls tab into a cleaner folder hierarchy: Info, Simulation, Commands, Scene (Environment, Camera, Debug Viz, Contacts), Camera Feeds
- Add interactive velocity joystick sliders under Commands/Twist for manual command override (closes #666)
- Enable camera tracking by default
- Hide Environment folder for single-env tasks, Commands folder for tasks without command terms

<img width="1072" height="1167" alt="Screenshot 2026-03-01 at 7 44 59 PM" src="https://github.com/user-attachments/assets/711f5db7-71f4-4dce-a217-204438850ed0" />