### PR TITLE
Add export-scene CLI and fix scene XML export

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -81,6 +81,7 @@ Table of Contents
    source/training/distributed_training
    source/training/cloud
    source/debugging/nan_guard
+   source/debugging/export_scene
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -13,6 +13,7 @@ Upcoming version (not yet released)
    - ``EventTermCfg`` no longer accepts ``domain_randomization``. The
      ``@requires_model_fields`` decorator on each ``dr`` function takes care
      of field expansion automatically.
+   - ``Scene.to_zip()`` is deprecated. Use ``Scene.write(path, zip=True)``.
 
 Added
 ^^^^^
@@ -63,6 +64,10 @@ Added
     (``material_names``).
   - Fixed ``dr.effort_limits`` drifting on repeated randomization.
   - Fixed ``dr.body_com_offset`` not triggering ``set_const``.
+
+- ``export-scene`` CLI script to export any task scene or asset_zoo entity
+  (``g1``, ``go1``, ``yam``) to a directory or zip archive for inspection
+  and debugging.
 
 - ``yam_lift_cube_vision_env_cfg`` now randomizes cube color (``dr.geom_rgba``)
   on every reset when ``cam_type="rgb"``.
@@ -115,6 +120,13 @@ Added
 - Added ``upload_model`` option to ``RslRlBaseRunnerCfg`` to control W&B model
   file uploads (``.pt`` and ``.onnx``) while keeping metric logging enabled
   (`#654 <https://github.com/mujocolab/mjlab/pull/654>`_).
+- ``Scene.write(output_dir, zip=False)`` exports the scene XML and mesh
+  assets to a directory (or zip archive). Replaces ``Scene.to_zip()``.
+- ``Entity.write_xml()`` and ``Scene.write()`` now apply XML fixups
+  (empty defaults, duplicate nested defaults) and strip buffer textures
+  that ``MjSpec.to_xml()`` cannot serialize.
+- ``fix_spec_xml`` and ``strip_buffer_textures`` utilities in
+  ``mjlab.utils.xml``.
 
 Changed
 ^^^^^^^

--- a/docs/source/debugging/export_scene.rst
+++ b/docs/source/debugging/export_scene.rst
@@ -1,0 +1,50 @@
+.. _export-scene:
+
+Export Scene
+============
+
+The ``export-scene`` script writes a complete scene (XML and mesh assets) to a
+directory for inspection, sharing, or loading in standalone MuJoCo.
+
+Quick start
+-----------
+
+.. code-block:: bash
+
+    # Export a built-in entity by alias.
+    uv run export-scene g1 --output-dir /tmp/g1
+
+    # Export a registered task scene.
+    uv run export-scene Mjlab-Velocity-Flat-Unitree-Go1 --output-dir /tmp/task
+
+    # Export as a zip archive.
+    uv run export-scene yam --output-dir /tmp/yam --zip True
+
+    # Export a custom entity via import path.
+    uv run export-scene my_pkg.robots:get_my_robot_cfg --output-dir /tmp/custom
+
+The output directory contains a ``scene.xml`` and an ``assets/`` subdirectory
+with all referenced mesh files. The XML can be loaded directly with
+``mujoco.MjModel.from_xml_path()`` or dropped into the
+`simulate viewer <https://mujoco.readthedocs.io/en/stable/programming/samples.html#sasimulate>`_.
+
+Target resolution
+-----------------
+
+The positional ``target`` argument is resolved in order:
+
+1. **Task ID**: checked against the task registry (``import mjlab.tasks``).
+2. **Entity alias**: one of the built-in shorthands (``g1``, ``go1``, ``yam``).
+3. **Import path**: a ``module:attribute`` string pointing to any callable
+   that returns an ``EntityCfg``.
+
+If none match, the script prints available task IDs and aliases.
+
+Options
+-------
+
+``--output-dir DIR`` *(default: "export")*
+    Destination directory. Cleaned before each export to prevent stale assets.
+
+``--zip True`` *(default: False)*
+    Compress the output into a ``.zip`` archive and remove the directory.

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -132,6 +132,23 @@ The ``nan_guard`` tool makes it easier to:
 
 Reporting well-isolated issues helps improve the framework for everyone.
 
+How can I inspect the generated scene XML?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use the ``export-scene`` script to write the full scene (XML and mesh assets)
+to a directory:
+
+.. code-block:: bash
+
+    uv run export-scene g1 --output-dir /tmp/g1
+
+The exported ``scene.xml`` can be loaded directly in MuJoCo for visual
+inspection or diffing. This is useful for verifying that task configuration
+and physics are set up correctly, and for creating minimal reproducible
+examples to share with mjlab or MuJoCo Warp developers. The script accepts task IDs,
+entity aliases (``g1``, ``go1``, ``yam``), or arbitrary import paths. See
+:doc:`debugging/export_scene` for full details.
+
 My contact sensor misses collisions when using decimation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ play = "mjlab.scripts.play:main"
 demo = "mjlab.scripts.demo:main"
 list_envs = "mjlab.scripts.list_envs:main"
 viz-nan = "mjlab.scripts.nan_viz:main"
+export-scene = "mjlab.scripts.export_scene:main"
 
 [dependency-groups]
 dev = [

--- a/src/mjlab/entity/entity.py
+++ b/src/mjlab/entity/entity.py
@@ -18,6 +18,7 @@ from mjlab.utils.lab_api.string import resolve_matching_names
 from mjlab.utils.mujoco import dof_width, qpos_width
 from mjlab.utils.spec import auto_wrap_fixed_base_mocap
 from mjlab.utils.string import resolve_expr
+from mjlab.utils.xml import fix_spec_xml, strip_buffer_textures
 
 
 @dataclass(frozen=False)
@@ -482,9 +483,13 @@ class Entity:
     return self.spec.compile()
 
   def write_xml(self, xml_path: Path) -> None:
-    """Write the MjSpec to disk."""
-    with open(xml_path, "w") as f:
-      f.write(self.spec.to_xml())
+    """Write the MjSpec to disk.
+
+    Operates on a copy of the spec to avoid mutating the original.
+    """
+    tmp = self.spec.copy()
+    strip_buffer_textures(tmp)
+    xml_path.write_text(fix_spec_xml(tmp.to_xml()))
 
   def to_zip(self, path: Path) -> None:
     """Write the MjSpec to a zip file."""

--- a/src/mjlab/scene/scene.py
+++ b/src/mjlab/scene/scene.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import shutil
 import warnings
+import zipfile
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable
@@ -16,6 +18,7 @@ from mjlab.sensor.camera_sensor import CameraSensor
 from mjlab.sensor.raycast_sensor import RayCastSensor
 from mjlab.sensor.sensor_context import SensorContext
 from mjlab.terrains.terrain_entity import TerrainEntity, TerrainEntityCfg
+from mjlab.utils.xml import fix_spec_xml, strip_buffer_textures
 
 _SCENE_XML = Path(__file__).parent / "scene.xml"
 
@@ -70,20 +73,46 @@ class Scene:
   def compile(self) -> mujoco.MjModel:
     return self._spec.compile()
 
-  def to_zip(self, path: Path) -> None:
-    """Export the scene to a zip file.
+  def write(self, output_dir: Path, *, zip: bool = False) -> None:
+    """Write the scene XML and mesh assets to a directory.
 
-    Warning: The generated zip may require manual adjustment of asset paths
-    to be reloadable. Specifically, you may need to add assetdir="assets"
-    to the compiler directive in the XML.
+    Creates ``scene.xml`` and an ``assets/`` subdirectory containing
+    all mesh files referenced by the spec. When *zip* is True the
+    directory is compressed into a ``.zip`` archive and the directory
+    is removed. Operates on a copy of the spec to avoid mutation.
 
     Args:
-      path: Output path for the zip file.
-
-    TODO: Verify if this is fixed in future MuJoCo releases.
+      output_dir: Destination directory (created if it doesn't exist).
+      zip: If True, produce ``<output_dir>.zip`` instead of a directory.
     """
-    with path.open("wb") as f:
-      mujoco.MjSpec.to_zip(self._spec, f)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    tmp = self._spec.copy()
+    strip_buffer_textures(tmp)
+    xml = fix_spec_xml(tmp.to_xml(), meshdir="assets")
+    (output_dir / "scene.xml").write_text(xml)
+    assets_dir = output_dir / "assets"
+    assets_dir.mkdir(parents=True, exist_ok=True)
+    for name, data in tmp.assets.items():
+      clean = name.removeprefix("assets/")
+      path = assets_dir / clean
+      path.parent.mkdir(parents=True, exist_ok=True)
+      path.write_bytes(data)
+    if zip:
+      zip_path = output_dir.with_suffix(".zip")
+      with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for file in sorted(output_dir.rglob("*")):
+          if file.is_file():
+            zf.write(file, file.relative_to(output_dir))
+      shutil.rmtree(output_dir)
+
+  def to_zip(self, path: Path) -> None:
+    """Deprecated. Use ``write(output_dir, zip=True)`` instead."""
+    warnings.warn(
+      "Scene.to_zip() is deprecated. Use Scene.write(path, zip=True).",
+      DeprecationWarning,
+      stacklevel=2,
+    )
+    self.write(path, zip=True)
 
   # Attributes.
 

--- a/src/mjlab/scripts/export_scene.py
+++ b/src/mjlab/scripts/export_scene.py
@@ -1,0 +1,81 @@
+"""Export a task scene or asset_zoo entity to a directory."""
+
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+
+import tyro
+import tyro.conf
+
+import mjlab
+import mjlab.tasks  # noqa: F401
+from mjlab.scene import Scene, SceneCfg
+from mjlab.tasks.registry import list_tasks, load_env_cfg
+from mjlab.utils.lab_api.string import string_to_callable
+
+ENTITY_ALIASES: dict[str, str] = {
+  "g1": "mjlab.asset_zoo.robots:get_g1_robot_cfg",
+  "go1": "mjlab.asset_zoo.robots:get_go1_robot_cfg",
+  "yam": "mjlab.asset_zoo.robots:get_yam_robot_cfg",
+}
+
+
+@dataclass
+class ExportSceneCfg:
+  target: tyro.conf.Positional[str]
+  """Task ID, entity alias (g1, go1, yam), or import path (pkg.module:get_cfg)."""
+
+  output_dir: str = "export"
+  """Output directory."""
+
+  zip: bool = False
+  """Compress into a zip archive."""
+
+
+def export_scene(cfg: ExportSceneCfg) -> None:
+  """Export a task scene or entity to a directory."""
+  task_ids = list_tasks()
+  target = ENTITY_ALIASES.get(cfg.target, cfg.target)
+
+  if target in task_ids:
+    env_cfg = load_env_cfg(target)
+    scene = Scene(env_cfg.scene, device="cpu")
+  elif ":" in target:
+    try:
+      factory = string_to_callable(target)
+    except (ValueError, ImportError) as e:
+      print(f"Error: {e}")
+      return
+    entity_cfg = factory()
+    scene_cfg = SceneCfg(entities={"robot": entity_cfg})
+    scene = Scene(scene_cfg, device="cpu")
+  else:
+    print(f"Unknown target: {cfg.target}\n")
+    print("Available task IDs:")
+    for tid in task_ids:
+      print(f"  {tid}")
+    print("\nAvailable entity aliases:")
+    for name in sorted(ENTITY_ALIASES):
+      print(f"  {name}")
+    print("\nYou can also pass an import path, e.g. my_pkg.robots:get_my_robot_cfg")
+    return
+
+  output_dir = Path(cfg.output_dir)
+  if output_dir.exists():
+    shutil.rmtree(output_dir)
+  scene.write(output_dir, zip=cfg.zip)
+  if cfg.zip:
+    print(f"Exported to {output_dir.with_suffix('.zip')}")
+  else:
+    print(f"Exported to {output_dir}")
+
+
+def main():
+  cfg = tyro.cli(ExportSceneCfg, config=mjlab.TYRO_FLAGS)
+  export_scene(cfg)
+
+
+if __name__ == "__main__":
+  main()

--- a/src/mjlab/utils/xml.py
+++ b/src/mjlab/utils/xml.py
@@ -1,0 +1,102 @@
+"""XML fixup utilities for MjSpec.to_xml() output."""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+
+import mujoco
+
+
+def strip_buffer_textures(spec: mujoco.MjSpec) -> None:
+  """Remove buffer textures and their materials from a spec.
+
+  MuJoCo's ``to_xml()`` cannot serialize textures created from raw pixel data
+  (``texture.data = ...``). This function deletes those textures and the materials that
+  reference them, and clears the material reference on any geom that used one.
+  """
+  buffer_names: set[str] = set()
+  for tex in list(spec.textures):
+    if len(tex.data) > 0:
+      buffer_names.add(tex.name)
+      spec.delete(tex)
+  if not buffer_names:
+    return
+  mat_names: set[str] = set()
+  for mat in list(spec.materials):
+    tex_name = mat.textures[mujoco.mjtTextureRole.mjTEXROLE_RGB]
+    if tex_name in buffer_names:
+      mat_names.add(mat.name)
+      spec.delete(mat)
+  if not mat_names:
+    return
+  for geom in spec.geoms:
+    if geom.material in mat_names:
+      geom.material = ""
+
+
+def _collapse_defaults(elem: ET.Element) -> None:
+  """Collapse duplicate nested defaults with the same class name.
+
+  MjSpec.to_xml() emits ``<default class="X"><default class="X">...`` after
+  ``attach(prefix=...)``. This hoists the children of the inner duplicate into the
+  outer element and removes the inner wrapper.
+  """
+  for child in list(elem):
+    if child.tag == "default":
+      _collapse_defaults(child)
+  for child in list(elem):
+    if (
+      child.tag == "default"
+      and child.get("class") is not None
+      and len(child) == 1
+      and child[0].tag == "default"
+      and child[0].get("class") == child.get("class")
+    ):
+      inner = child[0]
+      child.remove(inner)
+      for grandchild in list(inner):
+        child.append(grandchild)
+      child.text = inner.text
+      if inner.tail:
+        last = list(child)[-1] if len(child) else None
+        if last is not None:
+          last.tail = (last.tail or "") + inner.tail
+
+
+def _remove_empty_defaults(elem: ET.Element) -> None:
+  """Remove empty ``<default/>`` and ``<default class="..."/>`` elements."""
+  for child in list(elem):
+    if child.tag == "default":
+      _remove_empty_defaults(child)
+      if len(child) == 0 and not (child.text and child.text.strip()):
+        elem.remove(child)
+
+
+def fix_spec_xml(xml: str, meshdir: str | None = None) -> str:
+  """Fix known issues in MjSpec.to_xml() output.
+
+  1. Remove empty ``<default/>`` and ``<default class="..."/>`` tags.
+  2. Collapse duplicate nested defaults with the same class name.
+  3. Optionally set ``meshdir`` in the ``<compiler>`` element.
+
+  Args:
+    xml: Raw XML string from ``MjSpec.to_xml()``.
+    meshdir: If provided, set ``meshdir`` on the ``<compiler>`` element.
+  """
+  root = ET.fromstring(xml)
+
+  for default_root in root.findall("default"):
+    _remove_empty_defaults(default_root)
+    _collapse_defaults(default_root)
+  # Remove top-level <default> if it ended up empty.
+  for default_root in list(root):
+    if default_root.tag == "default" and len(default_root) == 0:
+      root.remove(default_root)
+
+  if meshdir is not None:
+    compiler = root.find("compiler")
+    if compiler is not None:
+      compiler.set("meshdir", meshdir)
+
+  ET.indent(root, space="  ")
+  return ET.tostring(root, encoding="unicode", xml_declaration=False) + "\n"

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -182,14 +182,13 @@ def test_compile_scene_with_entities(scene_with_entities_cfg, device):
   assert any("robot/" in name for name in body_names)
 
 
-# TODO: Test that we can unzip and reload the scene correctly.
-def test_to_zip(minimal_scene_cfg, tmp_path, device):
+def test_write_zip(minimal_scene_cfg, tmp_path, device):
   """Test exporting scene to zip file."""
   scene = Scene(minimal_scene_cfg, device)
-  zip_path = tmp_path / "scene.zip"
+  out = tmp_path / "scene_pkg"
 
-  scene.to_zip(zip_path)
-  assert zip_path.exists()
+  scene.write(out, zip=True)
+  assert out.with_suffix(".zip").exists()
 
 
 # ============================================================================
@@ -344,9 +343,9 @@ def test_full_scene_lifecycle(robot_entity_cfg, device, tmp_path):
 
   scene.reset(env_ids=torch.tensor([0, 2]))
 
-  zip_path = tmp_path / "test_scene.zip"
-  scene.to_zip(zip_path)
-  assert zip_path.exists()
+  out = tmp_path / "test_scene_pkg"
+  scene.write(out, zip=True)
+  assert out.with_suffix(".zip").exists()
 
   for entity in scene.entities.values():
     assert entity.data is not None

--- a/tests/test_xml_utils.py
+++ b/tests/test_xml_utils.py
@@ -1,0 +1,116 @@
+"""Tests for mjlab.utils.xml."""
+
+import zipfile
+
+import mujoco
+import numpy as np
+
+from mjlab.utils.xml import fix_spec_xml, strip_buffer_textures
+
+
+def test_strip_buffer_textures():
+  """Stripping buffer textures removes them and enables XML roundtrip."""
+  spec = mujoco.MjSpec()
+  body = spec.worldbody.add_body(name="terrain")
+
+  tex = spec.add_texture(
+    name="hf_tex",
+    type=mujoco.mjtTexture.mjTEXTURE_2D,
+    width=2,
+    height=2,
+  )
+  tex.data = (np.ones((2, 2, 3), dtype=np.uint8) * 128).tobytes()
+
+  mat = spec.add_material(name="hf_mat")
+  mat.textures[mujoco.mjtTextureRole.mjTEXROLE_RGB] = "hf_tex"
+
+  hf = spec.add_hfield(name="hf", nrow=4, ncol=4, size=[1, 1, 0.1, 0.01])
+  hf.userdata = np.zeros(16).tolist()
+  body.add_geom(
+    type=mujoco.mjtGeom.mjGEOM_HFIELD,
+    hfieldname="hf",
+    material="hf_mat",
+  )
+
+  strip_buffer_textures(spec)
+
+  assert len(spec.textures) == 0
+  assert len(spec.materials) == 0
+  assert spec.geoms[0].material == ""
+
+  # XML roundtrip should succeed now.
+  model = mujoco.MjModel.from_xml_string(spec.to_xml())
+  assert model.nhfield == 1
+
+
+def test_fix_spec_xml():
+  """Removes empty defaults and optionally injects meshdir."""
+  xml = (
+    "<mujoco>\n"
+    "  <compiler/>\n"
+    "  <default/>\n"
+    '  <default class="foo/bar"/>\n'
+    "  <worldbody/>\n"
+    "</mujoco>\n"
+  )
+  result = fix_spec_xml(xml, meshdir="assets")
+
+  assert "<default/>" not in result
+  assert 'class="foo/bar"' not in result
+  assert 'meshdir="assets"' in result
+  assert "meshdir" not in fix_spec_xml(xml)
+
+
+def test_rough_terrain_write_xml_roundtrip(tmp_path):
+  """Export terrain with hfield via Entity.write_xml, reload as MjModel."""
+  from mjlab.terrains.heightfield_terrains import (
+    HfRandomUniformTerrainCfg,
+  )
+  from mjlab.terrains.terrain_entity import TerrainEntity, TerrainEntityCfg
+  from mjlab.terrains.terrain_generator import TerrainGeneratorCfg
+
+  terrain = TerrainEntity(
+    TerrainEntityCfg(
+      terrain_type="generator",
+      terrain_generator=TerrainGeneratorCfg(
+        size=(2.0, 2.0),
+        num_rows=1,
+        num_cols=1,
+        sub_terrains={
+          "rough": HfRandomUniformTerrainCfg(
+            proportion=1.0,
+            noise_range=(-0.05, 0.05),
+            noise_step=0.005,
+          ),
+        },
+      ),
+    ),
+    device="cpu",
+  )
+  xml_path = tmp_path / "terrain.xml"
+  terrain.write_xml(xml_path)
+
+  model = mujoco.MjModel.from_xml_path(str(xml_path))
+  assert model.nhfield == 1
+
+
+def test_scene_write_zip(tmp_path):
+  """Scene.write produces a directory; with zip=True, a zip archive."""
+  from mjlab.scene.scene import Scene, SceneCfg
+
+  scene = Scene(SceneCfg(), device="cpu")
+
+  # Directory export.
+  dir_out = tmp_path / "scene_dir"
+  scene.write(dir_out)
+  assert (dir_out / "scene.xml").exists()
+  mujoco.MjModel.from_xml_path(str(dir_out / "scene.xml"))
+
+  # Zip export.
+  zip_out = tmp_path / "scene_pkg"
+  scene.write(zip_out, zip=True)
+  zip_path = zip_out.with_suffix(".zip")
+  assert zip_path.exists()
+  assert not zip_out.exists()
+  with zipfile.ZipFile(zip_path) as zf:
+    assert "scene.xml" in zf.namelist()


### PR DESCRIPTION
`Scene.to_zip` relied on `MjSpec.to_zip` which produced XML with broken asset paths and could not serialize buffer textures. This replaces it with `Scene.write`, which emits clean XML with correct meshdir references and copies mesh assets into an `assets/` subdirectory.

New xml utilities (`fix_spec_xml`, `strip_buffer_textures`) handle known `MjSpec.to_xml` limitations: empty default elements, duplicate nested defaults, and buffer textures that cannot round trip through XML. `Entity.write_xml` also applies these fixups. `Scene.to_zip` is kept as a deprecated wrapper.

New `export-scene` debug script for inspecting and sharing scenes:

```
export-scene g1 --output-dir /tmp/g1
export-scene Mjlab-Velocity-Flat-Unitree-Go1 --output-dir /tmp/task
export-scene yam --output-dir /tmp/yam --zip True
export-scene badname  (prints available targets)
```

Accepts a positional target that resolves against the task registry or a hardcoded entity lookup (`g1`, `go1`, `yam`). Output directory is cleaned before each export to avoid mixing stale assets.