### PR TITLE
Track first non-fixed body by default in native viewer

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -28,6 +28,9 @@ Added
   (``/update-mjwarp``, ``/commit-push-pr``).
 - Added optional ``ViewerConfig.fovy`` and apply it in native viewer camera
   setup when provided.
+- Native viewer now tracks the first non-fixed body by default (matching
+  the Viser viewer behavior introduced in
+  ``716aaaa58ad7bfaf34d2f771549d461204d1b4ba``).
 - New ``dr`` module (``mjlab.envs.mdp.dr``) replacing ``randomize_field``
   with typed per-field domain randomization functions. Each function
   automatically recomputes derived fields via ``set_const``. Highlights:

--- a/src/mjlab/viewer/native/viewer.py
+++ b/src/mjlab/viewer/native/viewer.py
@@ -431,11 +431,11 @@ class NativeMujocoViewer(BaseViewer):
     self.viewer.opt.frame = mujoco.mjtFrame.mjFRAME_WORLD.value
 
     if not self.cfg or not hasattr(self.cfg, "origin_type"):
-      self._set_camera_world()
+      self._set_camera_auto_track()
       return
 
     if self.cfg.origin_type == self.cfg.OriginType.WORLD:
-      self._set_camera_world()
+      self._set_camera_auto_track()
     elif self.cfg.origin_type == self.cfg.OriginType.ASSET_ROOT:
       self._set_camera_asset_root()
     else:  # ASSET_BODY
@@ -447,6 +447,21 @@ class NativeMujocoViewer(BaseViewer):
     )
     self.viewer.cam.azimuth = getattr(self.cfg, "azimuth", self.viewer.cam.azimuth)
     self.viewer.cam.distance = getattr(self.cfg, "distance", self.viewer.cam.distance)
+
+  def _set_camera_auto_track(self) -> None:
+    """Track first non-fixed body; fall back to free camera if none exists."""
+    assert self.viewer is not None
+    assert self.mjm is not None
+    for body_id in range(self.mjm.nbody):
+      is_weld = self.mjm.body_weldid[body_id] == 0
+      root_id = self.mjm.body_rootid[body_id]
+      root_is_mocap = self.mjm.body_mocapid[root_id] >= 0
+      if not (is_weld and not root_is_mocap):
+        self.viewer.cam.type = mujoco.mjtCamera.mjCAMERA_TRACKING.value
+        self.viewer.cam.trackbodyid = body_id
+        self.viewer.cam.fixedcamid = -1
+        return
+    self._set_camera_world()
 
   def _set_camera_world(self) -> None:
     """Configure free camera in world frame."""


### PR DESCRIPTION
## Summary

- Adds `_set_camera_auto_track()` to `NativeMujocoViewer` which iterates bodies using the same `is_fixed_body` logic as the Viser scene and sets `mjCAMERA_TRACKING` on the first non-fixed body
- Falls back to a free camera if no non-fixed body exists
- Replaces the `_set_camera_world()` calls in `_setup_camera()` for the default `WORLD` and no-config cases

This was missed when 716aaaa5 made tracking the default in the Viser viewer.

## Test plan

- [x] Launch native viewer on a locomotion task and confirm camera starts centered on the robot
- [x] Confirm `origin_type = ASSET_ROOT` / `ASSET_BODY` configs still work as before
- [x] Run `make check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)