### PR TITLE
Workaround rsl_rl bug: deepcopy ONNX model before CPU export

### DIFF
--- a/src/mjlab/rl/runner.py
+++ b/src/mjlab/rl/runner.py
@@ -1,3 +1,4 @@
+import copy
 import os
 
 import torch
@@ -34,7 +35,9 @@ class MjlabOnPolicyRunner(OnPolicyRunner):
     dynamic_axes being deprecated with the new TorchDynamo export path
     (torch>=2.9 default).
     """
-    onnx_model = self.alg.get_policy().as_onnx(verbose=verbose)
+    # Deep-copy because rsl_rl's _OnnxCNNModel shares CNN modules with the original
+    # policy; without this, .to("cpu") moves the live weights.
+    onnx_model = copy.deepcopy(self.alg.get_policy().as_onnx(verbose=verbose))
     onnx_model.to("cpu")
     onnx_model.eval()
     os.makedirs(path, exist_ok=True)


### PR DESCRIPTION
rsl_rl's `_OnnxCNNModel` shares CNN modules with the original policy instead of deep-copying them. Calling `.to("cpu")` for ONNX export moves the live CNN weights off device, crashing training on the next iteration.

Workaround: deep-copy the ONNX model before moving to CPU.