### PR TITLE
Call policy.reset() on manual environment reset

### DIFF
--- a/src/mjlab/viewer/base.py
+++ b/src/mjlab/viewer/base.py
@@ -336,6 +336,9 @@ class BaseViewer(ABC):
 
   def reset_environment(self) -> None:
     self.env.reset()
+    reset_fn = getattr(self.policy, "reset", None)
+    if reset_fn is not None:
+      reset_fn()
     self._step_count = 0
     self._sim_budget = 0.0
     self._last_error = None

--- a/tests/test_viewer_tick.py
+++ b/tests/test_viewer_tick.py
@@ -181,6 +181,24 @@ def test_reset_clears():
   assert v._last_error is None
 
 
+def test_reset_calls_policy_reset():
+  """reset_environment() calls policy.reset() if available."""
+  v = FakeViewer(step_dt=0.01)
+  v.policy = MagicMock()
+  v.policy.reset = MagicMock()
+
+  v.reset_environment()
+  v.policy.reset.assert_called_once()
+
+
+def test_reset_without_policy_reset():
+  """reset_environment() works fine when policy has no reset method."""
+  v = FakeViewer(step_dt=0.01)
+  v.policy = lambda obs: obs  # plain callable, no reset attribute
+
+  v.reset_environment()  # should not raise
+
+
 # Formatting and status.
 
 


### PR DESCRIPTION
Allows stateful policies (e.g. RNNs) to clear hidden state when the user resets the environment from the viewer. Plain callables without a reset method are unaffected.

Related: #724