### PR TITLE
Make neighbor env count configurable in ViewerConfig

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -242,8 +242,8 @@ How many environments can I visualize at once?
 Viewers render a small number of environments for performance reasons.
 
 - **Offscreen renderer** (for video recording): Renders the tracked
-  environment plus up to 2 nearest neighbors (see ``_MAX_EXTRA_ENVS``
-  in ``viewer/offscreen_renderer.py``).
+  environment plus its nearest neighbors. The count is controlled by
+  ``ViewerConfig.max_extra_envs`` (default 2).
 - **Native/Viser viewers**: Limited by MuJoCo's geometry buffer
   (default 10,000 geoms). The viewer shows whichever environments fit
   within the geometry budget.

--- a/src/mjlab/viewer/offscreen_renderer.py
+++ b/src/mjlab/viewer/offscreen_renderer.py
@@ -9,10 +9,6 @@ from mjlab.scene import Scene
 from mjlab.viewer.native.visualizer import MujocoNativeDebugVisualizer
 from mjlab.viewer.viewer_config import ViewerConfig
 
-# Max number of envs to visualize (performance/memory limit).
-# See FAQ: "How many environments can I visualize at once?"
-_MAX_EXTRA_ENVS = 2
-
 
 class OffscreenRenderer:
   def __init__(self, model: mujoco.MjModel, cfg: ViewerConfig, scene: Scene) -> None:
@@ -116,10 +112,10 @@ class OffscreenRenderer:
     We render a small local neighborhood around ``env_idx`` instead of the first
     N environments, so videos stay focused on the tracked robot and nearby peers.
     """
-    if _MAX_EXTRA_ENVS <= 0 or nworld <= 1:
+    if self._cfg.max_extra_envs <= 0 or nworld <= 1:
       return []
 
-    k = min(_MAX_EXTRA_ENVS, nworld - 1)
+    k = min(self._cfg.max_extra_envs, nworld - 1)
     origins = self._scene.env_origins[:nworld].cpu().numpy()
     ref = origins[env_idx]
     dist2 = np.sum((origins - ref) ** 2, axis=1)

--- a/src/mjlab/viewer/viewer_config.py
+++ b/src/mjlab/viewer/viewer_config.py
@@ -24,6 +24,8 @@ class ViewerConfig:
   entity_name: str | None = None
   body_name: str | None = None
   env_idx: int = 0
+  max_extra_envs: int = 2
+  """Number of neighboring environments to render around ``env_idx``."""
   enable_reflections: bool = True
   enable_shadows: bool = True
   height: int = 240


### PR DESCRIPTION
Replace the hardcoded `_MAX_EXTRA_ENVS` constant with a `ViewerConfig.max_extra_envs` field, letting users control how many neighboring environments are rendered around the tracked subject. Defaults to 2, preserving existing behavior.