### PR TITLE
Chunk batched eigh in pseudo_inertia DR to avoid cusolver limits

### DIFF
--- a/src/mjlab/envs/mdp/dr/body.py
+++ b/src/mjlab/envs/mdp/dr/body.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import warnings
 from typing import TYPE_CHECKING
 
@@ -26,6 +27,10 @@ from ._types import Distribution, Operation
 
 if TYPE_CHECKING:
   from mjlab.envs import ManagerBasedRlEnv
+
+# cusolverDnXsyevBatched has an undocumented batch size limit (~32k).
+# We chunk at 16k to stay well within the limit while keeping overhead low.
+_MAX_EIGH_BATCH = 16384
 
 # Pseudo-inertia helpers.
 
@@ -118,11 +123,8 @@ def _decompose_pseudo_inertia_J(
 
   # Columns of V are principal axes in body frame; eigenvalues are principal moments.
   # Chunk to avoid cusolver batch size limits on some GPUs.
-  _MAX_EIGH_BATCH = 16384
   batch_shape = I_com.shape[:-2]
-  flat_total = 1
-  for s in batch_shape:
-    flat_total *= s
+  flat_total = math.prod(batch_shape) if batch_shape else 1
   if flat_total > _MAX_EIGH_BATCH:
     I_flat = I_com.reshape(flat_total, 3, 3)
     pm_chunks, v_chunks = [], []

--- a/tests/test_domain_randomization.py
+++ b/tests/test_domain_randomization.py
@@ -945,6 +945,35 @@ def test_pseudo_inertia_partial_env_ids(device):
   assert torch.allclose(mass_after[1], mass_before[1], atol=1e-6)
 
 
+def test_decompose_pseudo_inertia_eigh_chunking():
+  """Chunked eigh produces the same result as a single call."""
+  from mjlab.envs.mdp.dr.body import (
+    _MAX_EIGH_BATCH,
+    _decompose_pseudo_inertia_J,
+    _reconstruct_pseudo_inertia_J,
+  )
+
+  torch.manual_seed(0)
+  # Build a batch larger than the chunk limit so the chunking path is taken.
+  n = _MAX_EIGH_BATCH + 100
+  mass = torch.rand(n) + 0.1
+  ipos = torch.randn(n, 3) * 0.05
+  inertia = torch.rand(n, 3) + 0.1
+  iquat = torch.randn(n, 4)
+  iquat = iquat / iquat.norm(dim=-1, keepdim=True)
+
+  J = _reconstruct_pseudo_inertia_J(mass, ipos, inertia, iquat)
+
+  # Decompose with chunking (the production path).
+  mass_out, ipos_out, pm_out, iquat_out = _decompose_pseudo_inertia_J(J)
+
+  # Reconstruct and compare: the round-trip should be near-exact.
+  J_rt = _reconstruct_pseudo_inertia_J(mass_out, ipos_out, pm_out, iquat_out)
+  assert torch.allclose(J, J_rt, atol=1e-5), (
+    f"Round-trip mismatch; max error: {(J - J_rt).abs().max()}"
+  )
+
+
 # Camera / Light DR tests.
 
 


### PR DESCRIPTION
## Summary
- `cusolverDnXsyevBatched` has an undocumented batch size limit (~32k) that causes `CUSOLVER_STATUS_INVALID_VALUE` when `dr.pseudo_inertia` is applied across many bodies and environments (e.g. 21 bodies × 10k envs = 210k batches).
- This splits the `torch.linalg.eigh` call in `_decompose_pseudo_inertia_J` into chunks of 16k, which is mathematically identical to the single call but stays within the cusolver limit.
- The downstream `torch.linalg.det` (3×3 determinant) and `quat_from_matrix` (pure algebra) are unaffected by the batch limit and don't require chunking.

## Test plan
- [x] Verified that training with `dr.pseudo_inertia` on 21 bodies × 10k envs (210k batches) no longer crashes with `cusolver error: CUSOLVER_STATUS_INVALID_VALUE`
- [x] Previously crashed with as few as 4 bodies × 10k envs (40k batches) without this fix
- [x] Confirmed no behavioral difference: chunked eigendecomposition produces identical results since each 3×3 matrix is decomposed independently


