### PR TITLE
Add apply_body_impulse event and force visualization

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -17,6 +17,9 @@ Upcoming version (not yet released)
 Added
 ^^^^^
 
+- Added ``"step"`` event mode that fires every environment step.
+- Added ``apply_body_impulse`` event for applying transient external wrenches
+  to bodies with configurable duration and optional application point offset.
 - ONNX auto-export and metadata attachment for manipulation tasks (lift cube)
   on every checkpoint save, matching the velocity and tracking task behavior.
 - Cloud training support via `SkyPilot <https://skypilot.readthedocs.io/>`_
@@ -116,6 +119,10 @@ Added
 Changed
 ^^^^^^^
 
+- Native viewer now syncs ``xfrc_applied`` to the render buffer and draws
+  arrows for any nonzero applied forces. Mouse perturbation forces are
+  converted to ``qfrc_applied`` (generalized joint space) so they coexist
+  with programmatic forces on ``xfrc_applied`` without conflict.
 - Reorganized the Viser Controls tab into a cleaner folder hierarchy:
   Info, Simulation, Commands, Scene (with Environment, Camera, Debug Viz,
   Contacts sub-folders), and Camera Feeds. The Environment folder is

--- a/docs/source/viewers.rst
+++ b/docs/source/viewers.rst
@@ -149,6 +149,13 @@ playback. The force transfers into the simulation on the next step,
 making it easy to test balance recovery, grasp robustness, or
 disturbance rejection without writing any code.
 
+Mouse perturbation forces are kept separate from programmatic forces
+(e.g. ``apply_body_impulse``) by routing them through different MuJoCo
+channels: programmatic forces use ``xfrc_applied`` (Cartesian body
+forces), while mouse forces are converted to ``qfrc_applied``
+(generalized joint forces) via ``mj_applyFT``. Both channels are summed
+during forward dynamics, so they coexist without conflict.
+
 **Domain randomization visualization.**
 The native viewer syncs all visual DR fields from GPU to CPU each
 frame. Randomized geom colors, sizes, positions, material colors,

--- a/scripts/demos/body_impulse.py
+++ b/scripts/demos/body_impulse.py
@@ -1,0 +1,194 @@
+"""Body impulse demo with force visualization.
+
+A cylinder hangs from a ball joint like a punching bag. Random impulses
+swing it around while magenta arrows show the applied forces. Both native
+and Viser viewers render the arrows via ``apply_body_impulse``'s built-in
+debug visualization.
+
+Run with:
+  uv run mjpython scripts/demos/body_impulse.py                      # macOS
+  uv run python scripts/demos/body_impulse.py                        # Linux
+  uv run python scripts/demos/body_impulse.py --viewer viser         # Viser
+"""
+
+from __future__ import annotations
+
+import math
+import os
+
+import mujoco
+import torch
+import tyro
+
+import mjlab
+from mjlab.entity import EntityCfg
+from mjlab.envs import ManagerBasedRlEnv, ManagerBasedRlEnvCfg
+from mjlab.envs.mdp.events import apply_body_impulse, reset_scene_to_default
+from mjlab.managers.event_manager import EventTermCfg
+from mjlab.managers.scene_entity_config import SceneEntityCfg
+from mjlab.rl import RslRlVecEnvWrapper
+from mjlab.scene import SceneCfg
+from mjlab.utils.torch import configure_torch_backends
+from mjlab.viewer import NativeMujocoViewer, ViserPlayViewer
+
+BAG_RADIUS = 0.12  # punching bag radius
+BAG_HALF_HEIGHT = 0.25  # punching bag half-height
+BAG_DENSITY = 500.0  # ~5.7 kg
+ROPE_LEN = 0.3  # rope length in meters
+CEILING_Z = 1.0  # pivot height
+ROPE_RADIUS = 0.008  # visual rope thickness
+
+
+def create_pendulum_spec() -> mujoco.MjSpec:
+  spec = mujoco.MjSpec()
+  spec.modelname = "impulse_punching_bag"
+
+  # Ground plane.
+  ground = spec.worldbody.add_geom()
+  ground.type = mujoco.mjtGeom.mjGEOM_PLANE
+  ground.size[:] = (5.0, 5.0, 0.1)
+  ground.rgba[:] = (0.4, 0.5, 0.6, 1.0)
+
+  # Light.
+  light = spec.worldbody.add_light()
+  light.pos[:] = (0, 0, 4)
+  light.dir[:] = (0, 0, -1)
+  light.diffuse[:] = (0.8, 0.8, 0.8)
+
+  # Ceiling anchor (visual only).
+  anchor = spec.worldbody.add_geom()
+  anchor.type = mujoco.mjtGeom.mjGEOM_BOX
+  anchor.size[:] = (0.04, 0.04, 0.02)
+  anchor.pos[:] = (0, 0, CEILING_Z)
+  anchor.rgba[:] = (0.3, 0.3, 0.3, 1.0)
+  anchor.contype = 0
+  anchor.conaffinity = 0
+
+  # Pendulum body. Ball joint pivot is at (0, 0, CEILING_Z).
+  bag_body = spec.worldbody.add_body()
+  bag_body.name = "bag"
+  bag_body.pos[:] = (0, 0, CEILING_Z)
+
+  joint = bag_body.add_joint()
+  joint.name = "bag_joint"
+  joint.type = mujoco.mjtJoint.mjJNT_BALL
+  joint.damping = 3.0
+  joint.frictionloss = 0.5
+
+  # Rope (visual only capsule from pivot to bag center).
+  rope = bag_body.add_geom()
+  rope.type = mujoco.mjtGeom.mjGEOM_CAPSULE
+  rope.size[:2] = (ROPE_RADIUS, ROPE_LEN / 2)
+  rope.pos[:] = (0, 0, -ROPE_LEN / 2)
+  rope.rgba[:] = (0.5, 0.4, 0.3, 1.0)
+  rope.contype = 0
+  rope.conaffinity = 0
+  rope.mass = 0.001  # negligible mass
+
+  # Punching bag cylinder hanging at the end of the rope.
+  geom = bag_body.add_geom()
+  geom.name = "bag_geom"
+  geom.type = mujoco.mjtGeom.mjGEOM_CYLINDER
+  geom.size[:2] = (BAG_RADIUS, BAG_HALF_HEIGHT)
+  geom.pos[:] = (0, 0, -ROPE_LEN - BAG_HALF_HEIGHT)
+  geom.density = BAG_DENSITY
+  geom.rgba[:] = (0.55, 0.15, 0.1, 0.35)
+
+  return spec
+
+
+def create_env_cfg() -> ManagerBasedRlEnvCfg:
+  bag_cfg = EntityCfg(
+    spec_fn=create_pendulum_spec,
+    init_state=EntityCfg.InitialStateCfg(
+      pos=(0.0, 0.0, 0.0),
+    ),
+  )
+
+  bag_mass = BAG_DENSITY * math.pi * BAG_RADIUS**2 * (2 * BAG_HALF_HEIGHT)
+  weight = bag_mass * 9.81
+  force_mag = weight * 0.8  # 0.8x body weight
+
+  cfg = ManagerBasedRlEnvCfg(
+    decimation=10,
+    scene=SceneCfg(
+      num_envs=1,
+      env_spacing=0.0,
+      extent=2.0,
+      entities={"bag": bag_cfg},
+    ),
+    events={
+      "reset_scene_to_default": EventTermCfg(
+        func=reset_scene_to_default,
+        mode="reset",
+      ),
+      "impulse": EventTermCfg(
+        func=apply_body_impulse,
+        mode="step",
+        params={
+          "force_range": (-force_mag, force_mag),
+          "torque_range": (-force_mag * 0.3, force_mag * 0.3),
+          "duration_s": (0.05, 0.1),
+          "cooldown_s": (1.0, 2.5),
+          "asset_cfg": SceneEntityCfg("bag", body_names=("bag",)),
+        },
+      ),
+    },
+  )
+
+  cfg.viewer.distance = 1.8
+  cfg.viewer.elevation = -10.0
+
+  return cfg
+
+
+class ZeroPolicy:
+  def __call__(self, obs: object) -> torch.Tensor:
+    del obs
+    return torch.zeros(1, 0)
+
+
+def main(device: str = "cpu", viewer: str = "auto") -> None:
+  configure_torch_backends()
+
+  env_cfg = create_env_cfg()
+  env = ManagerBasedRlEnv(cfg=env_cfg, device=device)
+  env = RslRlVecEnvWrapper(env)
+
+  # Print force scaling info.
+  mjm = env.unwrapped.sim.mj_model
+  bag_id = mujoco.mj_name2id(mjm, mujoco.mjtObj.mjOBJ_BODY, "bag")
+  subtree_mass = mjm.body_subtreemass[bag_id]
+  weight = subtree_mass * 9.81
+  bag_mass = BAG_DENSITY * math.pi * BAG_RADIUS**2 * (2 * BAG_HALF_HEIGHT)
+  force_mag = bag_mass * 9.81 * 0.8
+  print("=" * 50)
+  print("Body Impulse Demo (punching bag)")
+  print(f"  Bag mass         : {bag_mass:.2f} kg")
+  print(f"  Bag weight       : {weight:.2f} N")
+  print(f"  Rope length      : {ROPE_LEN} m")
+  print(f"  Force range      : +/-{force_mag:.0f} N")
+  print(f"  Force/weight     : {force_mag / weight:.1f}x")
+  print("=" * 50)
+
+  if viewer == "auto":
+    has_display = bool(os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"))
+    resolved = "native" if has_display else "viser"
+  else:
+    resolved = viewer
+
+  policy = ZeroPolicy()
+  if resolved == "native":
+    print("Launching native viewer...")
+    NativeMujocoViewer(env, policy).run()
+  elif resolved == "viser":
+    print("Launching Viser viewer...")
+    ViserPlayViewer(env, policy).run()
+  else:
+    raise ValueError(f"Unknown viewer: {viewer}")
+
+  env.close()
+
+
+if __name__ == "__main__":
+  tyro.cli(main, config=mjlab.TYRO_FLAGS)

--- a/src/mjlab/envs/manager_based_rl_env.py
+++ b/src/mjlab/envs/manager_based_rl_env.py
@@ -263,6 +263,7 @@ class ManagerBasedRlEnv:
     self.manager_visualizers = {}
     if getattr(self.command_manager, "active_terms", None):
       self.manager_visualizers["command_manager"] = self.command_manager
+    self.manager_visualizers["event_manager"] = self.event_manager
 
   def load_managers(self) -> None:
     """Load and initialize all managers.
@@ -401,6 +402,8 @@ class ManagerBasedRlEnv:
 
     self.command_manager.compute(dt=self.step_dt)
 
+    if "step" in self.event_manager.available_modes:
+      self.event_manager.apply(mode="step", dt=self.step_dt)
     if "interval" in self.event_manager.available_modes:
       self.event_manager.apply(mode="interval", dt=self.step_dt)
 

--- a/src/mjlab/envs/mdp/events.py
+++ b/src/mjlab/envs/mdp/events.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import torch
@@ -9,6 +10,7 @@ import torch
 from mjlab.entity import Entity
 from mjlab.managers.scene_entity_config import SceneEntityCfg
 from mjlab.utils.lab_api.math import (
+  quat_apply,
   quat_from_euler_xyz,
   quat_mul,
   sample_uniform,
@@ -16,6 +18,7 @@ from mjlab.utils.lab_api.math import (
 
 if TYPE_CHECKING:
   from mjlab.envs import ManagerBasedRlEnv
+  from mjlab.viewer.debug_visualizer import DebugVisualizer
 
 _DEFAULT_ASSET_CFG = SceneEntityCfg("robot")
 
@@ -351,3 +354,225 @@ def apply_external_force_torque(
   asset.write_external_wrench_to_sim(
     forces, torques, env_ids=env_ids, body_ids=asset_cfg.body_ids
   )
+
+
+class apply_body_impulse:
+  """Apply random impulses to bodies for a sampled duration.
+
+  Simulates transient external disturbances such as bumps, wind gusts, or
+  collisions with unseen objects. A constant force/torque wrench is applied
+  to one or more bodies for a randomly sampled duration, followed by a
+  cooldown period of silence before the next impulse.
+
+  **Lifecycle of a single impulse:**
+
+  1. **Cooldown.** The event is idle for a random duration sampled from ``cooldown_s``.
+    No force is applied.
+  2. **Trigger.** A force vector is sampled uniformly per component from ``force_range``
+    and written to ``xfrc_applied`` on the selected bodies.
+  3. **Sustain.** The force is held constant for a random duration sampled from
+    ``duration_s``.
+  4. **Expire.** The force is zeroed and the cooldown restarts at step 1.
+
+  Each environment runs its own independent timer so impulses are decorrelated across
+  the batch.
+
+  **Application point.** By default, forces act at each body's center of mass.
+  ``body_point_offset`` shifts the application point in the body's local frame, for
+  example ``(0, 0, 0.1)`` for 10 cm above the CoM. The offset produces additional
+  torque via the cross product ``offset x force``, causing the body to tip rather than
+  just translate. This is analogous to choosing where on the body an external push is
+  applied.
+
+  Use with ``mode="step"``.
+  """
+
+  @dataclass
+  class VizCfg:
+    """Arrow visualization settings for active impulse forces."""
+
+    rgba: tuple[float, float, float, float] = (0.9, 0.2, 0.8, 0.9)
+    """Arrow color (RGBA)."""
+    scale: float = 0.005
+    """Arrow length in meters per Newton of force."""
+    width: float = 0.015
+    """Arrow shaft width in meters."""
+    min_force: float = 1.0
+    """Minimum force magnitude (N) below which arrows are hidden."""
+
+  def __init__(self, cfg, env: ManagerBasedRlEnv):
+    self._asset: Entity = env.scene[cfg.params["asset_cfg"].name]
+    self._body_ids = cfg.params["asset_cfg"].body_ids
+    self._num_envs = env.num_envs
+    self._device = env.device
+    self._step_dt = env.step_dt
+    self._viz_cfg: apply_body_impulse.VizCfg = cfg.params.get(
+      "viz_cfg", apply_body_impulse.VizCfg()
+    )
+    offset = cfg.params.get("body_point_offset", None)
+    self._body_point_offset: torch.Tensor | None = (
+      torch.tensor(offset, device=self._device, dtype=torch.float32)
+      if offset is not None
+      else None
+    )
+
+    self._num_bodies = (
+      len(self._body_ids)
+      if isinstance(self._body_ids, list)
+      else self._asset.num_bodies
+    )
+
+    self._time_remaining = torch.zeros(self._num_envs, device=self._device)
+    self._interval_time_left = torch.zeros(self._num_envs, device=self._device)
+    self._active = torch.zeros(self._num_envs, device=self._device, dtype=torch.bool)
+
+  def __call__(
+    self,
+    env: ManagerBasedRlEnv,
+    env_ids: torch.Tensor | None,
+    force_range: tuple[float, float],
+    torque_range: tuple[float, float],
+    duration_s: tuple[float, float],
+    cooldown_s: tuple[float, float],
+    asset_cfg: SceneEntityCfg,
+    body_point_offset: tuple[float, float, float] | None = None,
+  ) -> None:
+    """Tick impulse state: expire old impulses, trigger new ones.
+
+    Args:
+      env: The environment instance.
+      env_ids: Unused (step events always operate on all envs).
+      force_range: ``(min, max)`` uniform range for each force component (N).
+      torque_range: ``(min, max)`` uniform range for each torque component (Nm).
+      duration_s: ``(min, max)`` uniform range for impulse duration in seconds.
+      cooldown_s: ``(min, max)`` uniform range for the cooldown between consecutive
+        impulses in seconds.
+      asset_cfg: Entity and body selection. ``body_ids`` on the config selects which
+        bodies receive forces.
+      body_point_offset: Optional ``(x, y, z)`` offset in the body frame where the
+        force is applied. Generates additional torque via ``cross(offset, force)``.
+    """
+    del env, env_ids, asset_cfg  # Unused.
+    dt = self._step_dt
+
+    # Decrement timers for active envs.
+    self._time_remaining[self._active] -= dt
+
+    # Clear expired impulses and resample their interval timers.
+    expired = self._active & (self._time_remaining <= 0)
+    if expired.any():
+      expired_ids = expired.nonzero(as_tuple=False).squeeze(-1)
+      zeros = torch.zeros((len(expired_ids), self._num_bodies, 3), device=self._device)
+      self._asset.write_external_wrench_to_sim(
+        zeros, zeros, env_ids=expired_ids, body_ids=self._body_ids
+      )
+      self._active[expired_ids] = False
+      self._time_remaining[expired_ids] = 0.0
+      int_low, int_high = cooldown_s
+      self._interval_time_left[expired_ids] = (
+        torch.rand(len(expired_ids), device=self._device) * (int_high - int_low)
+        + int_low
+      )
+
+    # Decrement interval timers.
+    self._interval_time_left -= dt
+
+    # Trigger new impulses for eligible envs.
+    eligible = (~self._active) & (self._interval_time_left <= 0)
+    if not eligible.any():
+      return
+
+    trigger_ids = eligible.nonzero(as_tuple=False).squeeze(-1)
+    n = len(trigger_ids)
+
+    # Sample forces and torques.
+    size = (n, self._num_bodies, 3)
+    forces = sample_uniform(*force_range, size, self._device)
+    torques = sample_uniform(*torque_range, size, self._device)
+
+    # Adjust torque for off-CoM application point.
+    if body_point_offset is not None:
+      offset_local = torch.tensor(
+        body_point_offset, device=self._device, dtype=torch.float32
+      )
+      body_quat = self._asset.data.body_com_quat_w[trigger_ids][:, self._body_ids]
+      # Rotate offset into world frame: (n, num_bodies, 3).
+      offset_w = quat_apply(
+        body_quat.reshape(-1, 4), offset_local.expand(n * self._num_bodies, 3)
+      ).reshape(n, self._num_bodies, 3)
+      torques = torques + torch.cross(offset_w, forces, dim=-1)
+
+    self._asset.write_external_wrench_to_sim(
+      forces, torques, env_ids=trigger_ids, body_ids=self._body_ids
+    )
+
+    # Sample duration and set timers.
+    dur_low, dur_high = duration_s
+    self._time_remaining[trigger_ids] = (
+      torch.rand(n, device=self._device) * (dur_high - dur_low) + dur_low
+    )
+    self._active[trigger_ids] = True
+
+    # Resample interval timers.
+    int_low, int_high = cooldown_s
+    self._interval_time_left[trigger_ids] = (
+      torch.rand(n, device=self._device) * (int_high - int_low) + int_low
+    )
+
+  def debug_vis(self, visualizer: DebugVisualizer) -> None:
+    """Draw arrows for active impulse forces."""
+    if not self._active.any():
+      return
+    viz = self._viz_cfg
+    min_sq = viz.min_force * viz.min_force
+    wrench = self._asset.data.body_external_wrench  # (nworld, nbody, 6)
+    com_pos = self._asset.data.body_com_pos_w  # (nworld, nbody, 3)
+    offset = self._body_point_offset
+    com_quat = self._asset.data.body_com_quat_w if offset is not None else None
+    for env_idx in visualizer.get_env_indices(self._num_envs):
+      if not self._active[env_idx]:
+        continue
+      for i in range(wrench.shape[1]):
+        force = wrench[env_idx, i, :3]
+        if (force * force).sum().item() < min_sq:
+          continue
+        force_np = force.cpu().numpy()
+        start_np = com_pos[env_idx, i].cpu().numpy()
+        if offset is not None and com_quat is not None:
+          offset_w = quat_apply(com_quat[env_idx, i], offset)
+          start_np = start_np + offset_w.cpu().numpy()
+        end_np = start_np + force_np * viz.scale
+        visualizer.add_arrow(
+          start=start_np,
+          end=end_np,
+          color=viz.rgba,
+          width=viz.width,
+        )
+
+  def reset(self, env_ids: torch.Tensor | slice | None = None) -> None:
+    if env_ids is None:
+      env_ids = slice(None)
+
+    # Clear forces for reset envs.
+    if isinstance(env_ids, slice):
+      reset_ids = env_ids
+    else:
+      reset_ids = env_ids
+
+    if self._active[reset_ids].any():
+      if isinstance(env_ids, slice):
+        active_ids = self._active.nonzero(as_tuple=False).squeeze(-1)
+      else:
+        active_ids = env_ids[self._active[env_ids]]
+      if len(active_ids) > 0:
+        zeros = torch.zeros(
+          (len(active_ids), self._num_bodies, 3),
+          device=self._device,
+        )
+        self._asset.write_external_wrench_to_sim(
+          zeros, zeros, env_ids=active_ids, body_ids=self._body_ids
+        )
+
+    self._time_remaining[reset_ids] = 0.0
+    self._interval_time_left[reset_ids] = 0.0
+    self._active[reset_ids] = False

--- a/src/mjlab/managers/event_manager.py
+++ b/src/mjlab/managers/event_manager.py
@@ -15,10 +15,11 @@ from mjlab.managers.manager_base import ManagerBase, ManagerTermBaseCfg
 
 if TYPE_CHECKING:
   from mjlab.envs import ManagerBasedRlEnv
+  from mjlab.viewer.debug_visualizer import DebugVisualizer
 
 F = Callable[..., None]
 
-EventMode = Literal["startup", "reset", "interval"]
+EventMode = Literal["startup", "reset", "interval", "step"]
 
 
 class RecomputeLevel(enum.IntEnum):
@@ -102,23 +103,27 @@ class EventTermCfg(ManagerTermBaseCfg):
   Event terms trigger operations at specific simulation events. They're commonly
   used for domain randomization, state resets, and periodic perturbations.
 
-  The three modes determine when the event fires:
+  The four modes determine when the event fires:
 
   - ``"startup"``: Once when the environment initializes. Use for parameters that
-    should be randomized per-environment but stay constant within an episode (
-    e.g., domain randomization).
+    should be randomized per-environment but stay constant within an episode (e.g.,
+    domain randomization).
 
-  - ``"reset"``: On every episode reset. Use for parameters that should vary
-    between episodes (e.g., initial robot pose, domain randomization).
+  - ``"reset"``: On every episode reset. Use for parameters that should vary between
+    episodes (e.g., initial robot pose, domain randomization).
 
-  - ``"interval"``: Periodically during simulation, controlled by
-    ``interval_range_s``. Use for perturbations that should happen during
-    episodes (e.g., pushing the robot, external disturbances).
+  - ``"interval"``: Periodically during simulation, controlled by ``interval_range_s``.
+    Use for perturbations that should happen during episodes (e.g., pushing the robot,
+    external disturbances).
+
+  - ``"step"``: Every environment step, unconditionally on all envs. Use for terms that
+    manage per-step state such as force lifetimes (e.g., ``apply_body_impulse``).
   """
 
   mode: EventMode
   """When the event triggers: ``"startup"`` (once at init), ``"reset"`` (every
-  episode), or ``"interval"`` (periodically during simulation)."""
+  episode), ``"interval"`` (periodically during simulation), or ``"step"`` (every
+  environment step)."""
 
   interval_range_s: tuple[float, float] | None = None
   """Time range in seconds for interval mode. The next trigger time is uniformly
@@ -247,6 +252,10 @@ class EventManager(ManagerBase):
       raise ValueError(
         f"Event mode '{mode}' requires the total number of environment steps to be provided."
       )
+    if mode == "step" and dt is None:
+      raise ValueError(
+        f"Event mode '{mode}' requires the time-step of the environment."
+      )
 
     strongest_fired = RecomputeLevel.none
 
@@ -276,6 +285,9 @@ class EventManager(ManagerBase):
             self._interval_term_time_left[index][valid_env_ids] = sampled_time
             term_cfg.func(self._env, valid_env_ids, **term_cfg.params)
             fired = True
+      elif mode == "step":
+        term_cfg.func(self._env, None, **term_cfg.params)
+        fired = True
       elif mode == "reset":
         assert global_env_step_count is not None
         min_step_count = term_cfg.min_step_count_between_reset
@@ -315,6 +327,13 @@ class EventManager(ManagerBase):
 
     if strongest_fired != RecomputeLevel.none:
       self._env.sim.recompute_constants(strongest_fired)
+
+  def debug_vis(self, visualizer: "DebugVisualizer") -> None:
+    """Delegate debug visualization to class-based event terms."""
+    for mode_cfgs in self._mode_class_term_cfgs.values():
+      for term_cfg in mode_cfgs:
+        if hasattr(term_cfg.func, "debug_vis"):
+          term_cfg.func.debug_vis(visualizer)
 
   def _prepare_terms(self) -> None:
     self._interval_term_time_left: list[torch.Tensor] = list()

--- a/src/mjlab/viewer/native/viewer.py
+++ b/src/mjlab/viewer/native/viewer.py
@@ -1,4 +1,43 @@
-"""Environment viewer built on MuJoCo's passive viewer."""
+"""Environment viewer built on MuJoCo's passive viewer.
+
+Overview
+--------
+The simulation runs on the GPU via mujoco_warp, but MuJoCo's passive viewer
+requires CPU ``MjModel`` and ``MjData`` structures. Each frame, this module
+copies the GPU state for one environment into CPU buffers, calls
+``mj_forward`` to recompute kinematics and contacts, and hands the result to
+the render thread via ``v.sync()``. Contacts visible in the viewer are
+computed by C MuJoCo on the CPU, not by mujoco_warp on the GPU.
+
+The per frame sync has four steps:
+
+1. ``_sync_env_state_to_mjdata``: copy ``qpos``, ``qvel``, ``mocap``, and
+   ``xfrc_applied`` from GPU tensors into CPU ``MjData``.
+2. ``mj_forward``: recompute kinematics, collisions, and derived quantities.
+3. ``_sync_model_fields``: if domain randomization expanded visual fields
+   (geom colors, body poses, camera parameters, etc.), copy the per world
+   values from GPU ``sim.model`` into CPU ``MjModel``.
+4. ``v.sync()``: hand ``MjModel``/``MjData`` to the passive viewer's render
+   thread.
+
+For multi environment scenes, steps 1 and 2 are repeated for neighboring
+environments into a secondary ``MjData`` (``self.vd``), and their geoms are
+injected via ``mjv_addGeoms``.
+
+External force channels
+-----------------------
+MuJoCo sums two external force inputs during forward dynamics:
+
+* ``xfrc_applied``: Cartesian forces per body (GPU to CPU, for rendering).
+* ``qfrc_applied``: generalized forces per DoF (CPU to GPU, for mouse input).
+
+Programmatic forces (e.g. ``apply_body_impulse``) write to ``xfrc_applied``
+on the GPU and flow one way to the CPU ``MjData`` for visualization. Mouse
+perturbation forces flow the opposite direction: the viewer computes them on
+the CPU via ``mjv_applyPerturbForce``, converts to joint space with
+``mj_applyFT``, and writes to ``qfrc_applied`` on the GPU. Each field flows
+in one direction only, so the two sources never overwrite each other.
+"""
 
 from __future__ import annotations
 
@@ -49,6 +88,8 @@ class _SimDataProtocol(Protocol):
   qvel: "_TensorArrayProtocol"
   mocap_pos: "_TensorArrayProtocol"
   mocap_quat: "_TensorArrayProtocol"
+  xfrc_applied: "_TensorArrayProtocol"
+  qfrc_applied: "_TensorArrayProtocol"
 
 
 class _CpuArrayProtocol(Protocol):
@@ -257,6 +298,7 @@ class NativeMujocoViewer(BaseViewer):
     if self.mjm.nmocap > 0:
       target_data.mocap_pos[:] = sim_data.mocap_pos[env_idx].cpu().numpy()
       target_data.mocap_quat[:] = sim_data.mocap_quat[env_idx].cpu().numpy()
+    target_data.xfrc_applied[:] = sim_data.xfrc_applied[env_idx].cpu().numpy()
 
   def _render_other_env_geoms(
     self,
@@ -318,16 +360,42 @@ class NativeMujocoViewer(BaseViewer):
       dst[:] = src.reshape(dst.shape)
 
   def sync_viewer_to_env(self) -> None:
-    """Copy perturbation forces from viewer to env."""
-    if not self.enable_perturbations or self._is_paused or not self.mjd:
+    """Sync mouse perturbation to sim via ``qfrc_applied``.
+
+    Mouse perturbation forces are converted from Cartesian body space
+    (``xfrc_applied``) to generalized joint space (``qfrc_applied``)
+    so that they coexist with programmatic forces on ``xfrc_applied``.
+    See the module docstring for details on the channel separation.
+    """
+    v = self.viewer
+    if v is None or self.mjm is None or self.mjd is None:
       return
-    assert self.mjm is not None
-    with self._mj_lock:
-      xfrc = torch.as_tensor(
-        self.mjd.xfrc_applied, dtype=torch.float, device=self.env.device
-      )
+
     sim_data = self.env.unwrapped.sim.data
-    sim_data.xfrc_applied[self.env_idx] = xfrc[None]
+    pert = v.perturb
+
+    if pert.active != 0 and pert.select > 0:
+      # Compute mouse perturbation force in Cartesian space.
+      mujoco.mjv_applyPerturbForce(self.mjm, self.mjd, pert)
+
+      body_id = pert.select
+      force = self.mjd.xfrc_applied[body_id, :3].copy()
+      torque = self.mjd.xfrc_applied[body_id, 3:].copy()
+      point = self.mjd.xipos[body_id].copy()
+
+      # Convert to generalized forces.
+      qfrc = np.zeros(self.mjm.nv)
+      mujoco.mj_applyFT(self.mjm, self.mjd, force, torque, point, body_id, qfrc)
+
+      sim_data.qfrc_applied[self.env_idx] = torch.from_numpy(qfrc).to(
+        device=sim_data.qfrc_applied.device
+      )
+
+      # Clear so _sync_env_state_to_mjdata writes clean programmatic
+      # forces next frame.
+      self.mjd.xfrc_applied[body_id] = 0.0
+    else:
+      sim_data.qfrc_applied[self.env_idx] = 0.0
 
   def close(self) -> None:
     """Close viewer and cleanup."""

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -507,7 +507,180 @@ def test_sync_actuator_delays(device):
 
 
 # ===========================================================================
-# Section 4: Recomputation integration
+# Section 4: Step mode and apply_body_impulse
+# ===========================================================================
+
+
+def test_step_mode_fires_every_call(device):
+  """Step-mode events fire unconditionally on every apply() call."""
+  call_count = [0]
+
+  def counter(env, env_ids):
+    call_count[0] += 1
+
+  env = Mock()
+  env.num_envs = 2
+  env.device = device
+  env.scene = {}
+  env.sim = Mock()
+
+  cfg = {
+    "step_counter": EventTermCfg(
+      mode="step",
+      func=counter,
+      params={},
+    ),
+  }
+  manager = EventManager(cfg, env)
+
+  for _ in range(5):
+    manager.apply(mode="step", dt=0.02)
+
+  assert call_count[0] == 5
+
+
+def _make_impulse_env(device, num_envs=2, num_bodies=1, body_ids=None):
+  """Create a mock env for apply_body_impulse tests."""
+  if body_ids is None:
+    body_ids = [0]
+  env = Mock()
+  env.num_envs = num_envs
+  env.device = device
+  env.step_dt = 0.02
+
+  mock_entity = Mock()
+  mock_entity.num_bodies = num_bodies
+  mock_entity.data = Mock()
+  mock_entity.data.body_com_quat_w = torch.zeros(
+    (num_envs, num_bodies, 4), device=device
+  )
+  mock_entity.data.body_com_quat_w[..., 0] = 1.0
+  env.scene = {"robot": mock_entity}
+
+  asset_cfg = SceneEntityCfg("robot", body_ids=body_ids)
+  term_cfg = Mock()
+  term_cfg.params = {"asset_cfg": asset_cfg}
+  impulse = events.apply_body_impulse(cfg=term_cfg, env=env)
+  return env, mock_entity, asset_cfg, impulse
+
+
+def test_apply_body_impulse_basic(device):
+  """Impulse is applied and cleared after duration expires."""
+  env, mock_entity, asset_cfg, impulse = _make_impulse_env(
+    device, num_envs=2, num_bodies=3, body_ids=[1]
+  )
+
+  # First call: cooldown_s starts at 0 and gets decremented by dt,
+  # so it becomes <= 0 and triggers.
+  impulse(
+    env,
+    None,
+    force_range=(10.0, 10.0),
+    torque_range=(0.0, 0.0),
+    duration_s=(0.05, 0.05),
+    cooldown_s=(10.0, 10.0),
+    asset_cfg=asset_cfg,
+  )
+  assert impulse._active.any()
+  mock_entity.write_external_wrench_to_sim.assert_called()
+
+  def step():
+    impulse(
+      env,
+      None,
+      force_range=(10.0, 10.0),
+      torque_range=(0.0, 0.0),
+      duration_s=(0.05, 0.05),
+      cooldown_s=(10.0, 10.0),
+      asset_cfg=asset_cfg,
+    )
+
+  # Step a few times (duration is 0.05s, step_dt is 0.02s).
+  mock_entity.write_external_wrench_to_sim.reset_mock()
+  step()  # t=0.02, remaining=0.03
+  assert impulse._active.all()
+
+  step()  # t=0.04, remaining=0.01
+  assert impulse._active.all()
+
+  step()  # t=0.06, remaining=-0.01 -> cleared
+  assert not impulse._active.any()
+
+  # Verify write_external_wrench_to_sim was called with zeros to clear.
+  clear_call = None
+  for call in mock_entity.write_external_wrench_to_sim.call_args_list:
+    forces = call[0][0]
+    if torch.all(forces == 0):
+      clear_call = call
+  assert clear_call is not None
+
+
+def test_apply_body_impulse_with_offset(device):
+  """body_point_offset adds cross-product contribution to torque."""
+  env, mock_entity, asset_cfg, impulse = _make_impulse_env(
+    device, num_envs=1, num_bodies=1, body_ids=[0]
+  )
+
+  impulse(
+    env,
+    None,
+    force_range=(1.0, 1.0),
+    torque_range=(0.0, 0.0),
+    duration_s=(1.0, 1.0),
+    cooldown_s=(0.0, 0.0),
+    asset_cfg=asset_cfg,
+    body_point_offset=(0.0, 0.0, 0.5),
+  )
+
+  call_args = mock_entity.write_external_wrench_to_sim.call_args
+  forces = call_args[0][0]
+  torques = call_args[0][1]
+
+  # force is (1,1,1) applied at offset (0,0,0.5).
+  # cross((0,0,0.5), (1,1,1)) = (-0.5, 0.5, 0)
+  offset = torch.tensor([0.0, 0.0, 0.5], device=device)
+  expected_extra_torque = torch.cross(offset.unsqueeze(0), forces.squeeze(0), dim=-1)
+  torch.testing.assert_close(
+    torques.squeeze(0), expected_extra_torque, atol=1e-5, rtol=1e-5
+  )
+
+
+def test_apply_body_impulse_reset_clears(device):
+  """reset() zeros forces and resets internal state."""
+  env, mock_entity, asset_cfg, impulse = _make_impulse_env(
+    device, num_envs=2, num_bodies=1, body_ids=[0]
+  )
+
+  # Trigger impulse.
+  impulse(
+    env,
+    None,
+    force_range=(10.0, 10.0),
+    torque_range=(0.0, 0.0),
+    duration_s=(1.0, 1.0),
+    cooldown_s=(0.0, 0.0),
+    asset_cfg=asset_cfg,
+  )
+  assert impulse._active.all()
+
+  # Reset env 0.
+  mock_entity.write_external_wrench_to_sim.reset_mock()
+  impulse.reset(env_ids=torch.tensor([0], device=device))
+
+  assert not impulse._active[0]
+  assert impulse._active[1]
+  assert impulse._time_remaining[0] == 0.0
+
+  # Verify clearing write was called for env 0.
+  mock_entity.write_external_wrench_to_sim.assert_called_once()
+  call_args = mock_entity.write_external_wrench_to_sim.call_args
+  env_ids_arg = call_args[1]["env_ids"]
+  assert len(env_ids_arg) == 1
+  assert env_ids_arg[0].item() == 0
+
+
+# ===========================================================================
+# Section 5: Recomputation integration
 # ===========================================================================
 
 
@@ -598,7 +771,7 @@ def test_dof_armature_recompute(device):
 
 
 # ===========================================================================
-# Section 5: Recompute vs mj_setConst / recompiled MjSpec
+# Section 6: Recompute vs mj_setConst / recompiled MjSpec
 # ===========================================================================
 
 


### PR DESCRIPTION
Adds transient external force perturbations to bodies via a new `apply_body_impulse` step event, with configurable duration, cooldown, and application point offset.

https://github.com/user-attachments/assets/5413b218-7e9c-4f86-9843-589f29334867

*Random impulses hit the punching bag while mouse perturbation is applied simultaneously. The two force sources coexist because programmatic forces flow through `xfrc_applied` and mouse forces through `qfrc_applied`.*

- `apply_body_impulse` with `VizCfg` for arrow rendering. Events can now implement `debug_vis()`, delegated through `EventManager`.
- Native viewer syncs `xfrc_applied` GPU to CPU for rendering and converts mouse perturbation to `qfrc_applied` via `mj_applyFT` so the two never overwrite each other.
- Punching bag demo (`scripts/demos/body_impulse.py`).