### PR TITLE
Add AUTO camera origin type and fix WORLD to use free camera

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -123,6 +123,10 @@ Changed
   arrows for any nonzero applied forces. Mouse perturbation forces are
   converted to ``qfrc_applied`` (generalized joint space) so they coexist
   with programmatic forces on ``xfrc_applied`` without conflict.
+- ``ViewerConfig.OriginType.WORLD`` now configures a free camera at the
+  specified lookat point instead of auto tracking a body. A new ``AUTO``
+  origin type (now the default) preserves the previous auto tracking
+  behavior.
 - Reorganized the Viser Controls tab into a cleaner folder hierarchy:
   Info, Simulation, Commands, Scene (with Environment, Camera, Debug Viz,
   Contacts sub-folders), and Camera Feeds. The Environment folder is

--- a/src/mjlab/viewer/native/viewer.py
+++ b/src/mjlab/viewer/native/viewer.py
@@ -502,8 +502,10 @@ class NativeMujocoViewer(BaseViewer):
       self._set_camera_auto_track()
       return
 
-    if self.cfg.origin_type == self.cfg.OriginType.WORLD:
+    if self.cfg.origin_type == self.cfg.OriginType.AUTO:
       self._set_camera_auto_track()
+    elif self.cfg.origin_type == self.cfg.OriginType.WORLD:
+      self._set_camera_world()
     elif self.cfg.origin_type == self.cfg.OriginType.ASSET_ROOT:
       self._set_camera_asset_root()
     else:  # ASSET_BODY

--- a/src/mjlab/viewer/offscreen_renderer.py
+++ b/src/mjlab/viewer/offscreen_renderer.py
@@ -24,7 +24,10 @@ class OffscreenRenderer:
 
     self._model.vis.global_.offheight = cfg.height
     self._model.vis.global_.offwidth = cfg.width
-    if cfg.fovy is not None and cfg.origin_type == cfg.OriginType.WORLD:
+    if cfg.fovy is not None and cfg.origin_type in (
+      cfg.OriginType.AUTO,
+      cfg.OriginType.WORLD,
+    ):
       self._model.vis.global_.fovy = cfg.fovy
 
     if not cfg.enable_shadows:
@@ -136,7 +139,10 @@ class OffscreenRenderer:
     camera = mujoco.MjvCamera()
     mujoco.mjv_defaultFreeCamera(self._model, camera)
 
-    if self._cfg.origin_type == self._cfg.OriginType.WORLD:
+    if self._cfg.origin_type in (
+      self._cfg.OriginType.AUTO,
+      self._cfg.OriginType.WORLD,
+    ):
       # Free camera, no tracking.
       camera.type = mujoco.mjtCamera.mjCAMERA_FREE.value
       camera.fixedcamid = -1

--- a/src/mjlab/viewer/viewer_config.py
+++ b/src/mjlab/viewer/viewer_config.py
@@ -13,14 +13,17 @@ class ViewerConfig:
   class OriginType(enum.Enum):
     """The frame in which the camera position and target are defined."""
 
+    AUTO = enum.auto()
+    """Track the first non-fixed body, or fall back to a free camera."""
     WORLD = enum.auto()
-    """The origin of the world."""
+    """Free camera at the configured lookat point."""
     ASSET_ROOT = enum.auto()
-    """The center of the asset defined by entity_name."""
+    """Track the root body of the asset defined by entity_name."""
     ASSET_BODY = enum.auto()
-    """The center of the body defined by body_name in asset defined by entity_name."""
+    """Track the body defined by body_name in the asset defined by
+    entity_name."""
 
-  origin_type: OriginType = OriginType.WORLD
+  origin_type: OriginType = OriginType.AUTO
   entity_name: str | None = None
   body_name: str | None = None
   env_idx: int = 0


### PR DESCRIPTION
ViewerConfig.OriginType.WORLD was calling auto-track instead of configuring a free camera. This made it impossible to set a static camera via the config. Adds a new AUTO origin type (now the default) that preserves the existing auto-track behavior, and corrects WORLD to place a free camera at the configured lookat point.