### PR TITLE
Update GPU ID format in documentation to conform to `tyro.conf.UsePythonSyntaxForLiteralCollections`

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ uv run train Mjlab-Velocity-Flat-Unitree-G1 --env.scene.num-envs 4096
 
 ```bash
 uv run train Mjlab-Velocity-Flat-Unitree-G1 \
-  --gpu-ids 0 1 \
+  --gpu-ids "[0, 1]" \
   --env.scene.num-envs 4096
 ```
 

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -63,7 +63,7 @@ Does mjlab support multi-GPU training?
 Yes, mjlab supports **multi-GPU distributed training** using
 `torchrunx <https://github.com/apoorvkh/torchrunx>`_.
 
-- Use ``--gpu-ids 0 1`` (or ``--gpu-ids all``) when running the ``train``
+- Use ``--gpu-ids "[0, 1]"`` (or ``--gpu-ids all``) when running the ``train``
   command.
 - See the :doc:`training/distributed_training` for configuration details and examples.
 

--- a/docs/source/training/distributed_training.rst
+++ b/docs/source/training/distributed_training.rst
@@ -16,10 +16,10 @@ Usage
 .. code-block:: bash
 
     # Single GPU (default).
-    uv run train <task-name> --gpu-ids 0
+    uv run train <task-name> --gpu-ids "[0]"
 
     # Two GPUs.
-    uv run train <task-name> --gpu-ids 0 1
+    uv run train <task-name> --gpu-ids "[0, 1]"
 
     # All available GPUs.
     uv run train <task-name> --gpu-ids all
@@ -30,7 +30,7 @@ Usage
 Key points:
 
 - GPU indices are relative to ``CUDA_VISIBLE_DEVICES`` if set. For example,
-  ``CUDA_VISIBLE_DEVICES=2,3 uv run train ... --gpu-ids 0 1`` uses physical
+  ``CUDA_VISIBLE_DEVICES=2,3 uv run train ... --gpu-ids "[0, 1]"`` uses physical
   GPUs 2 and 3.
 - Single-GPU and CPU modes run directly without torchrunx.
 
@@ -100,10 +100,10 @@ This can be customized:
 .. code-block:: bash
 
     # Disable torchrunx file logging.
-    uv run train <task-name> --gpu-ids 0 1 --torchrunx-log-dir ""
+    uv run train <task-name> --gpu-ids "[0, 1]" --torchrunx-log-dir ""
 
     # Custom log directory.
-    uv run train <task-name> --gpu-ids 0 1 --torchrunx-log-dir /path/to/logs
+    uv run train <task-name> --gpu-ids "[0, 1]" --torchrunx-log-dir /path/to/logs
 
     # Environment variable (takes precedence over the flag).
-    TORCHRUNX_LOG_DIR=/tmp/logs uv run train <task-name> --gpu-ids 0 1
+    TORCHRUNX_LOG_DIR=/tmp/logs uv run train <task-name> --gpu-ids "[0, 1]"


### PR DESCRIPTION
Hi,

The current type of `gpu_ids` is `list[int] | Literal["all"] | None`. The train script does not accept a single integer `0`, or multiple integers `0 1` because of the flag `tyro.conf.UsePythonSyntaxForLiteralCollections`. This patch changes all `--gpu-ids` to a list of integer form.