### PR TITLE
Sort actuators (optional flag)

### DIFF
--- a/src/mjlab/entity/entity.py
+++ b/src/mjlab/entity/entity.py
@@ -80,7 +80,11 @@ class EntityCfg:
     default_factory=lambda: (lambda: mujoco.MjSpec())
   )
   articulation: EntityArticulationInfoCfg | None = None
-  sort_actuators: bool = True
+  sort_actuators: bool = False
+  """When True, reorder actuators so that ``model.ctrl`` follows joint/tendon/site
+  definition order rather than the order actuators appear in the config. XML actuators
+  are excluded from sorting and always retain their declaration order.
+  """
 
   # Editors.
   lights: tuple[spec_cfg.LightCfg, ...] = field(default_factory=tuple)
@@ -170,9 +174,8 @@ class Entity:
     if self.cfg.articulation is None:
       return
 
-    sort = self.cfg.sort_actuators
-    pending = []
-
+    # Collect actuator instances and their targets.
+    pending: list[tuple[actuator.ActuatorCfg, actuator.Actuator, list[str]]] = []
     for actuator_cfg in self.cfg.articulation.actuators:
       # Find targets based on transmission type.
       if actuator_cfg.transmission_type == TransmissionType.JOINT:
@@ -197,35 +200,51 @@ class Entity:
         )
       actuator_instance = actuator_cfg.build(self, target_ids, target_names)
       self._actuators.append(actuator_instance)
+      pending.append((actuator_cfg, actuator_instance, target_spec_names))
 
-      if not sort or isinstance(actuator_instance, XmlActuator):
-        actuator_instance.edit_spec(self._spec, target_spec_names)
-      else:
-        for target_spec_name in target_spec_names:
-          pending.append(((actuator_cfg, actuator_instance), target_spec_name))
+    if not self.cfg.sort_actuators:
+      for _, inst, names in pending:
+        inst.edit_spec(self._spec, names)
+      return
 
-    if sort and pending:
-      # Sort so ctrl ordering matches joint/tendon/site definition order
-      type_priority = {
-        TransmissionType.JOINT: 0,
-        TransmissionType.TENDON: 1,
-        TransmissionType.SITE: 2,
-      }
-      order_maps = {
-        TransmissionType.JOINT: {name: i for i, name in enumerate(self.joint_names)},
-        TransmissionType.TENDON: {name: i for i, name in enumerate(self.tendon_names)},
-        TransmissionType.SITE: {name: i for i, name in enumerate(self.site_names)},
-      }
+    # Sort actuators so ctrl order matches joint/tendon/site definition order.
+    # XmlActuators are added first (they wrap pre-existing XML actuators),
+    # then remaining actuators sorted by transmission type and target order.
+    order_maps = {
+      TransmissionType.JOINT: {name: i for i, name in enumerate(self.joint_names)},
+      TransmissionType.TENDON: {name: i for i, name in enumerate(self.tendon_names)},
+      TransmissionType.SITE: {name: i for i, name in enumerate(self.site_names)},
+    }
+    # Group by transmission type (ordering is conventional, not physics-motivated).
+    # Within each group, actuators are sorted by their target's definition order in the
+    # spec.
+    type_priority = {
+      TransmissionType.JOINT: 0,
+      TransmissionType.TENDON: 1,
+      TransmissionType.SITE: 2,
+    }
 
-      def sort_key(item):
-        (actuator_cfg, _), target_spec_name = item
-        t = type_priority[actuator_cfg.transmission_type]
-        o = order_maps[actuator_cfg.transmission_type].get(target_spec_name, -1)
-        return (t, o)
+    # XmlActuators go first in declaration order (they reference actuators already
+    # present in the spec).
+    for _, inst, names in pending:
+      if isinstance(inst, XmlActuator):
+        inst.edit_spec(self._spec, names)
 
-      pending.sort(key=sort_key)
-      for (_, actuator_instance), target_spec_name in pending:
-        actuator_instance.edit_spec(self._spec, [target_spec_name])
+    # Flatten remaining actuators to (instance, single_target) pairs and sort.
+    flat: list[tuple[actuator.ActuatorCfg, actuator.Actuator, str]] = []
+    for cfg, inst, names in pending:
+      if not isinstance(inst, XmlActuator):
+        for name in names:
+          flat.append((cfg, inst, name))
+
+    flat.sort(
+      key=lambda item: (
+        type_priority[item[0].transmission_type],
+        order_maps[item[0].transmission_type].get(item[2], float("inf")),
+      )
+    )
+    for _, inst, name in flat:
+      inst.edit_spec(self._spec, [name])
 
   def _add_initial_state_keyframe(self) -> None:
     # If joint_pos is None, use existing keyframe from the model.

--- a/src/mjlab/utils/spec.py
+++ b/src/mjlab/utils/spec.py
@@ -168,22 +168,32 @@ def create_position_actuator(
   actuator.biasprm[1] = -stiffness
   actuator.biasprm[2] = -damping
 
-  # Limits.
+  # Position actuators must allow setpoints beyond joint limits.
+  # Since force = stiffness * (ctrl - pos), clamping ctrl to the joint range would
+  # produce zero force when the joint is at its limit. Force is still bounded by
+  # forcerange below. Both lines are needed: ctrllimited=False is the primary guard,
+  # and inheritrange=0 prevents MuJoCo from resolving the default ctrllimited=AUTO back
+  # to True when a joint range exists.
   actuator.inheritrange = 0.0
   actuator.ctrllimited = False
-  # No ctrlrange needed, but provide the max theoretical range anyway.
   if effort_limit is not None:
-    if transmission_type == TransmissionType.JOINT:
-      _range = spec.joint(joint_name).range
-    elif transmission_type == TransmissionType.TENDON:
-      _range = spec.tendon(joint_name).range
-    else:
-      _range = (0.0, 0.0)
-    delta = effort_limit / stiffness
-    actuator.ctrlrange[:] = np.array([_range[0] - delta, _range[1] + delta])
-
     actuator.forcelimited = True
     actuator.forcerange[:] = np.array([-effort_limit, effort_limit])
+
+    # Informational ctrlrange (not enforced since ctrllimited=False).
+    # Assuming zero velocity, force = stiffness * (ctrl - pos). Solving for the ctrl
+    # that saturates force at the worst-case position gives:
+    #   ctrl_max = joint_high + effort_limit / stiffness
+    #   ctrl_min = joint_low  - effort_limit / stiffness
+    # Beyond this range, force is always clamped regardless of position.
+    if transmission_type == TransmissionType.JOINT:
+      target_range = spec.joint(joint_name).range
+    elif transmission_type == TransmissionType.TENDON:
+      target_range = spec.tendon(joint_name).range
+    else:
+      target_range = (0.0, 0.0)
+    delta = effort_limit / stiffness
+    actuator.ctrlrange[:] = np.array([target_range[0] - delta, target_range[1] + delta])
   else:
     actuator.forcelimited = False
     # No forcerange needed.

--- a/tests/test_actuator_builtin_group.py
+++ b/tests/test_actuator_builtin_group.py
@@ -44,11 +44,11 @@ def device():
   return get_test_device()
 
 
-def create_entity(actuator_cfgs, robot_xml=ROBOT_XML, sort_actuators=True):
+def create_entity(actuator_cfgs, robot_xml=ROBOT_XML, **kwargs):
   cfg = EntityCfg(
     spec_fn=lambda: mujoco.MjSpec.from_string(robot_xml),
     articulation=EntityArticulationInfoCfg(actuators=actuator_cfgs),
-    sort_actuators=sort_actuators,
+    **kwargs,
   )
   return Entity(cfg)
 
@@ -136,48 +136,29 @@ def test_builtin_and_custom_actuators(device):
 
 
 def test_builtin_group_mismatched_indices(device):
-  """Test that controls are written correctly when actuators use different joints.
-
-  Regression test for ctrl_ids/joint_ids swap bug in BuiltinActuatorGroup.
-  When actuators are added in different order than joints, ctrl_ids != joint_ids.
-  This test verifies controls are written to the correct MuJoCo actuator indices.
-  """
-  # Add actuators in different order than joints.
+  """Controls are written correctly when actuator order differs from joint order."""
   # Actuators: position on joint2, motor on joint1+joint3.
-  # Natural joint order: joint1, joint2, joint3.
-  # MuJoCo actuator IDs (definition order): act0=joint2, act1=joint1, act2=joint3.
+  # MuJoCo ctrl order follows declaration: [joint2, joint1, joint3].
   position_cfg = BuiltinPositionActuatorCfg(
     target_names_expr=("joint2",), stiffness=50.0, damping=5.0
   )
   motor_cfg = BuiltinMotorActuatorCfg(
     target_names_expr=("joint1", "joint3"), effort_limit=100.0
   )
-  entity = create_entity(
-    (position_cfg, motor_cfg), robot_xml=ROBOT_XML_3JOINT, sort_actuators=False
-  )
+  entity = create_entity((position_cfg, motor_cfg), robot_xml=ROBOT_XML_3JOINT)
   entity, sim = initialize_entity(entity, device, num_envs=1)
 
-  # Set targets indexed by joint_id: joint1=10.0, joint2=20.0, joint3=30.0
   entity.set_joint_position_target(torch.tensor([[10.0, 20.0, 30.0]], device=device))
   entity.set_joint_effort_target(torch.tensor([[100.0, 200.0, 300.0]], device=device))
   entity.write_data_to_sim()
 
-  # Expected ctrl values in MuJoCo actuator definition order:
-  # ctrl[0] = joint2 position = 20.0 (actuator 0 controls joint2)
-  # ctrl[1] = joint1 effort = 100.0 (actuator 1 controls joint1)
-  # ctrl[2] = joint3 effort = 300.0 (actuator 2 controls joint3)
-  assert torch.allclose(
-    sim.data.ctrl[0], torch.tensor([20.0, 100.0, 300.0], device=device)
-  ), f"Got {sim.data.ctrl[0]}, expected [20.0, 100.0, 300.0]"
+  # ctrl follows declaration order: joint2=20, joint1=100, joint3=300.
+  expected = torch.tensor([20.0, 100.0, 300.0], device=device)
+  assert torch.allclose(sim.data.ctrl[0], expected)
 
 
 def test_sort_actuators(device):
-  """Test that sort_actuators=True reorders actuators to match joint order.
-
-  Same setup as test_builtin_group_mismatched_indices but with sort_actuators=True.
-  Actuators are reordered so ctrl order matches joint definition order:
-  joint1, joint2, joint3 instead of joint2, joint1, joint3.
-  """
+  """sort_actuators=True reorders ctrl to match joint definition order."""
   position_cfg = BuiltinPositionActuatorCfg(
     target_names_expr=("joint2",), stiffness=50.0, damping=5.0
   )
@@ -185,26 +166,23 @@ def test_sort_actuators(device):
     target_names_expr=("joint1", "joint3"), effort_limit=100.0
   )
   entity = create_entity(
-    (position_cfg, motor_cfg), robot_xml=ROBOT_XML_3JOINT, sort_actuators=True
+    (position_cfg, motor_cfg),
+    robot_xml=ROBOT_XML_3JOINT,
+    sort_actuators=True,
   )
   entity, sim = initialize_entity(entity, device, num_envs=1)
 
-  # Set targets indexed by joint_id: joint1=10.0, joint2=20.0, joint3=30.0
   entity.set_joint_position_target(torch.tensor([[10.0, 20.0, 30.0]], device=device))
   entity.set_joint_effort_target(torch.tensor([[100.0, 200.0, 300.0]], device=device))
   entity.write_data_to_sim()
 
-  # With sort_actuators=True, actuators are reordered to match joint order:
-  # ctrl[0] = joint1 effort = 100.0
-  # ctrl[1] = joint2 position = 20.0
-  # ctrl[2] = joint3 effort = 300.0
-  assert torch.allclose(
-    sim.data.ctrl[0], torch.tensor([100.0, 20.0, 300.0], device=device)
-  ), f"Got {sim.data.ctrl[0]}, expected [100.0, 20.0, 300.0]"
+  # Sorted by joint order: joint1=100, joint2=20, joint3=300.
+  expected = torch.tensor([100.0, 20.0, 300.0], device=device)
+  assert torch.allclose(sim.data.ctrl[0], expected)
 
 
-def test_builtin_actuators_ctrlrange_matches_forcerange(device):
-  """Commanding to ctrlrange limits (beyond joint limits) produces forces within 5% of forcerange."""
+def test_position_actuator_ctrlrange_matches_forcerange(device):
+  """Commanding to ctrlrange limits produces forces matching forcerange."""
   actuator_cfg = BuiltinPositionActuatorCfg(
     target_names_expr=("joint.*",),
     stiffness=50.0,
@@ -212,48 +190,26 @@ def test_builtin_actuators_ctrlrange_matches_forcerange(device):
     effort_limit=100.0,
   )
   entity = create_entity((actuator_cfg,), robot_xml=ROBOT_XML_3JOINT)
-
   model = entity.compile()
-  sim_cfg = SimulationCfg()
-  sim = Simulation(num_envs=1, cfg=sim_cfg, model=model, device=device)
+  sim = Simulation(num_envs=1, cfg=SimulationCfg(), model=model, device=device)
   entity.initialize(model, sim.model, sim.data, device)
 
-  num_actuators = model.nu
+  n = model.nu
   ctrlrange = torch.tensor(model.actuator_ctrlrange, device=device, dtype=torch.float32)
   forcerange = torch.tensor(
     model.actuator_forcerange, device=device, dtype=torch.float32
   )
+  zeros = torch.zeros((1, n), device=device)
 
-  # Set joints to zero position/velocity.
-  entity.write_joint_state_to_sim(
-    position=torch.zeros((1, num_actuators), device=device),
-    velocity=torch.zeros((1, num_actuators), device=device),
-  )
+  for col, label in [(1, "max"), (0, "min")]:
+    entity.write_joint_state_to_sim(position=zeros, velocity=zeros)
+    entity.set_joint_position_target(ctrlrange[:, col].unsqueeze(0))
+    entity.set_joint_effort_target(zeros)
+    entity.write_data_to_sim()
+    sim.step()
 
-  # Command to ctrlrange max and step.
-  entity.set_joint_position_target(ctrlrange[:, 1].unsqueeze(0))
-  entity.set_joint_effort_target(torch.zeros((1, num_actuators), device=device))
-  entity.write_data_to_sim()
-  sim.step()
-
-  forces_at_max = sim.data.actuator_force[0]
-  assert torch.allclose(forces_at_max, forcerange[:, 1], rtol=0.05), (
-    f"Forces at ctrl max {forces_at_max} not within 5% of "
-    f"forcerange max {forcerange[:, 1]}"
-  )
-
-  # Command to ctrlrange min and step.
-  entity.write_joint_state_to_sim(
-    position=torch.zeros((1, num_actuators), device=device),
-    velocity=torch.zeros((1, num_actuators), device=device),
-  )
-  entity.set_joint_position_target(ctrlrange[:, 0].unsqueeze(0))
-  entity.set_joint_effort_target(torch.zeros((1, num_actuators), device=device))
-  entity.write_data_to_sim()
-  sim.step()
-
-  forces_at_min = sim.data.actuator_force[0]
-  assert torch.allclose(forces_at_min, forcerange[:, 0], rtol=0.05), (
-    f"Forces at ctrl min {forces_at_min} not within 5% of "
-    f"forcerange min {forcerange[:, 0]}"
-  )
+    forces = sim.data.actuator_force[0]
+    assert torch.allclose(forces, forcerange[:, col], rtol=0.05), (
+      f"Forces at ctrl {label} {forces} not within 5% of "
+      f"forcerange {label} {forcerange[:, col]}"
+    )


### PR DESCRIPTION
These two changes improve portability when exporting mjlab defined specs to XML.

Add `EntityCfg.sort_actuators` boolean

- defaults to False to preserve original behavior
- when True, sorts actuators before `edit_spec()` call so that `model.ctrl` order will match `model.joint` order
- mjlab custom actuators are added after any XML defined actuators

Set ctrlrange in `create_position_actuator()` for consistency with other actuators
- was not defined originally since `ctrllimited=False`, but this change shouldn't affect https://github.com/mujocolab/mjlab/pull/354