### PR TITLE
Fuse delayed builtin actuators into batched buffer operations

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -5,6 +5,12 @@ Changelog
 Upcoming version (not yet released)
 -----------------------------------
 
+Added
+^^^^^
+
+- Added ``DelayedBuiltinActuatorGroup`` that fuses delayed builtin actuators
+  sharing the same delay configuration into a single buffer operation.
+
 Changed
 ^^^^^^^
 

--- a/src/mjlab/actuator/__init__.py
+++ b/src/mjlab/actuator/__init__.py
@@ -32,6 +32,9 @@ from mjlab.actuator.dc_actuator import DcMotorActuator as DcMotorActuator
 from mjlab.actuator.dc_actuator import DcMotorActuatorCfg as DcMotorActuatorCfg
 from mjlab.actuator.delayed_actuator import DelayedActuator as DelayedActuator
 from mjlab.actuator.delayed_actuator import DelayedActuatorCfg as DelayedActuatorCfg
+from mjlab.actuator.delayed_builtin_group import (
+  DelayedBuiltinActuatorGroup as DelayedBuiltinActuatorGroup,
+)
 from mjlab.actuator.learned_actuator import LearnedMlpActuator as LearnedMlpActuator
 from mjlab.actuator.learned_actuator import (
   LearnedMlpActuatorCfg as LearnedMlpActuatorCfg,

--- a/src/mjlab/actuator/delayed_builtin_group.py
+++ b/src/mjlab/actuator/delayed_builtin_group.py
@@ -1,0 +1,151 @@
+"""Fused delayed builtin actuator group for batch buffer operations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+import torch
+
+from mjlab.actuator.builtin_group import _TARGET_TENSOR_MAP, BuiltinActuatorType
+from mjlab.actuator.delayed_actuator import DelayedActuator, DelayedActuatorCfg
+from mjlab.utils.buffers import DelayBuffer
+
+if TYPE_CHECKING:
+  from mjlab.actuator.actuator import Actuator
+  from mjlab.entity.data import EntityData
+
+
+@dataclass
+class _FusedGroup:
+  """A single fused group of delayed builtin actuators sharing delay config."""
+
+  target_attr: str
+  target_ids: torch.Tensor
+  ctrl_ids: torch.Tensor
+  cfg: DelayedActuatorCfg
+  absorbed_actuators: list[DelayedActuator] = field(default_factory=list)
+  delay_buffer: DelayBuffer | None = field(default=None, init=False)
+
+
+@dataclass
+class DelayedBuiltinActuatorGroup:
+  """Fuses delayed builtin actuators into a single buffer operation.
+
+  When multiple ``DelayedActuator(BuiltinXxxActuator)`` instances share the same delay
+  configuration and builtin type, their per-actuator buffer operations can be merged
+  into one append + one compute per physics step instead of N, significantly reducing
+  overhead.
+  """
+
+  _groups: list[_FusedGroup]
+
+  @staticmethod
+  def process(
+    actuators: tuple[Actuator, ...] | list[Actuator],
+  ) -> tuple[DelayedBuiltinActuatorGroup, tuple[Actuator, ...]]:
+    """Extract delayed builtins and group by (type, transmission, delay cfg).
+
+    Args:
+      actuators: Custom actuators (already filtered by BuiltinActuatorGroup).
+
+    Returns:
+      A tuple of (fused group, remaining custom actuators).
+    """
+    grouped: dict[tuple, list[DelayedActuator]] = {}
+    remaining: list[Actuator] = []
+
+    for act in actuators:
+      if not (
+        isinstance(act, DelayedActuator)
+        and isinstance(act.base_actuator, BuiltinActuatorType)
+      ):
+        remaining.append(act)
+        continue
+
+      cfg = act.cfg
+
+      # Only fuse single-target delays. Multi-target on builtins is not meaningful
+      # since each builtin type uses exactly one target channel.
+      if isinstance(cfg.delay_target, tuple) and len(cfg.delay_target) > 1:
+        remaining.append(act)
+        continue
+
+      delay_config_key = (
+        cfg.delay_target
+        if isinstance(cfg.delay_target, tuple)
+        else (cfg.delay_target,),
+        cfg.delay_min_lag,
+        cfg.delay_max_lag,
+        cfg.delay_hold_prob,
+        cfg.delay_update_period,
+        cfg.delay_per_env_phase,
+      )
+      key = (type(act.base_actuator), cfg.transmission_type, delay_config_key)
+      grouped.setdefault(key, []).append(act)
+
+    if not grouped:
+      return DelayedBuiltinActuatorGroup([]), tuple(remaining)
+
+    groups: list[_FusedGroup] = []
+    for (base_type, transmission_type, _delay_cfg), acts in grouped.items():
+      target_attr = _TARGET_TENSOR_MAP[(base_type, transmission_type)]
+      target_ids = torch.cat([a.target_ids for a in acts], dim=0)
+      ctrl_ids = torch.cat([a.ctrl_ids for a in acts], dim=0)
+      groups.append(
+        _FusedGroup(
+          target_attr=target_attr,
+          target_ids=target_ids,
+          ctrl_ids=ctrl_ids,
+          cfg=acts[0].cfg,
+          absorbed_actuators=list(acts),
+        )
+      )
+
+    return DelayedBuiltinActuatorGroup(groups), tuple(remaining)
+
+  def initialize(self, num_envs: int, device: str) -> None:
+    """Create delay buffers for each fused group."""
+    for group in self._groups:
+      cfg = group.cfg
+      group.delay_buffer = DelayBuffer(
+        min_lag=cfg.delay_min_lag,
+        max_lag=cfg.delay_max_lag,
+        batch_size=num_envs,
+        device=device,
+        hold_prob=cfg.delay_hold_prob,
+        update_period=cfg.delay_update_period,
+        per_env_phase=cfg.delay_per_env_phase,
+      )
+      # Alias the fused buffer into each absorbed actuator so that
+      # per-actuator reset() and set_lags() operate on the shared buffer.
+      target = (
+        cfg.delay_target if isinstance(cfg.delay_target, str) else cfg.delay_target[0]
+      )
+      for act in group.absorbed_actuators:
+        act._delay_buffers = {target: group.delay_buffer}
+
+  def apply_controls(self, data: EntityData) -> None:
+    """Apply delayed controls for all fused groups."""
+    for group in self._groups:
+      assert group.delay_buffer is not None
+      target_tensor = getattr(data, group.target_attr)
+      targets = target_tensor[:, group.target_ids]
+      group.delay_buffer.append(targets)
+      data.write_ctrl(group.delay_buffer.compute(), group.ctrl_ids)
+
+  def reset(self, env_ids: torch.Tensor | slice | None = None) -> None:
+    """Reset all delay buffers for given env_ids."""
+    for group in self._groups:
+      if group.delay_buffer is not None:
+        group.delay_buffer.reset(env_ids)
+
+  def set_lags(
+    self,
+    lags: torch.Tensor,
+    env_ids: torch.Tensor | slice | None = None,
+  ) -> None:
+    """Set lags on all delay buffers."""
+    for group in self._groups:
+      if group.delay_buffer is not None:
+        group.delay_buffer.set_lags(lags, env_ids)

--- a/src/mjlab/entity/entity.py
+++ b/src/mjlab/entity/entity.py
@@ -13,6 +13,7 @@ import torch
 from mjlab import actuator
 from mjlab.actuator import BuiltinActuatorGroup
 from mjlab.actuator.actuator import TransmissionType
+from mjlab.actuator.delayed_builtin_group import DelayedBuiltinActuatorGroup
 from mjlab.actuator.xml_actuator import XmlActuator
 from mjlab.entity.data import EntityData
 from mjlab.utils import spec_config as spec_cfg
@@ -575,7 +576,12 @@ class Entity:
 
     # Vectorize built-in actuators; we'll loop through custom ones.
     builtin_group, custom_actuators = BuiltinActuatorGroup.process(self._actuators)
+    delayed_builtin_group, custom_actuators = DelayedBuiltinActuatorGroup.process(
+      custom_actuators
+    )
+    delayed_builtin_group.initialize(nworld, device)
     self._builtin_group = builtin_group
+    self._delayed_builtin_group = delayed_builtin_group
     self._custom_actuators = custom_actuators
 
     # Root state.
@@ -1150,6 +1156,7 @@ class Entity:
 
   def _apply_actuator_controls(self) -> None:
     self._builtin_group.apply_controls(self._data)
+    self._delayed_builtin_group.apply_controls(self._data)
     for act in self._custom_actuators:
       command = act.get_command(self._data)
       self._data.write_ctrl(act.compute(command), act.ctrl_ids)

--- a/tests/test_delayed_builtin_group.py
+++ b/tests/test_delayed_builtin_group.py
@@ -1,0 +1,182 @@
+"""Tests for DelayedBuiltinActuatorGroup."""
+
+import mujoco
+import pytest
+import torch
+from conftest import get_test_device, load_fixture_xml
+
+from mjlab.actuator import (
+  BuiltinPositionActuatorCfg,
+  DelayedActuatorCfg,
+  IdealPdActuatorCfg,
+)
+from mjlab.entity import Entity, EntityArticulationInfoCfg, EntityCfg
+from mjlab.sim.sim import Simulation, SimulationCfg
+
+ROBOT_XML = load_fixture_xml("floating_base_articulated")
+
+
+@pytest.fixture(scope="module")
+def device():
+  return get_test_device()
+
+
+def make_entity(actuator_cfgs, num_envs, device):
+  cfg = EntityCfg(
+    spec_fn=lambda: mujoco.MjSpec.from_string(ROBOT_XML),
+    articulation=EntityArticulationInfoCfg(actuators=actuator_cfgs),
+  )
+  entity = Entity(cfg)
+  model = entity.compile()
+  sim = Simulation(num_envs=num_envs, cfg=SimulationCfg(), model=model, device=device)
+  entity.initialize(model, sim.model, sim.data, device)
+  return entity, sim
+
+
+def test_fused_group_created(device):
+  """Delayed builtins with same config are fused into one group."""
+  cfg1 = DelayedActuatorCfg(
+    base_cfg=BuiltinPositionActuatorCfg(
+      target_names_expr=("joint1",), stiffness=50.0, damping=5.0
+    ),
+    delay_min_lag=1,
+    delay_max_lag=3,
+  )
+  cfg2 = DelayedActuatorCfg(
+    base_cfg=BuiltinPositionActuatorCfg(
+      target_names_expr=("joint2",), stiffness=50.0, damping=5.0
+    ),
+    delay_min_lag=1,
+    delay_max_lag=3,
+  )
+  entity, _ = make_entity((cfg1, cfg2), num_envs=2, device=device)
+
+  assert len(entity._delayed_builtin_group._groups) == 1
+  assert len(entity._custom_actuators) == 0
+
+
+def test_different_delay_configs_separate_groups(device):
+  """Delayed builtins with different delay configs get separate groups."""
+  cfg1 = DelayedActuatorCfg(
+    base_cfg=BuiltinPositionActuatorCfg(
+      target_names_expr=("joint1",), stiffness=50.0, damping=5.0
+    ),
+    delay_min_lag=1,
+    delay_max_lag=3,
+  )
+  cfg2 = DelayedActuatorCfg(
+    base_cfg=BuiltinPositionActuatorCfg(
+      target_names_expr=("joint2",), stiffness=50.0, damping=5.0
+    ),
+    delay_min_lag=5,
+    delay_max_lag=10,
+  )
+  entity, _ = make_entity((cfg1, cfg2), num_envs=2, device=device)
+
+  assert len(entity._delayed_builtin_group._groups) == 2
+
+
+def test_non_builtin_delayed_not_fused(device):
+  """Delayed non-builtin actuators remain in custom_actuators."""
+  delayed_builtin = DelayedActuatorCfg(
+    base_cfg=BuiltinPositionActuatorCfg(
+      target_names_expr=("joint1",), stiffness=50.0, damping=5.0
+    ),
+    delay_min_lag=1,
+    delay_max_lag=3,
+  )
+  delayed_custom = DelayedActuatorCfg(
+    base_cfg=IdealPdActuatorCfg(
+      target_names_expr=("joint2",),
+      stiffness=50.0,
+      damping=5.0,
+      effort_limit=100.0,
+    ),
+    delay_min_lag=1,
+    delay_max_lag=3,
+  )
+  entity, _ = make_entity((delayed_builtin, delayed_custom), num_envs=2, device=device)
+
+  assert len(entity._delayed_builtin_group._groups) == 1
+  assert len(entity._custom_actuators) == 1
+
+
+def test_delayed_controls_written(device):
+  """Fused delayed builtins write controls to sim correctly."""
+  cfg = DelayedActuatorCfg(
+    base_cfg=BuiltinPositionActuatorCfg(
+      target_names_expr=("joint.*",), stiffness=50.0, damping=5.0
+    ),
+    delay_min_lag=0,
+    delay_max_lag=0,
+  )
+  entity, sim = make_entity((cfg,), num_envs=1, device=device)
+
+  target = torch.tensor([[0.5, -0.3]], device=device)
+  entity.set_joint_position_target(target)
+  entity.write_data_to_sim()
+
+  # With lag=0, output equals input.
+  assert torch.allclose(sim.data.ctrl[0], target[0])
+
+
+def test_delay_actually_delays(device):
+  """With nonzero fixed lag, a new target takes lag steps to appear."""
+  cfg = DelayedActuatorCfg(
+    base_cfg=BuiltinPositionActuatorCfg(
+      target_names_expr=("joint.*",), stiffness=50.0, damping=5.0
+    ),
+    delay_min_lag=2,
+    delay_max_lag=2,
+  )
+  entity, sim = make_entity((cfg,), num_envs=1, device=device)
+
+  target_a = torch.tensor([[1.0, 2.0]], device=device)
+  target_b = torch.tensor([[5.0, 6.0]], device=device)
+
+  # Fill the buffer with target_a so lag clamp doesn't mask the test.
+  for _ in range(3):
+    entity.set_joint_position_target(target_a)
+    entity.write_data_to_sim()
+  assert torch.allclose(sim.data.ctrl[0], target_a[0])
+
+  # Now send target_b. With lag=2, it takes 2 more steps to arrive.
+  entity.set_joint_position_target(target_b)
+  entity.write_data_to_sim()
+  assert torch.allclose(sim.data.ctrl[0], target_a[0])  # still old
+
+  entity.set_joint_position_target(target_b)
+  entity.write_data_to_sim()
+  assert torch.allclose(sim.data.ctrl[0], target_a[0])  # still old
+
+  entity.set_joint_position_target(target_b)
+  entity.write_data_to_sim()
+  assert torch.allclose(sim.data.ctrl[0], target_b[0])  # now arrives
+
+
+def test_reset_clears_buffer(device):
+  """Reset clears delay buffers so old values don't leak through."""
+  cfg = DelayedActuatorCfg(
+    base_cfg=BuiltinPositionActuatorCfg(
+      target_names_expr=("joint.*",), stiffness=50.0, damping=5.0
+    ),
+    delay_min_lag=2,
+    delay_max_lag=2,
+  )
+  entity, sim = make_entity((cfg,), num_envs=1, device=device)
+
+  target_a = torch.tensor([[1.0, 2.0]], device=device)
+  target_b = torch.tensor([[5.0, 6.0]], device=device)
+
+  # Fill buffer with target_a.
+  for _ in range(3):
+    entity.set_joint_position_target(target_a)
+    entity.write_data_to_sim()
+  assert torch.allclose(sim.data.ctrl[0], target_a[0])
+
+  # Reset, then fill with target_b. Old target_a must not appear.
+  entity.reset(torch.tensor([0], device=device))
+  for _ in range(3):
+    entity.set_joint_position_target(target_b)
+    entity.write_data_to_sim()
+  assert torch.allclose(sim.data.ctrl[0], target_b[0])


### PR DESCRIPTION
Adds `DelayedBuiltinActuatorGroup` that merges N per-actuator delay buffer append + compute calls into one when actuators share the same delay config, builtin type, and transmission type.

Absorbed actuators retain access to the shared buffer via aliasing, so per-actuator `reset()` and `set_lags()` continue to work transparently.

Benchmarked on G1 (37 DOF, 6 actuator groups, RTX 5090). Unfused delayed actuators add 11-26% overhead depending on env count. Fusing recovers 80-86% of that (e.g. 26% → 5% at 1024 envs, 11% → 2% at 8192 envs).