### PR TITLE
Fix force arrow visualization on rough terrain

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -2,6 +2,16 @@
 Changelog
 =========
 
+Upcoming version (not yet released)
+-----------------------------------
+
+Fixed
+^^^^^
+
+- Set terrain geom mass to zero so that the static terrain body does not
+  inflate ``stat.meanmass``, which made force arrow visualization invisible
+  on rough terrain (:issue:`734`, :issue:`537`).
+
 Version 1.2.0 (March 6, 2026)
 -----------------------------
 

--- a/src/mjlab/terrains/terrain_generator.py
+++ b/src/mjlab/terrains/terrain_generator.py
@@ -206,6 +206,11 @@ class TerrainGenerator:
     counter = 0
     for geom in body.geoms:
       geom.name = f"terrain_{counter}"
+      # Terrain is static (no joints), so body mass is physically meaningless.
+      # Without this, the thousands of dense geoms give the terrain body millions of kg
+      # of mass, which inflates stat.meanmass and makes MuJoCo's force arrow
+      # visualization invisible (arrows scale as force / meanmass).
+      geom.mass = 0
       counter += 1
 
   def _generate_random_terrains(self, spec: mujoco.MjSpec) -> None:


### PR DESCRIPTION
Terrain geoms had default density, giving the static terrain body ~19 million kg of mass. This inflated `stat.meanmass` and made force arrows invisible (length scales as force / meanmass).

Set terrain geom mass to zero since the terrain body is static (no joints) and its mass is physically meaningless.

Fixes #734.
Fixes #537.

| Before | After |
|--------|-------|
| <img width="632" height="442" alt="Screenshot 2026-03-06 at 7 13 07 PM" src="https://github.com/user-attachments/assets/612c6633-3c8c-4f1a-87a7-eb02f5faafa9" /> | <img width="632" height="442" alt="Screenshot 2026-03-06 at 7 12 27 PM" src="https://github.com/user-attachments/assets/5d807ed5-d20f-4613-960c-3c754335b9ab" /> |
