### PR TITLE
Fix ~4 GB GPU memory overhead in dr.pseudo_inertia

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,6 +8,10 @@ Upcoming version (not yet released)
 Fixed
 ^^^^^
 
+- ``dr.pseudo_inertia`` no longer loads cuSOLVER, eliminating ~4 GB of
+  persistent GPU memory overhead. Cholesky and eigendecomposition are now
+  computed analytically for the small matrices involved (4x4 and 3x3)
+  (:issue:`753`).
 - Set terrain geom mass to zero so that the static terrain body does not
   inflate ``stat.meanmass``, which made force arrow visualization invisible
   on rough terrain (:issue:`734`, :issue:`537`).

--- a/src/mjlab/envs/mdp/dr/body.py
+++ b/src/mjlab/envs/mdp/dr/body.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import math
 import warnings
 from typing import TYPE_CHECKING
 
@@ -28,11 +27,110 @@ from ._types import Distribution, Operation
 if TYPE_CHECKING:
   from mjlab.envs import ManagerBasedRlEnv
 
-# cusolverDnXsyevBatched has an undocumented batch size limit (~32k).
-# We chunk at 16k to stay well within the limit while keeping overhead low.
-_MAX_EIGH_BATCH = 16384
+# Number of Jacobi sweeps for 3x3 eigendecomposition. Each sweep applies 3 Givens
+# rotations (one per off-diagonal pair). 5 sweeps are more than enough for 3x3 matrices
+# to converge to machine precision.
+_JACOBI_SWEEPS = 5
 
 # Pseudo-inertia helpers.
+
+
+def _cholesky_4x4(A: torch.Tensor) -> torch.Tensor:
+  """Analytical Cholesky for batched 4x4 SPD matrices.
+
+  Avoids ``torch.linalg.cholesky`` (and the cuSOLVER library it loads), which allocates
+  several GB of persistent GPU memory on first use.
+
+  Args:
+    A: ``(*batch, 4, 4)`` symmetric positive-definite matrix.
+
+  Returns:
+    L: ``(*batch, 4, 4)`` lower-triangular Cholesky factor.
+  """
+  L = torch.zeros_like(A)
+  L[..., 0, 0] = torch.sqrt(A[..., 0, 0])
+  L[..., 1, 0] = A[..., 1, 0] / L[..., 0, 0]
+  L[..., 2, 0] = A[..., 2, 0] / L[..., 0, 0]
+  L[..., 3, 0] = A[..., 3, 0] / L[..., 0, 0]
+  L[..., 1, 1] = torch.sqrt(A[..., 1, 1] - L[..., 1, 0] ** 2)
+  L[..., 2, 1] = (A[..., 2, 1] - L[..., 2, 0] * L[..., 1, 0]) / L[..., 1, 1]
+  L[..., 3, 1] = (A[..., 3, 1] - L[..., 3, 0] * L[..., 1, 0]) / L[..., 1, 1]
+  L[..., 2, 2] = torch.sqrt(A[..., 2, 2] - L[..., 2, 0] ** 2 - L[..., 2, 1] ** 2)
+  L[..., 3, 2] = (
+    A[..., 3, 2] - L[..., 3, 0] * L[..., 2, 0] - L[..., 3, 1] * L[..., 2, 1]
+  ) / L[..., 2, 2]
+  L[..., 3, 3] = torch.sqrt(
+    A[..., 3, 3] - L[..., 3, 0] ** 2 - L[..., 3, 1] ** 2 - L[..., 3, 2] ** 2
+  )
+  return L
+
+
+def _eigh_3x3_jacobi(
+  A: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+  """Batched eigendecomposition for 3x3 symmetric matrices via Jacobi.
+
+  Avoids ``torch.linalg.eigh`` (and the cuSOLVER library it loads), which allocates
+  several GB of persistent GPU memory on first use.
+
+  Uses cyclic Jacobi rotations over the three off-diagonal pairs. For 3x3 matrices,
+  ``_JACOBI_SWEEPS`` sweeps converge to machine precision.
+
+  Args:
+    A: ``(*batch, 3, 3)`` symmetric matrix.
+
+  Returns:
+    eigenvalues: ``(*batch, 3)`` in ascending order.
+    V: ``(*batch, 3, 3)`` orthogonal eigenvectors (columns).
+  """
+  D = A.clone()
+  V = torch.eye(3, device=A.device, dtype=A.dtype).expand_as(D).clone()
+
+  for _ in range(_JACOBI_SWEEPS):
+    for p, q in ((0, 1), (0, 2), (1, 2)):
+      r = 3 - p - q
+      apq = D[..., p, q]
+      app = D[..., p, p]
+      aqq = D[..., q, q]
+
+      # Jacobi rotation: tau = (aqq - app) / (2*apq),
+      # t = sign(tau) / (|tau| + sqrt(1 + tau^2)).
+      diff = aqq - app
+      denom = 2 * apq
+      tau = diff / denom
+      t = torch.sign(tau) / (torch.abs(tau) + torch.sqrt(1 + tau * tau))
+      # When apq ≈ 0, skip rotation (t = 0).
+      t = torch.where(torch.abs(denom) > 1e-30, t, torch.zeros_like(t))
+
+      c = 1 / torch.sqrt(1 + t * t)
+      s = t * c
+
+      # Update diagonal and off-diagonal elements.
+      D[..., p, p] = app - t * apq
+      D[..., q, q] = aqq + t * apq
+      D[..., p, q] = D[..., q, p] = 0
+
+      arp = D[..., r, p].clone()
+      arq = D[..., r, q].clone()
+      D[..., r, p] = D[..., p, r] = c * arp - s * arq
+      D[..., r, q] = D[..., q, r] = s * arp + c * arq
+
+      # Accumulate eigenvectors: V[:, p/q] = c*Vp ∓ s*Vq.
+      vp = V[..., :, p].clone()
+      vq = V[..., :, q].clone()
+      c_exp = c.unsqueeze(-1)
+      s_exp = s.unsqueeze(-1)
+      V[..., :, p] = c_exp * vp - s_exp * vq
+      V[..., :, q] = s_exp * vp + c_exp * vq
+
+  eigenvalues = torch.stack([D[..., 0, 0], D[..., 1, 1], D[..., 2, 2]], dim=-1)
+
+  # Sort in ascending order to match torch.linalg.eigh convention.
+  idx = eigenvalues.argsort(dim=-1)
+  eigenvalues = eigenvalues.gather(-1, idx)
+  V = V.gather(-1, idx.unsqueeze(-2).expand_as(V))
+
+  return eigenvalues, V
 
 
 def _reconstruct_pseudo_inertia_J(
@@ -122,20 +220,7 @@ def _decompose_pseudo_inertia_J(
   )  # (*batch, 3, 3)
 
   # Columns of V are principal axes in body frame; eigenvalues are principal moments.
-  # Chunk to avoid cusolver batch size limits on some GPUs.
-  batch_shape = I_com.shape[:-2]
-  flat_total = math.prod(batch_shape) if batch_shape else 1
-  if flat_total > _MAX_EIGH_BATCH:
-    I_flat = I_com.reshape(flat_total, 3, 3)
-    pm_chunks, v_chunks = [], []
-    for chunk in I_flat.split(_MAX_EIGH_BATCH, dim=0):
-      pm, v = torch.linalg.eigh(chunk)
-      pm_chunks.append(pm)
-      v_chunks.append(v)
-    principal_moments = torch.cat(pm_chunks, dim=0).reshape(*batch_shape, 3)
-    V = torch.cat(v_chunks, dim=0).reshape(*batch_shape, 3, 3)
-  else:
-    principal_moments, V = torch.linalg.eigh(I_com)  # (*batch, 3), (*batch, 3, 3)
+  principal_moments, V = _eigh_3x3_jacobi(I_com)
 
   # Ensure V is a proper rotation (det = +1). eigh can return reflections.
   dets = torch.linalg.det(V)  # (*batch,)
@@ -419,7 +504,7 @@ def pseudo_inertia(
   J_default = _reconstruct_pseudo_inertia_J(def_mass, def_ipos, def_inertia, def_iquat)
 
   # Cholesky factor L: (n_bodies, 4, 4), lower triangular.
-  L = torch.linalg.cholesky(J_default)
+  L = _cholesky_4x4(J_default)
 
   # Sample perturbation parameters, each (n_envs, n_bodies).
   def sample(r: tuple[float, float]) -> torch.Tensor:

--- a/tests/test_domain_randomization.py
+++ b/tests/test_domain_randomization.py
@@ -601,8 +601,8 @@ def test_body_quat_only_specified_axes(device):
   )
 
   result = env.sim.model.body_quat[:, body_ids, :]
-  # For the default quat [1,0,0,0] composed with a yaw-only rotation,
-  # qx and qy should remain 0 (pure yaw -> no roll/pitch).
+  # For the default quat [1,0,0,0] composed with a yaw-only rotation, qx and qy should
+  # remain 0 (pure yaw -> no roll/pitch).
   q_default = env.sim.get_default_field("body_quat")[body_ids]
   if torch.allclose(q_default, torch.tensor([[1.0, 0.0, 0.0, 0.0]], device=device)):
     assert torch.allclose(result[..., 1], torch.zeros_like(result[..., 1]), atol=1e-6)
@@ -622,7 +622,10 @@ def _make_inertia_env(device, num_envs=NUM_ENVS):
 
 
 def _matrix_from_quat(q: torch.Tensor) -> torch.Tensor:
-  """Convert wxyz quaternion(s) to 3×3 rotation matrix. Shape: (..., 4) → (..., 3, 3)."""
+  """Convert wxyz quaternion(s) to 3x3 rotation matrix.
+
+  Shape: (..., 4) → (..., 3, 3).
+  """
   w, x, y, z = q[..., 0], q[..., 1], q[..., 2], q[..., 3]
   return torch.stack(
     [
@@ -644,8 +647,8 @@ def _reconstruct_J(mass, ipos, inertia, iquat):
   """Reconstruct pseudo-inertia matrix from MuJoCo fields (test helper).
 
   Correctly accounts for body_iquat (the principal-frame rotation) and the
-  parallel-axis theorem (body_ipos) so that the reconstructed J is exact
-  regardless of shear magnitude.
+  parallel-axis theorem (body_ipos) so that the reconstructed J is exact regardless of
+  shear magnitude.
   """
   I3 = torch.eye(3, device=mass.device, dtype=mass.dtype)
   # MuJoCo body_iquat maps principal→body.
@@ -716,9 +719,9 @@ def test_pseudo_inertia_physical_consistency(device):
   assert torch.all(d1 + d3 >= d2 - 1e-6)
   assert torch.all(d2 + d3 >= d1 - 1e-6)
 
-  # Round-trip check: reconstruct J from all four stored fields (including
-  # body_iquat) and verify it is positive definite. This is exact because
-  # the implementation writes the eigendecomposition of J'.
+  # Round-trip check: reconstruct J from all four stored fields (including body_iquat)
+  # and verify it is positive definite. This is exact because the implementation writes
+  # the eigendecomposition of J'.
   J = _reconstruct_J(mass, ipos, inertia, iquat)
   eigvals = torch.linalg.eigvalsh(J)
   assert torch.all(eigvals > -1e-5), f"Non-positive J eigenvalue: {eigvals.min()}"
@@ -746,21 +749,26 @@ def test_pseudo_inertia_zero_perturbation_unchanged(device):
 
   assert torch.allclose(mass, def_mass.unsqueeze(0).expand_as(mass), atol=1e-5)
   assert torch.allclose(ipos, def_ipos.unsqueeze(0).expand_as(ipos), atol=1e-5)
-  assert torch.allclose(inertia, def_inertia.unsqueeze(0).expand_as(inertia), atol=1e-5)
-  # q and -q represent the same rotation; check both signs.
-  def_exp = def_iquat.unsqueeze(0).expand_as(iquat)
-  assert torch.allclose(iquat, def_exp, atol=1e-5) or torch.allclose(
-    iquat, -def_exp, atol=1e-5
-  ), "body_iquat changed unexpectedly under zero perturbation"
+  # For bodies with degenerate eigenvalues (2+ equal principal moments), the
+  # eigenvector basis is non-unique, so the (inertia, iquat) decomposition may differ
+  # while producing the same physical inertia tensor. Compare the full tensor
+  # R @ diag(inertia) @ R^T rather than individual components.
+  R_def = _matrix_from_quat(def_iquat)
+  I_def = R_def @ torch.diag_embed(def_inertia) @ R_def.mT
+  R_new = _matrix_from_quat(iquat)
+  I_new = R_new @ torch.diag_embed(inertia) @ R_new.mT
+  assert torch.allclose(I_new, I_def.unsqueeze(0).expand_as(I_new), atol=1e-5), (
+    "Inertia tensor changed unexpectedly under zero perturbation"
+  )
 
 
 def test_pseudo_inertia_zero_perturbation_offset_body(device):
   """Zero perturbation preserves physics for a body with non-trivial ipos/iquat.
 
-  Since ``eigh`` returns eigenvalues in ascending order while MuJoCo may
-  store them differently, we compare the reconstructed pseudo-inertia
-  matrix J (which is representation-independent) rather than the raw
-  principal moments and iquat individually.
+  Since ``eigh`` returns eigenvalues in ascending order while MuJoCo may store them
+  differently, we compare the reconstructed pseudo-inertia matrix J (which is
+  representation-independent) rather than the raw principal moments and iquat
+  individually.
   """
   env = _make_inertia_env(device)
   robot = env.scene["robot"]
@@ -794,8 +802,8 @@ def test_pseudo_inertia_zero_perturbation_offset_body(device):
   assert torch.allclose(mass, def_mass.unsqueeze(0).expand_as(mass), atol=1e-5)
   assert torch.allclose(ipos, def_ipos.unsqueeze(0).expand_as(ipos), atol=1e-5)
 
-  # Inertia and iquat may have different eigenvalue ordering, so compare
-  # the reconstructed J matrix instead.
+  # Inertia and iquat may have different eigenvalue ordering, so compare the
+  # reconstructed J matrix instead.
   J_default = _reconstruct_J(def_mass, def_ipos, def_inertia, def_iquat)
   J_result = _reconstruct_J(mass, ipos, inertia, iquat)
   assert torch.allclose(
@@ -943,35 +951,6 @@ def test_pseudo_inertia_partial_env_ids(device):
   assert not torch.allclose(mass_after[0], mass_before[0], atol=1e-6)
   # Env 1 unchanged.
   assert torch.allclose(mass_after[1], mass_before[1], atol=1e-6)
-
-
-def test_decompose_pseudo_inertia_eigh_chunking():
-  """Chunked eigh produces the same result as a single call."""
-  from mjlab.envs.mdp.dr.body import (
-    _MAX_EIGH_BATCH,
-    _decompose_pseudo_inertia_J,
-    _reconstruct_pseudo_inertia_J,
-  )
-
-  torch.manual_seed(0)
-  # Build a batch larger than the chunk limit so the chunking path is taken.
-  n = _MAX_EIGH_BATCH + 100
-  mass = torch.rand(n) + 0.1
-  ipos = torch.randn(n, 3) * 0.05
-  inertia = torch.rand(n, 3) + 0.1
-  iquat = torch.randn(n, 4)
-  iquat = iquat / iquat.norm(dim=-1, keepdim=True)
-
-  J = _reconstruct_pseudo_inertia_J(mass, ipos, inertia, iquat)
-
-  # Decompose with chunking (the production path).
-  mass_out, ipos_out, pm_out, iquat_out = _decompose_pseudo_inertia_J(J)
-
-  # Reconstruct and compare: the round-trip should be near-exact.
-  J_rt = _reconstruct_pseudo_inertia_J(mass_out, ipos_out, pm_out, iquat_out)
-  assert torch.allclose(J, J_rt, atol=1e-5), (
-    f"Round-trip mismatch; max error: {(J - J_rt).abs().max()}"
-  )
 
 
 # Camera / Light DR tests.


### PR DESCRIPTION
`torch.linalg.cholesky` and `torch.linalg.eigh` load cuSOLVER, which allocates ~4.4 GB of persistent GPU memory for batched eigendecomposition workspace. This doubles VRAM usage when `dr.pseudo_inertia` is enabled.

Replace both with analytical implementations that run as plain PyTorch tensor operations:

- **Cholesky 4x4**: unrolled column-by-column factorization
- **eigh 3x3**: cyclic Jacobi eigendecomposition (5 sweeps)

This also removes the `_MAX_EIGH_BATCH` chunking workaround for cuSOLVER's undocumented batch size limit.

Results on RTX 5070 Ti, PyTorch 2.10, CUDA 12.8 (4096 envs x 20 bodies = 82k matrices):

| Method | Peak GPU memory | Wall time |
|--------|-----------------|-----------|
| cuSOLVER (chunked at 16k) | 4,452 MB | 6.68 ms |
| Jacobi (5 sweeps) | 29 MB | 3.83 ms |

Standalone reproduction: https://github.com/kevinzakka/cusolver-eigh-vram

Thanks @NaCl-1374 for the detailed report.

Fixes #753