### PR TITLE
Fix: NativeMujocoViewer does not display sim.model.qpos0 changes

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -32,6 +32,9 @@ Fixed
 - Set terrain geom mass to zero so that the static terrain body does not
   inflate ``stat.meanmass``, which made force arrow visualization invisible
   on rough terrain (:issue:`734`, :issue:`537`).
+- Native viewer now syncs ``qpos0`` when domain randomized, fixing incorrect
+  body positions after ``dr.joint_default_pos`` randomization
+  (:issue:`760`).
 
 Version 1.2.0 (March 6, 2026)
 -----------------------------

--- a/src/mjlab/viewer/native/viewer.py
+++ b/src/mjlab/viewer/native/viewer.py
@@ -338,7 +338,7 @@ class NativeMujocoViewer(BaseViewer):
   # geom_rbound, dof_*, jnt_*, actuator_*, tendon_*, etc.) are skipped.
   _VISUAL_FIELDS = frozenset(
     {
-      "qpos0",
+      "qpos0",  # Needed for correct mj_forward kinematics (qpos - qpos0).
       "geom_rgba",
       "geom_size",
       "geom_pos",


### PR DESCRIPTION
NativeMujocoViewer does not display sim.model.qpos0 changes.

When dr.joint_default_pos (alias dr.qpos0) randomizes qpos0 per environment, the GPU sim.model.qpos0 gets per-world values. However, the CPU MjModel used by the native viewer never receives these changes because qpos0 is filtered out by _VISUAL_FIELDS.

The minimal fix would be to add "qpos0" to the set of fields synced in _sync_model_fields.