### PR TITLE
Fix `command_manager.compute` not called on reset

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -35,6 +35,10 @@ Fixed
 - Native viewer now syncs ``qpos0`` when domain randomized, fixing incorrect
   body positions after ``dr.joint_default_pos`` randomization
   (:issue:`760`).
+- ``command_manager.compute()`` is now called during ``reset()`` so that
+  derived command state (e.g. relative body positions in tracking
+  environments) is populated before the first observation is returned
+  (:issue:`761`).
 
 Version 1.2.0 (March 6, 2026)
 -----------------------------

--- a/src/mjlab/envs/manager_based_rl_env.py
+++ b/src/mjlab/envs/manager_based_rl_env.py
@@ -332,6 +332,7 @@ class ManagerBasedRlEnv:
     self._reset_idx(env_ids)
     self.scene.write_data_to_sim()
     self.sim.forward()
+    self.command_manager.compute(dt=0.0)
     self.sim.sense()
     self.obs_buf = self.observation_manager.compute(update_history=True)
     return self.obs_buf, self.extras


### PR DESCRIPTION
`reset()` only called `command_manager.reset()` which resamples raw commands, but never called `compute()` to run `_update_command()` and populate derived state like `body_pos_relative_w`. This left command observations zeroed after `reset()`, causing immediate terminations in tracking environments.

Fixed by calling `command_manager.compute(dt=0.0)` after `sim.forward()`. The zero dt avoids decrementing timers or triggering resampling.

Closes #761