### PR TITLE
Add margin, gap, and solmix to CollisionCfg

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,6 +8,8 @@ Upcoming version (not yet released)
 Added
 ^^^^^
 
+- Added ``margin``, ``gap``, and ``solmix`` fields to ``CollisionCfg``
+  for per geom contact parameter configuration (:issue:`766`).
 - Added ``DelayedBuiltinActuatorGroup`` that fuses delayed builtin actuators
   sharing the same delay configuration into a single buffer operation.
 - NaN guard now captures mocap body poses (``mocap_pos``, ``mocap_quat``)

--- a/src/mjlab/utils/spec_config.py
+++ b/src/mjlab/utils/spec_config.py
@@ -30,6 +30,9 @@ _GEOM_ATTR_DEFAULTS = {
   "friction": None,
   "solref": None,
   "solimp": None,
+  "margin": None,
+  "gap": None,
+  "solmix": None,
 }
 
 _LIGHT_TYPE_MAP = {
@@ -178,6 +181,12 @@ class CollisionCfg(SpecCfg):
   """Solver reference parameters as tuple or dict mapping patterns to tuples."""
   solimp: tuple[float, ...] | dict[str, tuple[float, ...]] | None = None
   """Solver impedance parameters as tuple or dict mapping patterns to tuples."""
+  margin: float | dict[str, float] | None = None
+  """Detection margin. Contacts are generated when geom distance < margin."""
+  gap: float | dict[str, float] | None = None
+  """Gap for solver inclusion. Contact included when dist < margin - gap."""
+  solmix: float | dict[str, float] | None = None
+  """Mixing weight for blending solver parameters between geom pairs."""
   disable_other_geoms: bool = True
   """Whether to disable collision for non-matching geoms."""
 
@@ -221,6 +230,36 @@ class CollisionCfg(SpecCfg):
               f"{field_name} must be non-negative, got {value} for pattern '{pattern}'"
             )
 
+    # Validate margin (non-negative).
+    if isinstance(self.margin, (int, float)) and self.margin < 0:
+      raise ValueError("margin must be non-negative")
+    if isinstance(self.margin, dict):
+      for pattern, value in self.margin.items():
+        if value < 0:
+          raise ValueError(
+            f"margin must be non-negative, got {value} for pattern '{pattern}'"
+          )
+
+    # Validate gap (non-negative).
+    if isinstance(self.gap, (int, float)) and self.gap < 0:
+      raise ValueError("gap must be non-negative")
+    if isinstance(self.gap, dict):
+      for pattern, value in self.gap.items():
+        if value < 0:
+          raise ValueError(
+            f"gap must be non-negative, got {value} for pattern '{pattern}'"
+          )
+
+    # Validate solmix (must be in [0, 1]).
+    if isinstance(self.solmix, (int, float)) and not (0 <= self.solmix <= 1):
+      raise ValueError("solmix must be in [0, 1]")
+    if isinstance(self.solmix, dict):
+      for pattern, value in self.solmix.items():
+        if not (0 <= value <= 1):
+          raise ValueError(
+            f"solmix must be in [0, 1], got {value} for pattern '{pattern}'"
+          )
+
   def edit_spec(self, spec: mujoco.MjSpec) -> None:
     from mjlab.utils.spec import disable_collision
     from mjlab.utils.string import filter_exp, resolve_field
@@ -247,6 +286,13 @@ class CollisionCfg(SpecCfg):
       CollisionCfg.set_array_field(geom.friction, resolved_fields["friction"][i])
       CollisionCfg.set_array_field(geom.solref, resolved_fields["solref"][i])
       CollisionCfg.set_array_field(geom.solimp, resolved_fields["solimp"][i])
+
+      if resolved_fields["margin"][i] is not None:
+        geom.margin = resolved_fields["margin"][i]
+      if resolved_fields["gap"][i] is not None:
+        geom.gap = resolved_fields["gap"][i]
+      if resolved_fields["solmix"][i] is not None:
+        geom.solmix = resolved_fields["solmix"][i]
 
     if self.disable_other_geoms:
       other_geoms = set(all_geom_names).difference(geom_subset)

--- a/tests/test_spec_config.py
+++ b/tests/test_spec_config.py
@@ -110,6 +110,44 @@ def test_collision_dict_field_resolution(multi_geom_spec):
   assert arm.priority == 0
 
 
+def test_collision_margin_gap_solmix(multi_geom_spec):
+  """CollisionCfg should set margin, gap, and solmix on matched geoms."""
+  collision_cfg = CollisionCfg(
+    geom_names_expr=("arm_collision",),
+    margin=0.01,
+    gap=0.005,
+    solmix=0.5,
+    disable_other_geoms=False,
+  )
+  collision_cfg.edit_spec(multi_geom_spec)
+
+  geom = multi_geom_spec.geom("arm_collision")
+  assert geom.margin == pytest.approx(0.01)
+  assert geom.gap == pytest.approx(0.005)
+  assert geom.solmix == pytest.approx(0.5)
+
+
+def test_collision_margin_gap_solmix_dict(multi_geom_spec):
+  """CollisionCfg should support dict-based margin, gap, solmix overrides."""
+  collision_cfg = CollisionCfg(
+    geom_names_expr=(r".*_foot\d_collision$", "arm_collision"),
+    margin={r".*_foot\d_collision$": 0.02, "arm_collision": 0.01},
+    gap={r".*_foot\d_collision$": 0.01, "arm_collision": 0.0},
+    solmix={r".*_foot\d_collision$": 0.8, "arm_collision": 0.2},
+    disable_other_geoms=False,
+  )
+  collision_cfg.edit_spec(multi_geom_spec)
+
+  left_foot = multi_geom_spec.geom("left_foot1_collision")
+  assert left_foot.margin == pytest.approx(0.02)
+  assert left_foot.gap == pytest.approx(0.01)
+  assert left_foot.solmix == pytest.approx(0.8)
+
+  arm = multi_geom_spec.geom("arm_collision")
+  assert arm.margin == pytest.approx(0.01)
+  assert arm.solmix == pytest.approx(0.2)
+
+
 def test_collision_disable_other_geoms(multi_geom_spec):
   """CollisionCfg should disable non-matching geoms when requested."""
   collision_cfg = CollisionCfg(
@@ -137,24 +175,24 @@ def test_collision_disable_other_geoms(multi_geom_spec):
     ("contype", -1, "contype must be non-negative"),
     ("conaffinity", -1, "conaffinity must be non-negative"),
     ("priority", -1, "priority must be non-negative"),
+    ("margin", -0.1, "margin must be non-negative"),
+    ("gap", -0.1, "gap must be non-negative"),
+    ("solmix", 1.5, r"solmix must be in \[0, 1\]"),
   ],
 )
 # fmt: on
 def test_collision_validation(param, value, expected_error):
   """CollisionCfg should validate parameters."""
   with pytest.raises(ValueError, match=expected_error):
-    geom_names_expr = ("test",)
-    contype = value if param == "contype" else 1
-    conaffinity = value if param == "conaffinity" else 1
-    condim = value if param == "condim" else 3
-    priority = value if param == "priority" else 0
-
     cfg = CollisionCfg(
-      geom_names_expr=geom_names_expr,
-      contype=contype,
-      conaffinity=conaffinity,
-      condim=condim,
-      priority=priority,
+      geom_names_expr=("test",),
+      contype=value if param == "contype" else 1,
+      conaffinity=value if param == "conaffinity" else 1,
+      condim=value if param == "condim" else 3,
+      priority=value if param == "priority" else 0,
+      margin=value if param == "margin" else None,
+      gap=value if param == "gap" else None,
+      solmix=value if param == "solmix" else None,
     )
     cfg.validate()
 


### PR DESCRIPTION
`CollisionCfg` supports `solref` and `solimp` but not the other per-geom contact parameters. This adds `margin`, `gap`, and `solmix` with the same scalar-or-dict-per-pattern interface, plus validation. Closes #766.