### PR TITLE
Add commit/PR conventions and broaden Claude Code permissions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,16 +1,16 @@
 {
   "permissions": {
     "allow": [
-      "Bash(find:*)",
-      "Bash(make check:*)",
-      "Bash(make test:*)",
-      "Bash(make docs:*)",
-      "Bash(git fetch:*)",
-      "Bash(git commit:*)",
-      "Bash(git checkout:*)",
-      "Bash(git reset:*)",
-      "Bash(gh api:*)",
-      "Bash(git ls-tree:*)"
+      "Bash(make:*)",
+      "Bash(uv run:*)",
+      "Bash(uv lock:*)",
+      "Bash(uv sync:*)",
+      "Bash(uv add:*)",
+      "Bash(git:*)",
+      "Bash(gh:*)",
+      "WebSearch",
+      "Skill(commit-push-pr)",
+      "Skill(pr-review-toolkit:review-pr)"
     ]
   },
   "hooks": {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,11 +30,25 @@ make test       # Run the full test suite
 make docs       # Build documentation
 ```
 
+Always run `make check` before committing. This runs formatting, linting,
+and type checking. Do not commit code that fails type checking.
+
 Before creating a PR, ensure all checks pass with `make test`.
 
 When making user-facing changes, add an entry to `docs/source/changelog.rst`
 under the "Upcoming version (not yet released)" section using
 Added/Changed/Fixed categories.
+
+# Commits and PRs
+
+- Put `Fixes #<number>` at the end of the commit message body, not in
+  the title.
+- PR body should be plain, concise prose. No section headers, checklists,
+  or structured templates. Describe the problem, what the change does, and
+  any non-obvious tradeoffs. A good PR description reads like a short
+  paragraph to a colleague, not a form.
+- PR and commit messages are rendered on GitHub, so don't hard-wrap them
+  at 88 columns. Let each sentence flow on one line.
 
 Some style guidelines to follow:
 - Line length limit is 88 columns. This applies to code, comments, and docstrings.


### PR DESCRIPTION
Require make check before committing so type errors are caught before they hit CI. Add guidelines for PR descriptions (plain prose, no templates) and commit messages (Fixes #N in body, not title). Broaden Claude Code allowed commands to reduce permission prompts.