### PR TITLE
Remove deprecated TerrainImporter and TerrainImporterCfg aliases

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -19,6 +19,8 @@ Added
 Changed
 ^^^^^^^
 
+- Removed deprecated ``TerrainImporter`` and ``TerrainImporterCfg`` aliases.
+  Use ``TerrainEntity`` and ``TerrainEntityCfg`` instead (:issue:`667`).
 - ``Entity.clear_state()`` is deprecated. Use ``Entity.reset()`` instead.
   ``clear_state`` only zeroed actuator targets without resetting actuator
   internal state (e.g. delay buffers), which could cause stale commands

--- a/src/mjlab/terrains/__init__.py
+++ b/src/mjlab/terrains/__init__.py
@@ -50,24 +50,3 @@ from mjlab.terrains.terrain_generator import (
 from mjlab.terrains.terrain_generator import SubTerrainCfg as SubTerrainCfg
 from mjlab.terrains.terrain_generator import TerrainGenerator as TerrainGenerator
 from mjlab.terrains.terrain_generator import TerrainGeneratorCfg as TerrainGeneratorCfg
-
-# TODO(kevin): remove these aliases, see https://github.com/mujocolab/mjlab/issues/667
-# Backwards compatibility aliases (deprecated).
-_DEPRECATED_ALIASES = {
-  "TerrainImporter": "TerrainEntity",
-  "TerrainImporterCfg": "TerrainEntityCfg",
-}
-
-
-def __getattr__(name: str):
-  if name in _DEPRECATED_ALIASES:
-    import warnings
-
-    new_name = _DEPRECATED_ALIASES[name]
-    warnings.warn(
-      f"{name} is deprecated and will be removed in a future version. Use {new_name} instead.",
-      DeprecationWarning,
-      stacklevel=2,
-    )
-    return globals()[new_name]
-  raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
These were replaced by TerrainEntity and TerrainEntityCfg in #663 and kept as deprecated aliases for one release cycle. That cycle is now complete, so this removes the `_DEPRECATED_ALIASES` dict and module-level `__getattr__` hook from `mjlab.terrains`.

Fixes #667

🤖 Generated with [Claude Code](https://claude.com/claude-code)