### PR TITLE
Fix RepresenterError when dumping agent_cfg to YAML

### DIFF
--- a/src/mjlab/scripts/train.py
+++ b/src/mjlab/scripts/train.py
@@ -155,6 +155,12 @@ def run_train(task_id: str, cfg: TrainConfig, log_dir: Path) -> None:
   if is_tracking_task:
     runner_kwargs["registry_name"] = registry_name
 
+  # Write config files before runner creation, since the runner mutates agent_cfg
+  # in-place (e.g., injecting non-serializable objects).
+  if rank == 0:
+    dump_yaml(log_dir / "params" / "env.yaml", env_cfg)
+    dump_yaml(log_dir / "params" / "agent.yaml", agent_cfg)
+
   runner = runner_cls(env, agent_cfg, str(log_dir), device, **runner_kwargs)
 
   add_wandb_tags(cfg.agent.wandb_tags)
@@ -162,11 +168,6 @@ def run_train(task_id: str, cfg: TrainConfig, log_dir: Path) -> None:
   if resume_path is not None:
     print(f"[INFO]: Loading model checkpoint from: {resume_path}")
     runner.load(str(resume_path))
-
-  # Only write config files from rank 0 to avoid race conditions.
-  if rank == 0:
-    dump_yaml(log_dir / "params" / "env.yaml", env_cfg)
-    dump_yaml(log_dir / "params" / "agent.yaml", agent_cfg)
 
   runner.learn(
     num_learning_iterations=cfg.agent.max_iterations, init_at_random_ep_len=True

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,5 +1,6 @@
 """Tests for MjlabOnPolicyRunner."""
 
+import ast
 import tempfile
 from dataclasses import asdict
 from pathlib import Path
@@ -12,6 +13,7 @@ from conftest import get_test_device
 from rsl_rl.models import MLPModel
 from tensordict import TensorDict
 
+import mjlab.scripts.train as train_mod
 from mjlab.actuator import XmlMotorActuatorCfg
 from mjlab.entity import EntityArticulationInfoCfg, EntityCfg
 from mjlab.envs import ManagerBasedRlEnv, ManagerBasedRlEnvCfg, mdp
@@ -23,6 +25,7 @@ from mjlab.scene import SceneCfg
 from mjlab.sim import MujocoCfg, SimulationCfg
 from mjlab.tasks.tracking.rl.runner import _OnnxMotionModel
 from mjlab.terrains import TerrainEntityCfg
+from mjlab.utils.os import dump_yaml
 
 
 @pytest.fixture(scope="module")
@@ -306,6 +309,59 @@ def test_cnn_onnx_export_to_file():
     )
     assert onnx_path.exists()
     onnx.checker.check_model(str(onnx_path))
+
+
+def test_agent_cfg_serializable_after_runner_creation(env, device):
+  """dump_yaml must be called before runner creation.
+
+  The runner mutates agent_cfg in-place (e.g. resolve_symmetry_config injects
+  non-serializable objects). Verify that the train script writes config files before
+  constructing the runner.
+
+  Regression test for https://github.com/mjlab-org/mjlab/issues/764.
+  """
+  wrapped_env = RslRlVecEnvWrapper(env)
+  agent_cfg = asdict(
+    RslRlOnPolicyRunnerCfg(num_steps_per_env=4, max_iterations=10, save_interval=5)
+  )
+
+  # Dump should succeed before runner creation.
+  with tempfile.TemporaryDirectory() as tmpdir:
+    dump_yaml(Path(tmpdir) / "agent.yaml", agent_cfg)
+
+  # Create runner (mutates agent_cfg via resolve_symmetry_config).
+  with tempfile.TemporaryDirectory() as tmpdir:
+    MjlabOnPolicyRunner(wrapped_env, agent_cfg, log_dir=tmpdir, device=device)
+
+  # Confirm that the runner added non-serializable keys to agent_cfg.
+  sym_cfg = agent_cfg.get("algorithm", {}).get("symmetry_cfg")
+  runner_mutated = sym_cfg is not None or "multi_gpu" in agent_cfg
+  assert runner_mutated, "Expected runner to mutate agent_cfg"
+
+  # Verify the train script calls dump_yaml before runner_cls().
+  source = Path(train_mod.__file__).read_text()
+  tree = ast.parse(source)
+
+  dump_yaml_line = None
+  runner_cls_line = None
+  for node in ast.walk(tree):
+    if isinstance(node, ast.Call):
+      func = node.func
+      # Look for dump_yaml(..., agent_cfg)
+      if isinstance(func, ast.Name) and func.id == "dump_yaml":
+        for arg in node.args:
+          if isinstance(arg, ast.Name) and arg.id == "agent_cfg":
+            dump_yaml_line = node.lineno
+      # Look for runner_cls(...)
+      if isinstance(func, ast.Name) and func.id == "runner_cls":
+        runner_cls_line = node.lineno
+
+  assert dump_yaml_line is not None, "dump_yaml(agent_cfg) not found"
+  assert runner_cls_line is not None, "runner_cls() not found"
+  assert dump_yaml_line < runner_cls_line, (
+    f"dump_yaml (line {dump_yaml_line}) must be called before "
+    f"runner_cls (line {runner_cls_line})"
+  )
 
 
 class _MockMotion:


### PR DESCRIPTION
The runner's `PPO.construct_algorithm` calls `resolve_symmetry_config`, which injects the live `env` object into `agent_cfg["algorithm"]["symmetry_cfg"]["_env"]` in-place. When `dump_yaml` runs after runner creation, it fails with a `RepresenterError` because the env object is not serializable.

The fix moves the `dump_yaml` calls to before runner creation, when `agent_cfg` is still a pure dict from `asdict()`. This also means the written config reflects the original user configuration rather than the runner's internal mutations (e.g. `multi_gpu`, popped `None` values).

Added a regression test that confirms the runner mutates `agent_cfg` and verifies via AST inspection that `dump_yaml` is called before `runner_cls()` in the train script.

Fixes #764

🤖 Generated with [Claude Code](https://claude.com/claude-code)