### PR TITLE
Implement ActionTermCfg.clip for clamping processed actions

### DIFF
--- a/docs/source/actions.rst
+++ b/docs/source/actions.rst
@@ -42,8 +42,19 @@ scaling; joint action types also provide ``use_default_offset``, which
 automatically loads the entity's default joint positions or velocities
 as the offset so that a raw output of zero produces the default pose.
 
-``clip`` optionally clamps the processed action before it reaches the
-actuator.
+``clip`` optionally clamps the processed action (after scale and offset)
+before it reaches the actuator. It accepts a dict mapping actuator name
+patterns to ``(min, max)`` tuples, resolved the same way as ``scale``
+and ``offset``.
+
+.. code-block:: python
+
+    JointPositionActionCfg(
+        entity_name="robot",
+        actuator_names=(".*",),
+        scale=0.5,
+        clip={".*_hip_.*": (-1.0, 1.0), ".*_knee_.*": (-0.5, 2.0)},
+    )
 
 Actions are written to actuator targets on every decimation substep
 (physics step), not just once per policy step. This is in contrast to

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -15,6 +15,8 @@ Added
 - NaN guard now captures mocap body poses (``mocap_pos``, ``mocap_quat``)
   when the model has mocap bodies, enabling full state reconstruction in
   the dump viewer for fixed-base entities.
+- Implemented ``ActionTermCfg.clip`` for clamping processed actions after
+  scale and offset (:issue:`771`).
 
 Changed
 ^^^^^^^

--- a/src/mjlab/envs/mdp/actions/actions.py
+++ b/src/mjlab/envs/mdp/actions/actions.py
@@ -88,6 +88,15 @@ class BaseAction(ActionTerm):
         f"Supported types are float and dict."
       )
 
+    if cfg.clip is not None:
+      self._clip = torch.tensor(
+        [[-float("inf"), float("inf")]], device=self.device
+      ).repeat(self.num_envs, self.action_dim, 1)
+      index_list, _, value_list = resolve_matching_names_values(
+        cfg.clip, self._target_names
+      )
+      self._clip[:, index_list] = torch.tensor(value_list, device=self.device)
+
   def _find_targets(self, cfg: BaseActionCfg) -> tuple[list[int], list[str]]:
     """Find target IDs and names based on transmission type.
 
@@ -143,9 +152,15 @@ class BaseAction(ActionTerm):
     return self._target_names
 
   def process_actions(self, actions: torch.Tensor):
-    """Process raw actions by applying scale and offset."""
+    """Process raw actions by applying scale, offset, and optional clip."""
     self._raw_actions[:] = actions
     self._processed_actions = self._raw_actions * self._scale + self._offset
+    if self.cfg.clip is not None:
+      self._processed_actions = torch.clamp(
+        self._processed_actions,
+        min=self._clip[:, :, 0],
+        max=self._clip[:, :, 1],
+      )
 
   def reset(self, env_ids: torch.Tensor | slice | None = None) -> None:
     """Reset raw actions to zero for specified environments."""

--- a/src/mjlab/managers/action_manager.py
+++ b/src/mjlab/managers/action_manager.py
@@ -27,8 +27,9 @@ class ActionTermCfg(abc.ABC):
   """Name of the entity in the scene that this action term controls."""
 
   clip: dict[str, tuple] | None = None
-  """Optional clipping bounds per transmission type. Maps transmission name
-  (e.g., 'position', 'velocity') to (min, max) tuple."""
+  """Optional clipping bounds applied to processed actions (after scale
+  and offset). Dict maps actuator name regex patterns to (min, max)
+  tuples, resolved the same way as ``scale`` and ``offset``."""
 
   @abc.abstractmethod
   def build(self, env: ManagerBasedRlEnv) -> ActionTerm:

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -194,3 +194,36 @@ def test_action_sets_entity_target(
 
   entity_target = getattr(entity.data, target_attr)
   assert torch.allclose(entity_target, target)
+
+
+def test_base_action_clip(fixtures_dir, device):
+  """BaseAction: clip clamps only matched actuators; others stay unclipped."""
+  entity = make_entity(
+    fixtures_dir / "fixed_base_articulated.xml",
+    ("joint.*",),
+    TransmissionType.JOINT,
+    device,
+    from_file=True,
+  )
+  env = make_env(entity, "robot", device)
+
+  # Clip only joint1; joint2 should remain unclipped.
+  cfg = JointPositionActionCfg(
+    entity_name="robot",
+    actuator_names=("joint.*",),
+    scale=1.0,
+    use_default_offset=False,
+    clip={"joint1": (-0.5, 0.5)},
+  )
+  action = cfg.build(env)
+
+  # joint1=2.0 should be clipped to 0.5, joint2=2.0 should pass through.
+  raw = torch.tensor([[2.0, 2.0]], device=device).expand(4, -1)
+  action.process_actions(raw)
+
+  assert torch.allclose(
+    action._processed_actions[:, 0], torch.tensor(0.5, device=device)
+  )
+  assert torch.allclose(
+    action._processed_actions[:, 1], torch.tensor(2.0, device=device)
+  )


### PR DESCRIPTION
The `clip` field was declared on `ActionTermCfg` but had no implementation. This adds the actual clamping logic in `BaseAction.process_actions`, applied after scale and offset. The clip dict maps actuator name regex patterns to `(min, max)` tuples, resolved the same way as `scale` and `offset` via `resolve_matching_names_values`. The clip tensor is built once at construction time so the hot path is a single `torch.clamp` call.

Also fixes the docstring which incorrectly described clip as mapping "transmission names", and adds a usage example to the actions docs.

Fixes #771

🤖 Generated with [Claude Code](https://claude.com/claude-code)