### PR TITLE
Configure Sphinx extlinks so :issue: role renders properly

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,8 @@ Before creating a PR, ensure all checks pass with `make test`.
 
 When making user-facing changes, add an entry to `docs/source/changelog.rst`
 under the "Upcoming version (not yet released)" section using
-Added/Changed/Fixed categories.
+Added/Changed/Fixed categories. Reference issues with `:issue:\`123\``
+(renders as a link to the GitHub issue).
 
 # Commits and PRs
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,15 @@ extensions = [
   "sphinx_design",
   "sphinx_tabs.tabs",
   "sphinx_multiversion",
+  "sphinx.ext.extlinks",
 ]
+
+extlinks = {
+  "issue": (
+    "https://github.com/mujocolab/mjlab/issues/%s",
+    "#%s",
+  ),
+}
 
 mathjax3_config = {
   "tex": {


### PR DESCRIPTION
The changelog was using `:issue:` references but `sphinx.ext.extlinks` was not enabled, so they rendered as broken roles instead of links. This adds the extension with the GitHub issue URL pattern and documents the `:issue:` convention in CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)