### PR TITLE
Add motion imitation documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,7 @@ uv run play Mjlab-Velocity-Flat-Unitree-G1 --wandb-run-path your-org/mjlab/run-i
 
 ### 2. Motion Imitation
 
-Train a humanoid to mimic reference motions. mjlab uses WandB to manage motion datasets.
-See the [motion preprocessing documentation](https://github.com/HybridRobotics/whole_body_tracking/blob/main/README.md#motion-preprocessing--registry-setup) for setup instructions.
+Train a humanoid to mimic reference motions. See the [motion imitation guide](https://mujocolab.github.io/mjlab/main/source/training/motion_imitation.html) for preprocessing setup.
 
 ```bash
 uv run train Mjlab-Tracking-Flat-Unitree-G1 --registry-name your-org/motions/motion-name --env.scene.num-envs 4096

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,6 +8,10 @@ Upcoming version (not yet released)
 Added
 ^^^^^
 
+- Added :ref:`motion imitation <motion-imitation>` documentation with
+  preprocessing instructions. The README now links here instead of the
+  BeyondMimic repository, which produced incompatible NPZ files when used
+  with mjlab (:issue:`777`).
 - Added ``margin``, ``gap``, and ``solmix`` fields to ``CollisionCfg``
   for per geom contact parameter configuration (:issue:`766`).
 - Added ``DelayedBuiltinActuatorGroup`` that fuses delayed builtin actuators

--- a/docs/source/training/motion_imitation.rst
+++ b/docs/source/training/motion_imitation.rst
@@ -1,0 +1,65 @@
+.. _motion-imitation:
+
+Motion Imitation
+================
+
+mjlab can train humanoid policies to imitate reference motions. This page
+covers motion data preprocessing and training.
+
+WandB registry setup
+--------------------
+
+mjlab uses `Weights & Biases <https://wandb.ai/>`_ to store and load
+reference motions. Before preprocessing any motions, create a WandB registry
+by following the
+`BeyondMimic instructions <https://github.com/HybridRobotics/whole_body_tracking/blob/main/README.md#motion-preprocessing--registry-setup>`_
+(only the registry creation step; skip the ``csv_to_npz.py`` command shown
+there).
+
+Motion preprocessing
+--------------------
+
+Reference motions are retargeted CSV files in Unitree's generalized
+coordinate convention (base position, base quaternion in xyzw, then joint
+angles).
+
+Convert a CSV to the NPZ format mjlab expects:
+
+.. code-block:: bash
+
+   MUJOCO_GL=egl uv run -m mjlab.scripts.csv_to_npz \
+       --input-file <PATH_TO_CSV> \
+       --output-name <MOTION_NAME> \
+       --input-fps 30 \
+       --output-fps 50 \
+       --render True
+
+The script plays the motion through MuJoCo Warp, computes forward kinematics
+for every body, and uploads the resulting NPZ to your WandB registry.
+
+.. warning::
+
+   You **must** use mjlab's converter (``mjlab.scripts.csv_to_npz``).
+   Converters from other frameworks such as IsaacLab produce NPZ files with
+   incompatible body orderings. The NPZ stores precomputed body positions and
+   quaternions indexed by body number, and different physics engines assign
+   body indices differently (MuJoCo uses depth first traversal, PhysX uses
+   breadth first). A mismatched NPZ will map tracking targets to the wrong
+   bodies and training will not converge.
+
+Training
+--------
+
+.. code-block:: bash
+
+   uv run train Mjlab-Tracking-Flat-Unitree-G1 \
+       --registry-name your-org/motions/motion-name \
+       --env.scene.num-envs 4096
+
+Evaluation
+----------
+
+.. code-block:: bash
+
+   uv run play Mjlab-Tracking-Flat-Unitree-G1 \
+       --wandb-run-path your-org/mjlab/run-id

--- a/docs/source/training/rsl_rl.rst
+++ b/docs/source/training/rsl_rl.rst
@@ -265,3 +265,8 @@ If you use RSL-RL in your research, consider citing:
         journal={arXiv preprint arXiv:2509.10771},
         year={2025}
     }
+
+.. toctree::
+   :maxdepth: 1
+
+   motion_imitation


### PR DESCRIPTION
The README previously linked to BeyondMimic's preprocessing instructions, which told users to run BeyondMimic's `csv_to_npz.py`. That script computes forward kinematics through IsaacLab/PhysX, producing an NPZ where body arrays are indexed in PhysX's breadth first order rather than MuJoCo's depth first order. Loading that NPZ in mjlab maps every tracking target to the wrong body, so training cannot converge.

This adds a motion imitation doc page (nested under the RSL-RL training page) with the correct preprocessing command using `mjlab.scripts.csv_to_npz`, a warning about incompatible formats, and a link to BeyondMimic only for WandB registry setup. The README now links to this page instead.

Fixes #777