### PR TITLE
Fix velocity actuator for continuous joints

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -47,6 +47,9 @@ Fixed
   of ``actuator_force`` (actuation space) for mechanical power computation.
   Previously the reward was incorrect for actuators with gear ratios other
   than 1 (:issue:`776`).
+- ``create_velocity_actuator`` no longer sets ``ctrllimited=True`` with
+  ``inheritrange=1.0``. This caused a ``ValueError`` for continuous joints
+  (e.g. wheels) that have no position range defined (:issue:`787`).
 - ``dr.pseudo_inertia`` no longer loads cuSOLVER, eliminating ~4 GB of
   persistent GPU memory overhead. Cholesky and eigendecomposition are now
   computed analytically for the small matrices involved (4x4 and 3x3)

--- a/src/mjlab/utils/spec.py
+++ b/src/mjlab/utils/spec.py
@@ -217,10 +217,14 @@ def create_velocity_actuator(
   effort_limit: float | None = None,
   armature: float = 0.0,
   frictionloss: float = 0.0,
-  inheritrange: float = 1.0,
   transmission_type: TransmissionType = TransmissionType.JOINT,
 ) -> mujoco.MjsActuator:
-  """Creates a <velocity> actuator."""
+  """Creates a <velocity> actuator.
+
+  Control inputs are not clamped so that velocity commands work for any joint,
+  including continuous joints that have no range defined. Force output is still
+  bounded when effort_limit is set.
+  """
   actuator = spec.add_actuator(name=joint_name, target=joint_name)
 
   actuator.trntype = _TRANSMISSION_TYPE_MAP[transmission_type]
@@ -228,8 +232,8 @@ def create_velocity_actuator(
   actuator.gaintype = mujoco.mjtGain.mjGAIN_FIXED
   actuator.biastype = mujoco.mjtBias.mjBIAS_AFFINE
 
-  actuator.inheritrange = inheritrange
-  actuator.ctrllimited = True  # Technically redundant but being explicit.
+  actuator.inheritrange = 0.0
+  actuator.ctrllimited = False
   actuator.gainprm[0] = damping
   actuator.biasprm[2] = -damping
 

--- a/tests/test_spec_utils.py
+++ b/tests/test_spec_utils.py
@@ -4,7 +4,7 @@ import mujoco
 import numpy as np
 import pytest
 
-from mjlab.utils.spec import create_position_actuator
+from mjlab.utils.spec import create_position_actuator, create_velocity_actuator
 
 
 @pytest.fixture
@@ -152,3 +152,63 @@ def test_ctrllimited_true_would_clip_internally():
   np.testing.assert_allclose(force_beyond, force_at_limit, rtol=1e-10)
   expected_force = -stiffness * (0.5 - 1.0)
   np.testing.assert_allclose(force_at_limit, expected_force, rtol=1e-5)
+
+
+@pytest.fixture
+def spec_with_continuous_joint():
+  """Create a spec with a continuous (unlimited) hinge joint."""
+  spec = mujoco.MjSpec()
+  body = spec.worldbody.add_body(name="wheel")
+  body.add_joint(
+    name="wheel_joint",
+    type=mujoco.mjtJoint.mjJNT_HINGE,
+    axis=[0, 0, 1],
+  )
+  body.add_geom(type=mujoco.mjtGeom.mjGEOM_CYLINDER, size=[0.1, 0.05], mass=1.0)
+  return spec
+
+
+def test_velocity_actuator_continuous_joint(spec_with_continuous_joint):
+  """Velocity actuator compiles for continuous joints with no range."""
+  damping = 10.0
+  create_velocity_actuator(
+    spec_with_continuous_joint,
+    "wheel_joint",
+    damping=damping,
+  )
+  model = spec_with_continuous_joint.compile()
+  data = mujoco.MjData(model)
+
+  actuator_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, "wheel_joint")
+  assert model.actuator_ctrllimited[actuator_id] == 0
+
+  # Commanding a velocity target should produce force = damping * (ctrl - qvel).
+  data.qvel[0] = 0.0
+  data.ctrl[0] = 5.0
+  mujoco.mj_forward(model, data)
+  expected_force = damping * 5.0
+  np.testing.assert_allclose(data.actuator_force[0], expected_force, rtol=1e-5)
+
+
+def test_velocity_actuator_forces_clipped_to_effort_limit(
+  spec_with_continuous_joint,
+):
+  """Velocity actuator force is bounded by effort_limit."""
+  effort_limit = 20.0
+  create_velocity_actuator(
+    spec_with_continuous_joint,
+    "wheel_joint",
+    damping=1000.0,
+    effort_limit=effort_limit,
+  )
+  model = spec_with_continuous_joint.compile()
+  data = mujoco.MjData(model)
+
+  actuator_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, "wheel_joint")
+  assert model.actuator_forcelimited[actuator_id] == 1
+
+  # Large velocity error would exceed effort_limit without clamping.
+  data.qvel[0] = 0.0
+  data.ctrl[0] = 100.0
+  mujoco.mj_forward(model, data)
+  assert abs(data.actuator_force[0]) <= effort_limit + 1e-6


### PR DESCRIPTION
Velocity actuators set `ctrllimited=True` with `inheritrange=1.0`, which inherited ctrlrange from the joint's position range. Continuous joints like wheels have no position range, so MuJoCo rejected the resulting `[0, 0]` ctrlrange.

Control clamping is now disabled and range inheritance removed, matching the position actuator design. The policy can output unconstrained velocity targets while `forcerange` still bounds torque output. The `inheritrange` parameter is also removed from the function signature since no callers used it.

Added two tests covering continuous joint compilation and effort limit enforcement.