### PR TITLE
Fix stepping stones gap around platform and scale size with difficulty

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -30,6 +30,9 @@ Added
 Changed
 ^^^^^^^
 
+- ``BoxSteppingStonesTerrainCfg`` stone size now decreases with difficulty,
+  interpolating from the large end of ``stone_size_range`` at difficulty 0
+  to the small end at difficulty 1 (:issue:`785`).
 - Removed deprecated ``TerrainImporter`` and ``TerrainImporterCfg`` aliases.
   Use ``TerrainEntity`` and ``TerrainEntityCfg`` instead (:issue:`667`).
 - ``Entity.clear_state()`` is deprecated. Use ``Entity.reset()`` instead.
@@ -55,6 +58,10 @@ Fixed
   (``DcMotorActuator``, ``IdealPdActuator``) previously showed incorrect
   contact forces because the viewer ran with ``ctrl=0``
   (:issue:`786`).
+- ``BoxSteppingStonesTerrainCfg`` no longer creates a large gap around the
+  platform. Stones are now only skipped when their center falls inside the
+  platform; edges that extend under the platform are allowed since the
+  platform covers them (:issue:`785`).
 - ``dr.pseudo_inertia`` no longer loads cuSOLVER, eliminating ~4 GB of
   persistent GPU memory overhead. Cholesky and eigendecomposition are now
   computed analytically for the small matrices involved (4x4 and 3x3)

--- a/src/mjlab/terrains/primitive_terrains.py
+++ b/src/mjlab/terrains/primitive_terrains.py
@@ -1156,8 +1156,9 @@ class BoxSteppingStonesTerrainCfg(SubTerrainCfg):
     d_low, d_high = self.stone_distance_range
     avg_distance = (d_low + d_high) / 2 + difficulty * (d_high - d_low) / 2
 
-    # Grid spacing (stone size + gap).
-    avg_stone_size = (self.stone_size_range[0] + self.stone_size_range[1]) / 2
+    # Decrease stone size with difficulty (larger stones are easier).
+    s_min, s_max = self.stone_size_range
+    avg_stone_size = (s_min + s_max) / 2 - difficulty * (s_max - s_min) / 2
     spacing = avg_stone_size + avg_distance
 
     # Aggressive grid density to reach borders.
@@ -1218,8 +1219,7 @@ class BoxSteppingStonesTerrainCfg(SubTerrainCfg):
 
     for i in range(num_x):
       for j in range(num_y):
-        avg_s_min, avg_s_max = self.stone_size_range
-        base_size = (avg_s_min + avg_s_max) / 2
+        base_size = avg_stone_size
 
         # Proposed position with displacement.
         px = (
@@ -1237,10 +1237,10 @@ class BoxSteppingStonesTerrainCfg(SubTerrainCfg):
         x_min, x_max = px - size_x / 2, px + size_x / 2
         y_min, y_max = py - size_y / 2, py + size_y / 2
 
-        # Avoid platform.
-        margin = max(avg_s_max, self.stone_size_variation * 2) / 2
-        if (platform_min - margin <= px <= platform_max + margin) and (
-          platform_min - margin <= py <= platform_max + margin
+        # Skip stones centered inside the platform. Stones whose edges
+        # extend under the platform are kept; the platform covers the overlap.
+        if (platform_min <= px <= platform_max) and (
+          platform_min <= py <= platform_max
         ):
           continue
 

--- a/tests/test_terrains.py
+++ b/tests/test_terrains.py
@@ -1,0 +1,76 @@
+"""Tests for terrain generation."""
+
+import mujoco
+import numpy as np
+
+from mjlab.terrains.primitive_terrains import BoxSteppingStonesTerrainCfg
+
+_CFG = BoxSteppingStonesTerrainCfg(
+  proportion=1.0,
+  size=(8.0, 8.0),
+  stone_size_range=(0.2, 0.6),
+  stone_distance_range=(0.05, 0.25),
+  stone_height=0.2,
+  stone_height_variation=0.05,
+  stone_size_variation=0.05,
+  displacement_range=0.1,
+  floor_depth=2.0,
+  platform_width=1.5,
+  border_width=0.25,
+)
+
+
+def _generate_stones(
+  cfg: BoxSteppingStonesTerrainCfg,
+  difficulty: float,
+  rng: np.random.Generator,
+) -> list[tuple[float, float, float, float]]:
+  """Generate terrain and return stone (cx, cy, half_x, half_y) tuples."""
+  spec = mujoco.MjSpec()
+  spec.worldbody.add_body(name="terrain")
+  output = cfg.function(difficulty=difficulty, spec=spec, rng=rng)
+
+  center = cfg.size[0] / 2
+  stones = []
+  for geom_info in output.geometries:
+    geom = geom_info.geom
+    if geom is None:
+      continue
+    pos, size = geom.pos, geom.size
+    # Skip platform, floor, and border geoms.
+    is_platform = (
+      np.isclose(pos[0], center)
+      and np.isclose(pos[1], center)
+      and np.isclose(size[0], cfg.platform_width / 2, atol=1e-4)
+    )
+    is_full_span = np.isclose(size[0], cfg.size[0] / 2) or np.isclose(
+      size[1], cfg.size[1] / 2
+    )
+    if is_platform or is_full_span:
+      continue
+    stones.append((pos[0], pos[1], size[0], size[1]))
+  return stones
+
+
+def test_no_stone_centers_inside_platform():
+  """No stone center should fall inside the platform."""
+  center = _CFG.size[0] / 2
+  p_half = _CFG.platform_width / 2
+  p_min, p_max = center - p_half, center + p_half
+
+  for difficulty in [0.0, 0.5, 1.0]:
+    stones = _generate_stones(_CFG, difficulty, np.random.default_rng(42))
+    for cx, cy, _, _ in stones:
+      assert not (p_min <= cx <= p_max and p_min <= cy <= p_max), (
+        f"Stone at ({cx:.3f}, {cy:.3f}) inside platform at difficulty={difficulty}"
+      )
+
+
+def test_stone_size_decreases_with_difficulty():
+  """Average stone size should be smaller at higher difficulty."""
+  sizes = {}
+  for difficulty in [0.0, 1.0]:
+    stones = _generate_stones(_CFG, difficulty, np.random.default_rng(42))
+    sizes[difficulty] = np.mean([hx + hy for _, _, hx, hy in stones])
+
+  assert sizes[0.0] > sizes[1.0]


### PR DESCRIPTION
`BoxSteppingStonesTerrainCfg` used a fixed margin (`max(avg_s_max, stone_size_variation * 2) / 2`) to skip stones near the platform. This excluded stones that did not actually overlap the platform, creating a visible gap. Stones are now only skipped when their center falls inside the platform. Edges that extend under the platform are allowed since the platform covers them.

Stone base size was also fixed regardless of difficulty. It now interpolates from the large end of `stone_size_range` at difficulty 0 to the small end at difficulty 1, matching how `stone_distance_range` already scales.

<img width="1600" height="800" alt="stepping_stones_compare" src="https://github.com/user-attachments/assets/da6cc465-f317-432b-99c7-4aa46be4295c" />