### PR TITLE
Add onnxruntime roundtrip tests for ONNX policy export

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ dev = [
   "ipdb>=0.13.13",
   "pre-commit>=4.3.0",
   "pyright>=1.1.408",
+  "onnxruntime>=1.19.0; python_version >= '3.11'",
   "pytest>=v9.0.2",
   "ruff>=v0.14.14",
   "ty>=v0.0.14",

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -220,6 +220,35 @@ def test_onnx_export_without_normalization():
   assert out.shape == (4, 4)
 
 
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+def test_onnx_runtime_roundtrip_matches_pytorch():
+  """Exported .onnx file produces the same outputs as PyTorch via onnxruntime."""
+  ort = pytest.importorskip("onnxruntime")
+  actor = _make_actor(obs_normalization=True)
+  _train_normalizer(actor)
+  onnx_model = actor.as_onnx(verbose=False)
+  onnx_model.eval()
+
+  x = torch.randn(4, actor.obs_dim)
+  expected = _model_output(actor, x)
+
+  with tempfile.TemporaryDirectory() as tmpdir:
+    path = Path(tmpdir) / "policy.onnx"
+    torch.onnx.export(
+      onnx_model,
+      (x,),
+      str(path),
+      input_names=onnx_model.input_names,  # pyright: ignore[reportArgumentType]
+      output_names=onnx_model.output_names,  # pyright: ignore[reportArgumentType]
+      opset_version=18,
+      dynamo=False,
+    )
+    sess = ort.InferenceSession(str(path))
+    [actual] = sess.run(None, {"obs": x.numpy()})
+
+  torch.testing.assert_close(torch.from_numpy(actual), expected, atol=1e-5, rtol=0)
+
+
 # CNN (spatial-softmax) ONNX export tests.
 
 _IMG_H, _IMG_W, _IMG_C = 16, 16, 3
@@ -253,6 +282,19 @@ def _make_cnn_actor(obs_normalization=True):
   )
 
 
+def _train_cnn_normalizer(actor, n_batches=50, batch_size=64):
+  actor.train()
+  for _ in range(n_batches):
+    obs = TensorDict(
+      {
+        "actor": torch.randn(batch_size, _OBS_DIM_1D) * 5 + 3,
+        "camera": torch.randn(batch_size, _IMG_C, _IMG_H, _IMG_W),
+      }
+    )
+    actor.update_normalization(obs)
+  actor.eval()
+
+
 def _cnn_model_output(actor, x_1d, x_2d):
   obs = TensorDict({"actor": x_1d, "camera": x_2d})
   with torch.no_grad():
@@ -262,17 +304,7 @@ def _cnn_model_output(actor, x_1d, x_2d):
 def test_cnn_onnx_export_matches_actor():
   """as_onnx() with SpatialSoftmaxCNNModel matches the original model."""
   actor = _make_cnn_actor(obs_normalization=True)
-  # Train normalizer on 1D observations.
-  actor.train()
-  for _ in range(50):
-    obs = TensorDict(
-      {
-        "actor": torch.randn(64, _OBS_DIM_1D) * 5 + 3,
-        "camera": torch.randn(64, _IMG_C, _IMG_H, _IMG_W),
-      }
-    )
-    actor.update_normalization(obs)
-  actor.eval()
+  _train_cnn_normalizer(actor)
 
   onnx_model = actor.as_onnx(verbose=False)
   onnx_model.eval()
@@ -309,6 +341,37 @@ def test_cnn_onnx_export_to_file():
     )
     assert onnx_path.exists()
     onnx.checker.check_model(str(onnx_path))
+
+
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+def test_cnn_onnx_runtime_roundtrip_matches_pytorch():
+  """Exported CNN .onnx file produces the same outputs as PyTorch via onnxruntime."""
+  ort = pytest.importorskip("onnxruntime")
+  actor = _make_cnn_actor(obs_normalization=True)
+  _train_cnn_normalizer(actor)
+
+  onnx_model = actor.as_onnx(verbose=False)
+  onnx_model.eval()
+
+  x_1d = torch.randn(4, _OBS_DIM_1D)
+  x_2d = torch.randn(4, _IMG_C, _IMG_H, _IMG_W)
+  expected = _cnn_model_output(actor, x_1d, x_2d)
+
+  with tempfile.TemporaryDirectory() as tmpdir:
+    path = Path(tmpdir) / "cnn_policy.onnx"
+    torch.onnx.export(
+      onnx_model,
+      (x_1d, x_2d),
+      str(path),
+      input_names=onnx_model.input_names,  # pyright: ignore[reportArgumentType]
+      output_names=onnx_model.output_names,  # pyright: ignore[reportArgumentType]
+      opset_version=18,
+      dynamo=False,
+    )
+    sess = ort.InferenceSession(str(path))
+    [actual] = sess.run(None, {"obs": x_1d.numpy(), "camera": x_2d.numpy()})
+
+  torch.testing.assert_close(torch.from_numpy(actual), expected, atol=1e-5, rtol=0)
 
 
 def test_agent_cfg_serializable_after_runner_creation(env, device):

--- a/uv.lock
+++ b/uv.lock
@@ -728,6 +728,14 @@ wheels = [
 ]
 
 [[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl", hash = "sha256:7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4", size = 26661, upload-time = "2025-12-19T23:16:13.622Z" },
+]
+
+[[package]]
 name = "fonttools"
 version = "4.61.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1647,6 +1655,7 @@ cu128 = [
 [package.dev-dependencies]
 dev = [
     { name = "ipdb" },
+    { name = "onnxruntime", marker = "python_full_version >= '3.11' or (extra == 'extra-5-mjlab-cpu' and extra == 'extra-5-mjlab-cu128')" },
     { name = "pre-commit" },
     { name = "pyright" },
     { name = "pytest" },
@@ -1702,6 +1711,7 @@ provides-extras = ["cu128", "cpu"]
 [package.metadata.requires-dev]
 dev = [
     { name = "ipdb", specifier = ">=0.13.13" },
+    { name = "onnxruntime", marker = "python_full_version >= '3.11'", specifier = ">=1.19.0" },
     { name = "pre-commit", specifier = ">=4.3.0" },
     { name = "pyright", specifier = ">=1.1.408" },
     { name = "pytest", specifier = ">=9.0.2" },
@@ -2318,6 +2328,37 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/4b/c4/d7c52d89120ae2d90025bf30999f44ec029bb297be706ada81a2b7ce3e73/onnx_ir-0.1.11.tar.gz", hash = "sha256:05fd55f7548f4301a17476c53e19c16f92f4fc4c0f468fcd8d3afb6869f8ae75", size = 112093, upload-time = "2025-10-15T22:20:46.785Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3a/de/a9bb49f36e2d27ff2b1941972ce01838c9032155256e3380960c6f545455/onnx_ir-0.1.11-py3-none-any.whl", hash = "sha256:f23edd0d3f49b92abfab275625cb325da3978f5b41ba8cdaa28e85e87b44d2c1", size = 128694, upload-time = "2025-10-15T22:20:45.208Z" },
+]
+
+[[package]]
+name = "onnxruntime"
+version = "1.24.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flatbuffers", marker = "python_full_version >= '3.11' or (extra == 'extra-5-mjlab-cpu' and extra == 'extra-5-mjlab-cu128')" },
+    { name = "numpy", version = "2.3.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-5-mjlab-cpu' and extra == 'extra-5-mjlab-cu128')" },
+    { name = "packaging", marker = "python_full_version >= '3.11' or (extra == 'extra-5-mjlab-cpu' and extra == 'extra-5-mjlab-cu128')" },
+    { name = "protobuf", marker = "python_full_version >= '3.11' or (extra == 'extra-5-mjlab-cpu' and extra == 'extra-5-mjlab-cu128')" },
+    { name = "sympy", marker = "python_full_version >= '3.11' or (extra == 'extra-5-mjlab-cpu' and extra == 'extra-5-mjlab-cu128')" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/41/3253db975a90c3ce1d475e2a230773a21cd7998537f0657947df6fb79861/onnxruntime-1.24.3-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:3e6456801c66b095c5cd68e690ca25db970ea5202bd0c5b84a2c3ef7731c5a3c", size = 17332766, upload-time = "2026-03-05T17:18:59.714Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/c5/3af6b325f1492d691b23844d88ed26844c1164620860c5efe95c0e22782d/onnxruntime-1.24.3-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b2ebc54c6d8281dccff78d4b06e47d4cf07535937584ab759448390a70f4978", size = 15130330, upload-time = "2026-03-05T16:34:53.831Z" },
+    { url = "https://files.pythonhosted.org/packages/03/4b/f96b46c1866a293ed23ca2cf5e5a63d413ad3a951da60dd877e3c56cbbca/onnxruntime-1.24.3-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fb56575d7794bf0781156955610c9e651c9504c64d42ec880784b6106244882d", size = 17213247, upload-time = "2026-03-05T17:17:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/36/13/27cf4d8df2578747584e8758aeb0b673b60274048510257f1f084b15e80e/onnxruntime-1.24.3-cp311-cp311-win_amd64.whl", hash = "sha256:c958222ef9eff54018332beecd32d5d94a3ab079d8821937b333811bf4da0d39", size = 12595530, upload-time = "2026-03-05T17:18:49.356Z" },
+    { url = "https://files.pythonhosted.org/packages/19/8c/6d9f31e6bae72a8079be12ed8ba36c4126a571fad38ded0a1b96f60f6896/onnxruntime-1.24.3-cp311-cp311-win_arm64.whl", hash = "sha256:a8f761857ebaf58a85b9e42422d03207f1d39e6bb8fecfdbf613bac5b9710723", size = 12261715, upload-time = "2026-03-05T17:18:39.699Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/7f/dfdc4e52600fde4c02d59bfe98c4b057931c1114b701e175aee311a9bc11/onnxruntime-1.24.3-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:0d244227dc5e00a9ae15a7ac1eba4c4460d7876dfecafe73fb00db9f1d914d91", size = 17342578, upload-time = "2026-03-05T17:19:02.403Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/dc/1f5489f7b21817d4ad352bf7a92a252bd5b438bcbaa7ad20ea50814edc79/onnxruntime-1.24.3-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a9847b870b6cb462652b547bc98c49e0efb67553410a082fde1918a38707452", size = 15150105, upload-time = "2026-03-05T16:34:56.897Z" },
+    { url = "https://files.pythonhosted.org/packages/28/7c/fd253da53594ab8efbefdc85b3638620ab1a6aab6eb7028a513c853559ce/onnxruntime-1.24.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b354afce3333f2859c7e8706d84b6c552beac39233bcd3141ce7ab77b4cabb5d", size = 17237101, upload-time = "2026-03-05T17:18:02.561Z" },
+    { url = "https://files.pythonhosted.org/packages/71/5f/eaabc5699eeed6a9188c5c055ac1948ae50138697a0428d562ac970d7db5/onnxruntime-1.24.3-cp312-cp312-win_amd64.whl", hash = "sha256:44ea708c34965439170d811267c51281d3897ecfc4aa0087fa25d4a4c3eb2e4a", size = 12597638, upload-time = "2026-03-05T17:18:52.141Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/5c/d8066c320b90610dbeb489a483b132c3b3879b2f93f949fb5d30cfa9b119/onnxruntime-1.24.3-cp312-cp312-win_arm64.whl", hash = "sha256:48d1092b44ca2ba6f9543892e7c422c15a568481403c10440945685faf27a8d8", size = 12270943, upload-time = "2026-03-05T17:18:42.006Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8d/487ece554119e2991242d4de55de7019ac6e47ee8dfafa69fcf41d37f8ed/onnxruntime-1.24.3-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:34a0ea5ff191d8420d9c1332355644148b1bf1a0d10c411af890a63a9f662aa7", size = 17342706, upload-time = "2026-03-05T16:35:10.813Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/25/8b444f463c1ac6106b889f6235c84f01eec001eaf689c3eff8c69cf48fae/onnxruntime-1.24.3-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1fd2ec7bb0fabe42f55e8337cfc9b1969d0d14622711aac73d69b4bd5abb5ed7", size = 15149956, upload-time = "2026-03-05T16:34:59.264Z" },
+    { url = "https://files.pythonhosted.org/packages/34/fc/c9182a3e1ab46940dd4f30e61071f59eee8804c1f641f37ce6e173633fb6/onnxruntime-1.24.3-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:df8e70e732fe26346faaeec9147fa38bef35d232d2495d27e93dd221a2d473a9", size = 17237370, upload-time = "2026-03-05T17:18:05.258Z" },
+    { url = "https://files.pythonhosted.org/packages/05/7e/3b549e1f4538514118bff98a1bcd6481dd9a17067f8c9af77151621c9a5c/onnxruntime-1.24.3-cp313-cp313-win_amd64.whl", hash = "sha256:2d3706719be6ad41d38a2250998b1d87758a20f6ea4546962e21dc79f1f1fd2b", size = 12597939, upload-time = "2026-03-05T17:18:54.772Z" },
+    { url = "https://files.pythonhosted.org/packages/80/41/9696a5c4631a0caa75cc8bc4efd30938fd483694aa614898d087c3ee6d29/onnxruntime-1.24.3-cp313-cp313-win_arm64.whl", hash = "sha256:b082f3ba9519f0a1a1e754556bc7e635c7526ef81b98b3f78da4455d25f0437b", size = 12270705, upload-time = "2026-03-05T17:18:44.774Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/65/a26c5e59e3b210852ee04248cf8843c81fe7d40d94cf95343b66efe7eec9/onnxruntime-1.24.3-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72f956634bc2e4bd2e8b006bef111849bd42c42dea37bd0a4c728404fdaf4d34", size = 15161796, upload-time = "2026-03-05T16:35:02.871Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/25/2035b4aa2ccb5be6acf139397731ec507c5f09e199ab39d3262b22ffa1ac/onnxruntime-1.24.3-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:78d1f25eed4ab9959db70a626ed50ee24cf497e60774f59f1207ac8556399c4d", size = 17240936, upload-time = "2026-03-05T17:18:09.534Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The existing ONNX export tests verify that the `as_onnx()` PyTorch wrapper matches the actor output, and that the exported `.onnx` file is a valid graph. But nothing actually runs the serialized file through onnxruntime and compares the result against PyTorch. This means `torch.onnx.export` tracing bugs (wrong normalization params, broken control flow, silent op lowering issues) would only surface at deployment time.

This adds two end-to-end roundtrip tests that export to `.onnx`, load via `ort.InferenceSession`, and assert numerical equivalence against PyTorch at `atol=1e-5`: one for MLP and one for CNN (spatial softmax), both with obs normalization enabled and a trained normalizer. Also extracts a `_train_cnn_normalizer` helper to deduplicate the CNN normalizer training loop, and adds `onnxruntime` to dev dependencies.