### PR TITLE
feat: proportion-based robot spawning on terrain columns

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -35,6 +35,10 @@ Added
 Changed
 ^^^^^^^
 
+- In curriculum terrain mode, each terrain type now gets exactly one column
+  (``num_cols`` is set to ``len(sub_terrains)``). The ``proportion`` field
+  now controls robot spawning distribution across columns rather than column
+  count. Random mode is unchanged (:issue:`811`).
 - ``BoxSteppingStonesTerrainCfg`` stone size now decreases with difficulty,
   interpolating from the large end of ``stone_size_range`` at difficulty 0
   to the small end at difficulty 1 (:issue:`785`).

--- a/src/mjlab/terrains/terrain_entity.py
+++ b/src/mjlab/terrains/terrain_entity.py
@@ -11,6 +11,31 @@ from mjlab.entity import Entity, EntityCfg
 from mjlab.terrains.terrain_generator import TerrainGenerator, TerrainGeneratorCfg
 from mjlab.utils import spec_config as spec_cfg
 
+
+def _proportional_counts(num_envs: int, proportions: np.ndarray) -> np.ndarray:
+  """Distribute *num_envs* across buckets proportionally.
+
+  Every bucket gets at least one when ``num_envs >= len(proportions)``. Remaining slots
+  are allocated via the Largest Remainder Method.
+  """
+  n = len(proportions)
+  if num_envs >= n:
+    counts = np.ones(n, dtype=int)
+    remaining = num_envs - n
+  else:
+    counts = np.zeros(n, dtype=int)
+    remaining = num_envs
+  if remaining > 0:
+    ideal = proportions * remaining
+    floor = np.floor(ideal).astype(int)
+    counts += floor
+    leftover = remaining - floor.sum()
+    if leftover > 0:
+      order = np.argsort(-(ideal - floor))
+      counts[order[:leftover]] += 1
+  return counts
+
+
 _DEFAULT_SUN_LIGHT = spec_cfg.LightCfg(
   name="sun", pos=(0.0, 0.0, 1.5), type="directional"
 )
@@ -114,9 +139,10 @@ class TerrainEntity(Entity):
         self.cfg.terrain_generator, device=self._device
       )
       terrain_generator.compile(self._spec)
-      self._configure_env_origins(
-        terrain_generator.terrain_origins, self.cfg.terrain_generator
-      )
+      gen_cfg = self.cfg.terrain_generator
+      proportions = np.array([s.proportion for s in gen_cfg.sub_terrains.values()])
+      proportions = proportions / proportions.sum()
+      self._configure_env_origins(terrain_generator.terrain_origins, proportions)
       self._flat_patches: dict[str, torch.Tensor] = {
         name: torch.from_numpy(arr).to(device=self._device, dtype=torch.float)
         for name, arr in terrain_generator.flat_patches.items()
@@ -154,15 +180,15 @@ class TerrainEntity(Entity):
   def configure_env_origins(
     self,
     origins: np.ndarray | torch.Tensor | None = None,
-    terrain_generator_cfg: TerrainGeneratorCfg | None = None,
+    proportions: np.ndarray | None = None,
   ) -> None:
     """Configure the origins of the environments based on the terrain."""
-    self._configure_env_origins(origins, terrain_generator_cfg)
+    self._configure_env_origins(origins, proportions)
 
   def _configure_env_origins(
     self,
     origins: np.ndarray | torch.Tensor | None = None,
-    terrain_generator_cfg: TerrainGeneratorCfg | None = None,
+    proportions: np.ndarray | None = None,
   ) -> None:
     if origins is not None:
       if isinstance(origins, np.ndarray):
@@ -171,7 +197,7 @@ class TerrainEntity(Entity):
         assert isinstance(origins, torch.Tensor)
       self.terrain_origins = origins.to(self._device, dtype=torch.float)
       self.env_origins = self._compute_env_origins_curriculum(
-        self.cfg.num_envs, self.terrain_origins, terrain_generator_cfg
+        self.cfg.num_envs, self.terrain_origins, proportions
       )
     else:
       self.terrain_origins = None
@@ -296,17 +322,16 @@ class TerrainEntity(Entity):
     self,
     num_envs: int,
     origins: torch.Tensor,
-    terrain_generator_cfg: TerrainGeneratorCfg | None = None,
+    proportions: np.ndarray | None = None,
   ) -> torch.Tensor:
-    """Compute the origins of the environments defined by the sub-terrain origins.
+    """Compute env origins from sub-terrain origins.
 
-    Allocation strategy:
-      - Columns (terrain_types): Distributed across environments **by proportion**.
-        Each column (terrain type) receives
-        ``max(1, round(proportion / total * num_envs))`` environments.
-        Falls back to even distribution when *terrain_generator_cfg* is ``None``.
-      - Rows (terrain_levels): Randomly sampled from [0, max_init_terrain_level].
-        Supports curriculum learning where rows represent difficulty levels.
+    Args:
+      num_envs: Number of environments to place.
+      origins: Sub-terrain origins, shape ``[num_rows, num_cols, 3]``.
+      proportions: Normalized per-column weights. When provided, robots
+        are distributed proportionally (every column gets at least one
+        when ``num_envs >= num_cols``). ``None`` gives even distribution.
     """
     num_rows, num_cols = origins.shape[:2]
     if self.cfg.max_init_terrain_level is None:
@@ -318,35 +343,13 @@ class TerrainEntity(Entity):
       0, max_init_level + 1, (num_envs,), device=self._device
     )
 
-    # Distribute robots across columns by proportion.
-    if (
-      terrain_generator_cfg is not None
-      and len(terrain_generator_cfg.sub_terrains) == num_cols
-    ):
-      proportions = np.array(
-        [cfg.proportion for cfg in terrain_generator_cfg.sub_terrains.values()]
-      )
-      proportions = proportions / proportions.sum()
-
-      # Base allocation using floor to ensure we never exceed num_envs
-      counts = np.floor(proportions * num_envs).astype(int)
-
-      # Distribute remainder to columns with largest fractional parts
-      remainder = num_envs - counts.sum()
-      if remainder > 0:
-        fractional_part = (proportions * num_envs) - counts
-        order = np.argsort(-fractional_part)
-        for i in range(remainder):
-          counts[order[i % num_cols]] += 1
-
-      self.terrain_types = torch.cat(
-        [
-          torch.full((c,), col, device=self._device, dtype=torch.long)
-          for col, c in enumerate(counts)
-        ]
+    if proportions is not None and len(proportions) == num_cols:
+      counts = _proportional_counts(num_envs, proportions)
+      self.terrain_types = torch.repeat_interleave(
+        torch.arange(num_cols, device=self._device),
+        torch.from_numpy(counts).to(self._device),
       )
     else:
-      # Fallback: even distribution.
       self.terrain_types = torch.div(
         torch.arange(num_envs, device=self._device),
         (num_envs / num_cols),

--- a/src/mjlab/terrains/terrain_generator.py
+++ b/src/mjlab/terrains/terrain_generator.py
@@ -92,10 +92,10 @@ class TerrainGeneratorCfg:
   curriculum: bool = False
   """Controls terrain allocation mode:
 
-  - curriculum=True: Each terrain type gets exactly ONE column.
-    ``num_cols`` is automatically set to ``len(sub_terrains)``.
-    Difficulty increases along rows. The ``proportion`` field controls
-    how many robots are spawned per column, not column count.
+  - curriculum=True: Each terrain type gets exactly ONE column. The generator uses
+    ``len(sub_terrains)`` columns regardless of ``num_cols``. Difficulty increases
+    along rows. The ``proportion`` field controls how many robots are spawned per
+    column, not column count.
 
   - curriculum=False: Every patch is randomly sampled from all terrain types.
     Proportions control sampling probability. Use this for random variety.
@@ -113,9 +113,8 @@ class TerrainGeneratorCfg:
   num_cols: int = 1
   """Number of sub-terrain columns in the grid.
 
-  In curriculum mode this is automatically overridden to
-  ``len(sub_terrains)`` (one column per terrain type).
-  In random mode it is used as-is."""
+  In curriculum mode the generator ignores this value and uses one column per terrain
+  type (``len(sub_terrains)``). In random mode it is used as-is."""
   color_scheme: Literal["height", "random", "none"] = "height"
   """Coloring strategy for terrain geometry. "height" colors by elevation,
   "random" assigns random colors, "none" uses uniform gray."""
@@ -137,9 +136,9 @@ class TerrainGenerator:
     terrain type weighted by proportions. Results in random variety across
     all patches.
 
-  - **Curriculum mode** (curriculum=True): Each terrain type gets exactly one
-    column (``num_cols`` is overridden to ``len(sub_terrains)``). Difficulty
-    increases along rows. The ``proportion`` field controls robot spawning
+  - **Curriculum mode** (curriculum=True): Each terrain type gets exactly one column
+    (the generator uses ``len(sub_terrains)`` columns regardless of ``num_cols``).
+    Difficulty increases along rows. The ``proportion`` field controls robot spawning
     distribution, not column count.
 
   Terrain types are weighted by proportion and their geometry is generated
@@ -157,7 +156,9 @@ class TerrainGenerator:
 
     # In curriculum mode, one column per terrain type.
     if self.cfg.curriculum:
-      self.cfg.num_cols = len(self.cfg.sub_terrains)
+      self._num_cols = len(self.cfg.sub_terrains)
+    else:
+      self._num_cols = self.cfg.num_cols
 
     for sub_cfg in self.cfg.sub_terrains.values():
       sub_cfg.size = self.cfg.size
@@ -168,7 +169,7 @@ class TerrainGenerator:
       seed = np.random.randint(0, 10000)
     self.np_rng = np.random.default_rng(seed)
 
-    self.terrain_origins = np.zeros((self.cfg.num_rows, self.cfg.num_cols, 3))
+    self.terrain_origins = np.zeros((self.cfg.num_rows, self._num_cols, 3))
 
     # Pre-allocate flat patch storage by scanning all sub-terrain configs.
     self.flat_patches: dict[str, np.ndarray] = {}
@@ -186,7 +187,7 @@ class TerrainGenerator:
           )
     for name, max_num_patches in patch_names.items():
       self.flat_patches[name] = np.zeros(
-        (self.cfg.num_rows, self.cfg.num_cols, max_num_patches, 3)
+        (self.cfg.num_rows, self._num_cols, max_num_patches, 3)
       )
 
   def compile(self, spec: mujoco.MjSpec) -> None:
@@ -227,8 +228,8 @@ class TerrainGenerator:
     sub_terrains_cfgs = list(self.cfg.sub_terrains.values())
 
     # Randomly sample and place sub-terrains in the grid.
-    for index in range(self.cfg.num_rows * self.cfg.num_cols):
-      sub_row, sub_col = np.unravel_index(index, (self.cfg.num_rows, self.cfg.num_cols))
+    for index in range(self.cfg.num_rows * self._num_cols):
+      sub_row, sub_col = np.unravel_index(index, (self.cfg.num_rows, self._num_cols))
       sub_row = int(sub_row)
       sub_col = int(sub_col)
 
@@ -255,9 +256,8 @@ class TerrainGenerator:
   def _generate_curriculum_terrains(self, spec: mujoco.MjSpec) -> None:
     # One column per terrain type — proportion is only for spawning.
     sub_terrains_cfgs = list(self.cfg.sub_terrains.values())
-    sub_indices = np.arange(len(sub_terrains_cfgs), dtype=np.int32)
 
-    for sub_col in range(self.cfg.num_cols):
+    for sub_col in range(self._num_cols):
       for sub_row in range(self.cfg.num_rows):
         lower, upper = self.cfg.difficulty_range
         difficulty = (sub_row + self.np_rng.uniform()) / self.cfg.num_rows
@@ -267,7 +267,7 @@ class TerrainGenerator:
           spec,
           world_position,
           difficulty,
-          sub_terrains_cfgs[sub_indices[sub_col]],
+          sub_terrains_cfgs[sub_col],
           sub_row,
           sub_col,
         )
@@ -285,7 +285,7 @@ class TerrainGenerator:
 
     # Offset to center the entire grid at world origin.
     grid_offset_x = -self.cfg.num_rows * self.cfg.size[0] * 0.5
-    grid_offset_y = -self.cfg.num_cols * self.cfg.size[1] * 0.5
+    grid_offset_y = -self._num_cols * self.cfg.size[1] * 0.5
 
     return np.array([grid_offset_x + rel_x, grid_offset_y + rel_y, 0.0])
 
@@ -344,11 +344,11 @@ class TerrainGenerator:
     body = spec.body("terrain")
     border_size = (
       self.cfg.num_rows * self.cfg.size[0] + 2 * self.cfg.border_width,
-      self.cfg.num_cols * self.cfg.size[1] + 2 * self.cfg.border_width,
+      self._num_cols * self.cfg.size[1] + 2 * self.cfg.border_width,
     )
     inner_size = (
       self.cfg.num_rows * self.cfg.size[0],
-      self.cfg.num_cols * self.cfg.size[1],
+      self._num_cols * self.cfg.size[1],
     )
     # Border should be centered at origin since the terrain grid is centered.
     border_center = (0, 0, -self.cfg.border_height / 2)
@@ -370,7 +370,7 @@ class TerrainGenerator:
       return
 
     total_width = self.cfg.size[0] * self.cfg.num_rows
-    total_height = self.cfg.size[1] * self.cfg.num_cols
+    total_height = self.cfg.size[1] * self._num_cols
     light_height = max(total_width, total_height) * 0.6
 
     spec.body("terrain").add_light(

--- a/tests/test_terrain_proportion_spawning.py
+++ b/tests/test_terrain_proportion_spawning.py
@@ -1,20 +1,22 @@
 """Tests for proportion-based robot spawning on terrain columns."""
 
+from __future__ import annotations
+
+import numpy as np
+import pytest
 import torch
 
 from mjlab.terrains.primitive_terrains import BoxFlatTerrainCfg
 from mjlab.terrains.terrain_entity import TerrainEntity, TerrainEntityCfg
-from mjlab.terrains.terrain_generator import TerrainGeneratorCfg
+from mjlab.terrains.terrain_generator import TerrainGenerator, TerrainGeneratorCfg
 
 
 def _make_terrain_entity(num_envs: int) -> TerrainEntity:
-  """Create a TerrainEntity with plane terrain for testing."""
   cfg = TerrainEntityCfg(terrain_type="plane", num_envs=num_envs, env_spacing=2.0)
   return TerrainEntity(cfg, device="cpu")
 
 
 def _make_origins(num_rows: int, num_cols: int) -> torch.Tensor:
-  """Create mock terrain origins tensor [num_rows, num_cols, 3]."""
   origins = torch.zeros(num_rows, num_cols, 3)
   for r in range(num_rows):
     for c in range(num_cols):
@@ -23,125 +25,178 @@ def _make_origins(num_rows: int, num_cols: int) -> torch.Tensor:
   return origins
 
 
-def _make_generator_cfg(proportions: list[float]) -> TerrainGeneratorCfg:
-  """Create a TerrainGeneratorCfg with given proportions."""
-  sub_terrains = {}
-  for i, p in enumerate(proportions):
-    sub_terrains[f"terrain_{i}"] = BoxFlatTerrainCfg(
-      proportion=p,
-      size=(4.0, 4.0),
+def _normalized(proportions: list[float]) -> np.ndarray:
+  p = np.array(proportions)
+  return p / p.sum()
+
+
+def _get_counts(entity: TerrainEntity, num_cols: int) -> list[int]:
+  return [int((entity.terrain_types == col).sum().item()) for col in range(num_cols)]
+
+
+# Fallback (no proportions).
+
+
+def test_even_distribution_without_proportions() -> None:
+  num_envs = 30
+  num_cols = 3
+  entity = _make_terrain_entity(num_envs)
+  origins = _make_origins(5, num_cols)
+
+  entity._compute_env_origins_curriculum(num_envs, origins, None)
+
+  assert _get_counts(entity, num_cols) == [10, 10, 10]
+
+
+# Proportional distribution.
+
+
+def test_basic_proportions() -> None:
+  num_envs = 100
+  proportions = _normalized([0.5, 0.3, 0.2])
+  entity = _make_terrain_entity(num_envs)
+  origins = _make_origins(5, len(proportions))
+
+  entity._compute_env_origins_curriculum(num_envs, origins, proportions)
+
+  assert _get_counts(entity, len(proportions)) == [50, 30, 20]
+
+
+@pytest.mark.parametrize("num_envs", [3, 7, 32, 64, 100, 512, 1024, 4096])
+def test_counts_sum_to_num_envs(num_envs: int) -> None:
+  """Total terrain_types length must always equal num_envs."""
+  proportions = _normalized([0.6, 0.25, 0.1, 0.05])
+  entity = _make_terrain_entity(num_envs)
+  origins = _make_origins(5, len(proportions))
+
+  entity._compute_env_origins_curriculum(num_envs, origins, proportions)
+
+  assert len(entity.terrain_types) == num_envs
+
+
+@pytest.mark.parametrize(
+  "num_envs, proportions",
+  [
+    (3, [0.98, 0.01, 0.01]),
+    (5, [0.9, 0.05, 0.03, 0.01, 0.01]),
+    (100, [0.9, 0.05, 0.05]),
+    (10, [0.97, 0.01, 0.01, 0.01]),
+  ],
+)
+def test_every_column_gets_at_least_one(
+  num_envs: int, proportions: list[float]
+) -> None:
+  """When num_envs >= num_cols, every column gets at least 1 robot."""
+  p = _normalized(proportions)
+  entity = _make_terrain_entity(num_envs)
+  origins = _make_origins(5, len(p))
+
+  entity._compute_env_origins_curriculum(num_envs, origins, p)
+
+  counts = _get_counts(entity, len(p))
+  for col, count in enumerate(counts):
+    assert count >= 1, f"Column {col} got 0 envs (counts={counts})"
+
+
+def test_fewer_envs_than_cols() -> None:
+  """When num_envs < num_cols, should still work without errors."""
+  num_envs = 2
+  proportions = _normalized([0.5, 0.3, 0.1, 0.1])
+  entity = _make_terrain_entity(num_envs)
+  origins = _make_origins(5, len(proportions))
+
+  result = entity._compute_env_origins_curriculum(num_envs, origins, proportions)
+
+  assert len(entity.terrain_types) == num_envs
+  assert result.shape == (num_envs, 3)
+
+
+def test_equal_proportions_gives_equal_counts() -> None:
+  num_envs = 30
+  proportions = _normalized([1.0, 1.0, 1.0, 1.0])
+  entity = _make_terrain_entity(num_envs)
+  origins = _make_origins(5, len(proportions))
+
+  entity._compute_env_origins_curriculum(num_envs, origins, proportions)
+
+  counts = _get_counts(entity, len(proportions))
+  for c in counts:
+    assert 7 <= c <= 8, f"Expected 7 or 8 envs per column, got {c}"
+
+
+def test_env_origins_shape() -> None:
+  num_envs = 20
+  proportions = _normalized([0.5, 0.3, 0.2])
+  entity = _make_terrain_entity(num_envs)
+  origins = _make_origins(5, len(proportions))
+
+  result = entity._compute_env_origins_curriculum(num_envs, origins, proportions)
+
+  assert result.shape == (num_envs, 3)
+
+
+def test_env_origins_match_terrain_origins() -> None:
+  """Each env_origin must correspond to a valid (level, type) in origins."""
+  num_envs = 50
+  proportions = _normalized([0.6, 0.3, 0.1])
+  entity = _make_terrain_entity(num_envs)
+  origins = _make_origins(5, len(proportions))
+
+  result = entity._compute_env_origins_curriculum(num_envs, origins, proportions)
+
+  for i in range(num_envs):
+    level = int(entity.terrain_levels[i].item())
+    ttype = int(entity.terrain_types[i].item())
+    expected = origins[level, ttype]
+    assert torch.allclose(result[i], expected), (
+      f"env {i}: origin {result[i].tolist()} != "
+      f"origins[{level},{ttype}]={expected.tolist()}"
     )
-  return TerrainGeneratorCfg(
+
+
+def test_mismatched_cols_falls_back_to_even() -> None:
+  """When proportions length != num_cols, should fall back to even."""
+  num_envs = 30
+  num_cols = 3
+  # 4 proportions but only 3 columns in origins.
+  proportions = _normalized([0.4, 0.3, 0.2, 0.1])
+  entity = _make_terrain_entity(num_envs)
+  origins = _make_origins(5, num_cols)
+
+  entity._compute_env_origins_curriculum(num_envs, origins, proportions)
+
+  assert _get_counts(entity, num_cols) == [10, 10, 10]
+
+
+def test_proportions_are_respected_approximately() -> None:
+  """With large num_envs, actual distribution should track proportions."""
+  num_envs = 10000
+  raw = [0.5, 0.3, 0.15, 0.05]
+  proportions = _normalized(raw)
+  entity = _make_terrain_entity(num_envs)
+  origins = _make_origins(5, len(proportions))
+
+  entity._compute_env_origins_curriculum(num_envs, origins, proportions)
+
+  counts = _get_counts(entity, len(proportions))
+  for col, (count, prop) in enumerate(zip(counts, proportions, strict=True)):
+    expected = prop * num_envs
+    assert abs(count - expected) < 10, (
+      f"Column {col}: got {count}, expected ~{expected:.0f}"
+    )
+
+
+def test_generator_does_not_mutate_cfg_num_cols() -> None:
+  """TerrainGenerator must not mutate the caller's cfg.num_cols."""
+  cfg = TerrainGeneratorCfg(
     size=(4.0, 4.0),
-    sub_terrains=sub_terrains,
+    curriculum=True,
+    num_cols=1,
+    sub_terrains={
+      "a": BoxFlatTerrainCfg(proportion=0.5, size=(4.0, 4.0)),
+      "b": BoxFlatTerrainCfg(proportion=0.3, size=(4.0, 4.0)),
+      "c": BoxFlatTerrainCfg(proportion=0.2, size=(4.0, 4.0)),
+    },
   )
-
-
-class TestEvenDistributionFallback:
-  """Without terrain_generator_cfg, robots should be distributed evenly."""
-
-  def test_even_distribution_without_generator_cfg(self) -> None:
-    num_envs = 30
-    num_cols = 3
-    entity = _make_terrain_entity(num_envs)
-    origins = _make_origins(5, num_cols)
-
-    entity._compute_env_origins_curriculum(num_envs, origins, None)
-
-    # Each column should get num_envs / num_cols = 10 robots.
-    for col in range(num_cols):
-      count = (entity.terrain_types == col).sum().item()
-      assert count == 10, f"Column {col} got {count} envs, expected 10"
-
-
-class TestProportionDistribution:
-  """With terrain_generator_cfg, robots should be distributed by proportion."""
-
-  def test_basic_proportions(self) -> None:
-    num_envs = 100
-    proportions = [0.5, 0.3, 0.2]
-    gen_cfg = _make_generator_cfg(proportions)
-    entity = _make_terrain_entity(num_envs)
-    origins = _make_origins(5, len(proportions))
-
-    entity._compute_env_origins_curriculum(num_envs, origins, gen_cfg)
-
-    counts = [
-      (entity.terrain_types == col).sum().item() for col in range(len(proportions))
-    ]
-    assert counts[0] == 50
-    assert counts[1] == 30
-    assert counts[2] == 20
-
-  def test_counts_sum_to_num_envs(self) -> None:
-    """Total terrain_types length must always equal num_envs."""
-    for num_envs in [32, 64, 100, 512, 1024, 4096]:
-      proportions = [0.6, 0.25, 0.1, 0.05]
-      gen_cfg = _make_generator_cfg(proportions)
-      entity = _make_terrain_entity(num_envs)
-      origins = _make_origins(5, len(proportions))
-
-      entity._compute_env_origins_curriculum(num_envs, origins, gen_cfg)
-
-      assert len(entity.terrain_types) == num_envs, (
-        f"num_envs={num_envs}: terrain_types has {len(entity.terrain_types)} elements"
-      )
-
-  def test_minimum_one_per_column(self) -> None:
-    """Every column should get at least 1 robot, even with tiny proportions."""
-    num_envs = 100
-    proportions = [0.9, 0.05, 0.05]
-    gen_cfg = _make_generator_cfg(proportions)
-    entity = _make_terrain_entity(num_envs)
-    origins = _make_origins(5, len(proportions))
-
-    entity._compute_env_origins_curriculum(num_envs, origins, gen_cfg)
-
-    for col in range(len(proportions)):
-      count = (entity.terrain_types == col).sum().item()
-      assert count >= 1, f"Column {col} got 0 envs despite minimum-1 guarantee"
-
-  def test_equal_proportions_gives_equal_counts(self) -> None:
-    """Equal proportions should give (approximately) equal counts."""
-    num_envs = 30
-    proportions = [0.25, 0.25, 0.25, 0.25]
-    gen_cfg = _make_generator_cfg(proportions)
-    entity = _make_terrain_entity(num_envs)
-    origins = _make_origins(5, len(proportions))
-
-    entity._compute_env_origins_curriculum(num_envs, origins, gen_cfg)
-
-    counts = [
-      (entity.terrain_types == col).sum().item() for col in range(len(proportions))
-    ]
-    # 30 / 4 = 7.5 → expects 8, 8, 7, 7 (or similar rounding).
-    for c in counts:
-      assert 7 <= c <= 8, f"Expected 7 or 8 envs per column, got {c}"
-
-  def test_env_origins_shape(self) -> None:
-    """env_origins must be [num_envs, 3]."""
-    num_envs = 20
-    proportions = [0.5, 0.3, 0.2]
-    gen_cfg = _make_generator_cfg(proportions)
-    entity = _make_terrain_entity(num_envs)
-    origins = _make_origins(5, len(proportions))
-
-    result = entity._compute_env_origins_curriculum(num_envs, origins, gen_cfg)
-
-    assert result.shape == (num_envs, 3)
-
-  def test_mismatched_cols_falls_back_to_even(self) -> None:
-    """When sub_terrains count != num_cols, should fall back to even."""
-    num_envs = 30
-    num_cols = 3
-    # Generator config has 4 sub-terrains but origins only have 3 columns.
-    gen_cfg = _make_generator_cfg([0.4, 0.3, 0.2, 0.1])
-    entity = _make_terrain_entity(num_envs)
-    origins = _make_origins(5, num_cols)
-
-    entity._compute_env_origins_curriculum(num_envs, origins, gen_cfg)
-
-    # Should fall back to even distribution: 10 per column.
-    for col in range(num_cols):
-      count = (entity.terrain_types == col).sum().item()
-      assert count == 10, f"Column {col} got {count} envs, expected 10 (fallback)"
+  TerrainGenerator(cfg)
+  assert cfg.num_cols == 1, f"cfg.num_cols was mutated to {cfg.num_cols}"


### PR DESCRIPTION
## Description
Changes how proportional terrain generation works in curriculum mode so that robots are distributed across terrains based on their proportions, rather than expanding the terrain grid itself. This allows more accurate proportion control compared to making terrains itself. Also when there are more terrain types, the previous implementation was skipping some terrain types since the proportion was too small. This prevents making too many terrains, or skipping some terrain types.
**Key changes:**
- **1:1 Terrain-to-Column Mapping:** In curriculum mode, `num_cols` is automatically overridden so each terrain type gets exactly one unique column.
- **Proportional Spawning:** Robots (`num_envs`) are now distributed across the columns based exactly on the config's `proportion` values using the Largest Remainder Method to ensure they add up cleanly. 
- Included 7 new unit tests in `test_terrain_proportion_spawning.py`.
*(Note: Random terrain generation mode remains completely unchanged - proportions still control per-patch sampling probability).*

<img width="1643" height="847" alt="Screenshot 2026-03-16 at 6 26 26 PM" src="https://github.com/user-attachments/assets/50a8752d-c839-4502-ba3f-6be870d24c61" />
