### PR TITLE
Generalize RayCastSensor for multi-frame sensing and ring patterns

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -122,6 +122,12 @@ Added
   to bodies with configurable duration and optional application point offset.
 - ONNX auto-export and metadata attachment for manipulation tasks (lift cube)
   on every checkpoint save, matching the velocity and tracking task behavior.
+- Multi-frame ``RayCastSensor``: pass a tuple of ``ObjRef`` to ``frame`` for
+  per-site raycasting with independent body exclusion. New properties:
+  ``num_frames``, ``num_rays_per_frame``. New ``RayCastData`` fields:
+  ``frame_pos_w`` and ``frame_quat_w``.
+- ``RingPatternCfg`` ray pattern for concentric ring sampling around each
+  frame.
 - Cloud training support via `SkyPilot <https://skypilot.readthedocs.io/>`_
   and Lambda Cloud, with documentation covering setup, monitoring, and
   cost management.

--- a/src/mjlab/envs/mdp/observations.py
+++ b/src/mjlab/envs/mdp/observations.py
@@ -115,6 +115,7 @@ def height_scan(
   """Height scan from a raycast sensor.
 
   Returns the height of the sensor frame above each hit point.
+  Supports multi-frame sensors: each ray uses its own frame's Z.
 
   Args:
     env: The environment.
@@ -124,13 +125,22 @@ def height_scan(
       Defaults to the sensor's ``max_distance``.
 
   Returns:
-    Tensor of shape [B, N] where B is num_envs and N is num_rays.
+    Tensor of shape [B, N] where N = num_frames * num_rays_per_frame.
+    Rays are ordered frame-major (all rays for frame 0, then frame 1, etc.).
   """
   sensor: RayCastSensor = env.scene[sensor_name]
   if miss_value is None:
     miss_value = sensor.cfg.max_distance
-  heights = (
-    sensor.data.pos_w[:, 2].unsqueeze(1) - sensor.data.hit_pos_w[..., 2] - offset
-  )
-  miss_mask = sensor.data.distances < 0
+
+  data = sensor.data
+  F, N = sensor.num_frames, sensor.num_rays_per_frame
+  B = data.distances.shape[0]
+
+  # Each ray's height = its frame's Z - hit Z. For single-frame sensors (F=1) this
+  # reduces to the original pos_w[:, 2] - hit_z broadcast.
+  frame_z = data.frame_pos_w[:, :, 2:3]  # [B, F, 1]
+  hit_z = data.hit_pos_w[..., 2].view(B, F, N)  # [B, F, N]
+  heights = (frame_z - hit_z - offset).view(B, F * N)
+
+  miss_mask = data.distances < 0
   return torch.where(miss_mask, torch.full_like(heights, miss_value), heights)

--- a/src/mjlab/scene/scene.py
+++ b/src/mjlab/scene/scene.py
@@ -13,9 +13,8 @@ import numpy as np
 import torch
 
 from mjlab.entity import Entity, EntityCfg
-from mjlab.sensor import BuiltinSensor, Sensor, SensorCfg
+from mjlab.sensor import BuiltinSensor, RayCastSensor, Sensor, SensorCfg
 from mjlab.sensor.camera_sensor import CameraSensor
-from mjlab.sensor.raycast_sensor import RayCastSensor
 from mjlab.sensor.sensor_context import SensorContext
 from mjlab.terrains.terrain_entity import TerrainEntity, TerrainEntityCfg
 from mjlab.utils.xml import fix_spec_xml, strip_buffer_textures

--- a/src/mjlab/sensor/__init__.py
+++ b/src/mjlab/sensor/__init__.py
@@ -15,6 +15,7 @@ from mjlab.sensor.raycast_sensor import (
 from mjlab.sensor.raycast_sensor import RayCastData as RayCastData
 from mjlab.sensor.raycast_sensor import RayCastSensor as RayCastSensor
 from mjlab.sensor.raycast_sensor import RayCastSensorCfg as RayCastSensorCfg
+from mjlab.sensor.raycast_sensor import RingPatternCfg as RingPatternCfg
 from mjlab.sensor.sensor import Sensor as Sensor
 from mjlab.sensor.sensor import SensorCfg as SensorCfg
 from mjlab.sensor.sensor_context import SensorContext as SensorContext

--- a/src/mjlab/sensor/raycast_sensor.py
+++ b/src/mjlab/sensor/raycast_sensor.py
@@ -3,7 +3,7 @@
 Ray Patterns
 ------------
 
-This module provides two ray pattern types for different use cases:
+This module provides three ray pattern types for different use cases:
 
 **Grid Pattern** - Parallel rays in a 2D grid::
 
@@ -35,16 +35,29 @@ This module provides two ray pattern types for different use cases:
 - Lower altitude → tighter ground coverage, denser hits
 - Good for: simulating depth cameras, LiDAR with angular resolution
 
+**Ring Pattern** - Rays in concentric rings around the origin::
+
+    Ring (8 samples):
+         ●   ●
+       ●       ●     ← evenly spaced on circle
+       ●       ●
+         ●   ●
+           ●         ← center (optional)
+
+- Rays cast from offsets arranged in rings around the attachment frame
+- Supports multiple concentric rings at different radii
+- Good for: per-site height sensing, foot clearance, terrain sampling
+
 **Pattern Comparison**:
 
-============== ==================== ==========================
-Aspect         Grid                 Pinhole
-============== ==================== ==========================
-Ray direction  All parallel         Diverge from origin
-Spacing        Meters               Degrees (FOV)
-Height affect  No                   Yes
-Real-world     Orthographic proj.   Perspective camera / LiDAR
-============== ==================== ==========================
+============== ==================== ========================== =================
+Aspect         Grid                 Pinhole                    Ring
+============== ==================== ========================== =================
+Ray direction  All parallel         Diverge from origin        All parallel
+Spacing        Meters               Degrees (FOV)              Radius + count
+Height affect  No                   Yes                        No
+Real-world     Orthographic proj.   Perspective camera / LiDAR Terrain probe
+============== ==================== ========================== =================
 
 The pinhole behavior matches real depth sensors (RealSense, LiDAR) - when
 you're farther from an object, each pixel covers more area.
@@ -53,13 +66,14 @@ you're farther from an object, each pixel covers more area.
 Frame Attachment
 ----------------
 
-Rays are attached to a frame in the scene via ``ObjRef``. Supported frame types:
+Rays are attached to one or more frames in the scene via ``ObjRef``. Supported
+frame types:
 
 - **body**: Attach to a body's origin. Rays follow body position and orientation.
 - **site**: Attach to a site. Useful for precise placement or offset from body.
 - **geom**: Attach to a geometry. Useful for sensors mounted on specific parts.
 
-Example::
+Single frame::
 
     from mjlab.sensor import ObjRef, RayCastSensorCfg, GridPatternCfg
 
@@ -68,6 +82,21 @@ Example::
         frame=ObjRef(type="body", name="base", entity="robot"),
         pattern=GridPatternCfg(size=(1.0, 1.0), resolution=0.1),
     )
+
+Multiple frames (e.g. per-foot height sensing)::
+
+    cfg = RayCastSensorCfg(
+        name="foot_heights",
+        frame=(
+            ObjRef(type="site", name="left_foot", entity="robot"),
+            ObjRef(type="site", name="right_foot", entity="robot"),
+        ),
+        pattern=RingPatternCfg.single_ring(radius=0.05, num_samples=8),
+    )
+
+With multiple frames, the output ``distances`` has shape ``[B, F*N]`` where
+F is the number of frames and N is rays per frame. Each frame's parent body
+is excluded independently when ``exclude_parent_body`` is True.
 
 The ``exclude_parent_body`` option (default: True) prevents rays from hitting
 the body they're attached to.
@@ -150,10 +179,12 @@ Access sensor data via the ``data`` property, which returns ``RayCastData``:
 - ``distances``: [B, N] Distance to hit, or -1 if no hit / beyond max_distance
 - ``hit_pos_w``: [B, N, 3] World-space hit positions
 - ``normals_w``: [B, N, 3] Surface normals at hit points (world frame)
-- ``pos_w``: [B, 3] Sensor frame position
-- ``quat_w``: [B, 4] Sensor frame orientation (w, x, y, z)
+- ``pos_w``: [B, 3] First frame position (backward compat)
+- ``quat_w``: [B, 4] First frame orientation (backward compat)
+- ``frame_pos_w``: [B, F, 3] All frame positions
+- ``frame_quat_w``: [B, F, 4] All frame orientations
 
-Where B = number of environments, N = number of rays.
+Where B = environments, F = frames, N = F * num_rays_per_frame (total rays).
 """
 
 from __future__ import annotations
@@ -177,12 +208,25 @@ if TYPE_CHECKING:
   from mjlab.sensor.sensor_context import SensorContext
   from mjlab.viewer.debug_visualizer import DebugVisualizer
 
-
-# NOTE: Need to define this here because it's not publicly exposed by mujoco_warp.
-vec6 = wp.types.vector(length=6, dtype=float)
-
-# Type aliases for configuration choices.
 RayAlignment = Literal["base", "yaw", "world"]
+
+# NOTE: Not publicly exposed by mujoco_warp.
+_vec6 = wp.types.vector(length=6, dtype=float)
+_ALL_GROUPS = _vec6(-1, -1, -1, -1, -1, -1)
+
+
+def _geom_groups_to_vec6(groups: tuple[int, ...] | None):  # -> _vec6
+  """Convert geom group tuple to mujoco_warp vec6 format.
+
+  In the vec6 format, -1 means include and 0 means exclude.
+  """
+  if groups is None:
+    return _ALL_GROUPS
+  out = [0, 0, 0, 0, 0, 0]
+  for g in groups:
+    if 0 <= g <= 5:
+      out[g] = -1
+  return _vec6(*out)
 
 
 @dataclass
@@ -349,7 +393,102 @@ class PinholeCameraPatternCfg:
     return local_offsets, local_directions
 
 
-PatternCfg = GridPatternCfg | PinholeCameraPatternCfg
+@dataclass
+class RingPatternCfg:
+  """Ring pattern - rays in concentric rings around the origin.
+
+  Useful for per-site height sensing where you want to sample the
+  terrain around each attachment frame.
+  """
+
+  @dataclass
+  class Ring:
+    """A single ring in the pattern."""
+
+    radius: float
+    """Radius of this ring in meters."""
+
+    num_samples: int
+    """Number of evenly spaced sample points on this ring."""
+
+  rings: tuple[Ring, ...]
+  """Ring definitions. Multiple rings create a concentric pattern."""
+
+  include_center: bool = True
+  """Whether to include a ray at the center (zero offset)."""
+
+  direction: tuple[float, float, float] = (0.0, 0.0, -1.0)
+  """Ray direction in frame-local coordinates."""
+
+  @classmethod
+  def single_ring(
+    cls,
+    radius: float = 0.1,
+    num_samples: int = 8,
+    include_center: bool = True,
+    direction: tuple[float, float, float] = (0.0, 0.0, -1.0),
+  ) -> RingPatternCfg:
+    """Create a single-ring pattern.
+
+    Args:
+      radius: Ring radius in meters.
+      num_samples: Number of evenly spaced points on the ring.
+      include_center: Whether to include a center ray.
+      direction: Ray direction in frame-local coordinates.
+
+    Returns:
+      RingPatternCfg with one ring.
+    """
+    return cls(
+      rings=(cls.Ring(radius, num_samples),),
+      include_center=include_center,
+      direction=direction,
+    )
+
+  def generate_rays(
+    self, mj_model: mujoco.MjModel | None, device: str
+  ) -> tuple[torch.Tensor, torch.Tensor]:
+    """Generate ray pattern.
+
+    Args:
+      mj_model: MuJoCo model (unused for ring pattern).
+      device: Device for tensor operations.
+
+    Returns:
+      Tuple of (local_offsets [N, 3], local_directions [N, 3]).
+    """
+    del mj_model
+    offsets: list[torch.Tensor] = []
+
+    if self.include_center:
+      offsets.append(torch.zeros(3, device=device, dtype=torch.float32))
+
+    for ring in self.rings:
+      for i in range(ring.num_samples):
+        angle = 2.0 * math.pi * i / ring.num_samples
+        offsets.append(
+          torch.tensor(
+            [
+              ring.radius * math.cos(angle),
+              ring.radius * math.sin(angle),
+              0.0,
+            ],
+            device=device,
+            dtype=torch.float32,
+          )
+        )
+
+    local_offsets = torch.stack(offsets)  # [N, 3]
+    num_rays = local_offsets.shape[0]
+
+    direction = torch.tensor(self.direction, device=device, dtype=torch.float32)
+    direction = direction / direction.norm()
+    local_directions = direction.unsqueeze(0).expand(num_rays, 3).clone()
+
+    return local_offsets, local_directions
+
+
+PatternCfg = GridPatternCfg | PinholeCameraPatternCfg | RingPatternCfg
 
 
 @dataclass
@@ -362,7 +501,10 @@ class RayCastData:
   """
 
   distances: torch.Tensor
-  """[B, N] Distance to hit point. -1 if no hit."""
+  """[B, N] Distance to hit point. -1 if no hit.
+
+  N = num_frames * num_rays_per_frame.
+  """
 
   normals_w: torch.Tensor
   """[B, N, 3] Surface normal at hit point (world frame). Zero if no hit."""
@@ -371,17 +513,23 @@ class RayCastData:
   """[B, N, 3] Hit position in world frame. Ray origin if no hit."""
 
   pos_w: torch.Tensor
-  """[B, 3] Frame position in world coordinates."""
+  """[B, 3] First frame position in world coordinates."""
 
   quat_w: torch.Tensor
-  """[B, 4] Frame orientation quaternion (w, x, y, z) in world coordinates."""
+  """[B, 4] First frame orientation quaternion (w, x, y, z)."""
+
+  frame_pos_w: torch.Tensor
+  """[B, F, 3] All frame positions in world coordinates."""
+
+  frame_quat_w: torch.Tensor
+  """[B, F, 4] All frame orientations (w, x, y, z)."""
 
 
 @dataclass
 class RayCastSensorCfg(SensorCfg):
   """Raycast sensor configuration.
 
-  Supports multiple ray patterns (grid, pinhole camera) and alignment modes.
+  Supports multiple ray patterns (grid, pinhole camera, ring) and alignment modes.
   """
 
   @dataclass
@@ -412,18 +560,25 @@ class RayCastSensorCfg(SensorCfg):
     normal_length: float = 5.0
     """Length of surface normal arrows (multiplier of meansize)."""
 
-  frame: ObjRef
-  """Body or site to attach rays to."""
+  frame: ObjRef | tuple[ObjRef, ...]
+  """Body, site, or geom to attach rays to.
+
+  Pass a single ``ObjRef`` for one frame, or a tuple for multi-frame
+  sensing (e.g. per-foot height sensors). Each frame's parent body is
+  excluded independently when ``exclude_parent_body`` is True.
+  """
 
   pattern: PatternCfg = field(default_factory=GridPatternCfg)
   """Ray pattern configuration. Defaults to GridPatternCfg."""
 
   ray_alignment: RayAlignment = "base"
-  """How rays align with the frame.
+  """How rays are oriented relative to the frame. Controls direction only;
+  the ray origin is always the physical frame position (``site_xpos`` /
+  ``geom_xpos`` / ``body_xpos``).
 
-  - "base": Full position + rotation (default).
-  - "yaw": Position + yaw only, ignores pitch/roll (good for height maps).
-  - "world": Fixed in world frame, position only follows body.
+  - "base": Full rotation (default). Rays rotate with the body.
+  - "yaw": Yaw only, ignores pitch/roll (good for height maps).
+  - "world": Fixed in world frame, rays always point the same direction.
   """
 
   max_distance: float = 10.0
@@ -462,13 +617,13 @@ class RayCastSensor(Sensor[RayCastData]):
     self._device: str | None = None
     self._wp_device: wp.context.Device | None = None
 
-    self._frame_body_id: int | None = None
-    self._frame_site_id: int | None = None
-    self._frame_geom_id: int | None = None
-    self._frame_type: Literal["body", "site", "geom"] = "body"
+    # Per-frame info: list of (frame_type, obj_id, body_id).
+    self._frame_infos: list[tuple[Literal["body", "site", "geom"], int, int]] = []
+    self._num_frames: int = 0
+    self._num_rays_per_frame: int = 0
 
     self._local_offsets: torch.Tensor | None = None
-    self._local_directions: torch.Tensor | None = None  # [N, 3] per-ray directions
+    self._local_directions: torch.Tensor | None = None  # [rays_per_frame, 3]
     self._num_rays: int = 0
 
     self._ray_pnt: wp.array | None = None
@@ -477,21 +632,22 @@ class RayCastSensor(Sensor[RayCastData]):
     self._ray_geomid: wp.array | None = None
     self._ray_normal: wp.array | None = None
     self._ray_bodyexclude: wp.array | None = None
-    self._geomgroup = vec6(-1, -1, -1, -1, -1, -1)
+    self._geomgroup = _vec6(-1, -1, -1, -1, -1, -1)
 
     self._distances: torch.Tensor | None = None
     self._normals_w: torch.Tensor | None = None
     self._hit_pos_w: torch.Tensor | None = None
     self._pos_w: torch.Tensor | None = None
     self._quat_w: torch.Tensor | None = None
+    self._frame_pos_w: torch.Tensor | None = None
+    self._frame_quat_w: torch.Tensor | None = None
 
     self._cached_world_origins: torch.Tensor | None = None
     self._cached_world_rays: torch.Tensor | None = None
     self._cached_frame_pos: torch.Tensor | None = None
     self._cached_frame_mat: torch.Tensor | None = None
 
-    self._frame_local_pos: torch.Tensor | None = None
-
+    self._debug_vis_enabled: bool = True
     self._ctx: SensorContext | None = None
 
   def edit_spec(
@@ -515,43 +671,39 @@ class RayCastSensor(Sensor[RayCastData]):
     self._wp_device = wp.get_device(device)
     num_envs = data.nworld
 
-    frame = self.cfg.frame
-    frame_name = frame.prefixed_name()
+    # Normalize frame to tuple.
+    frames = self.cfg.frame
+    if isinstance(frames, ObjRef):
+      frames = (frames,)
 
-    if frame.type == "body":
-      self._frame_body_id = mj_model.body(frame_name).id
-      self._frame_type = "body"
-    elif frame.type == "site":
-      self._frame_site_id = mj_model.site(frame_name).id
-      # Look up parent body for exclusion.
-      self._frame_body_id = int(mj_model.site_bodyid[self._frame_site_id])
-      self._frame_type = "site"
-      self._frame_local_pos = torch.tensor(
-        mj_model.site_pos[self._frame_site_id],
-        dtype=torch.float32,
-        device=device,
-      )
-    elif frame.type == "geom":
-      self._frame_geom_id = mj_model.geom(frame_name).id
-      # Look up parent body for exclusion.
-      self._frame_body_id = int(mj_model.geom_bodyid[self._frame_geom_id])
-      self._frame_type = "geom"
-      self._frame_local_pos = torch.tensor(
-        mj_model.geom_pos[self._frame_geom_id],
-        dtype=torch.float32,
-        device=device,
-      )
-    else:
-      raise ValueError(
-        f"RayCastSensor frame must be 'body', 'site', or 'geom', got '{frame.type}'"
-      )
+    # Resolve per-frame IDs.
+    self._frame_infos = []
+    for frame in frames:
+      frame_name = frame.prefixed_name()
+      info: tuple[Literal["body", "site", "geom"], int, int]
+      if frame.type == "body":
+        bid = mj_model.body(frame_name).id
+        info = ("body", bid, bid)
+      elif frame.type == "site":
+        sid = mj_model.site(frame_name).id
+        info = ("site", sid, int(mj_model.site_bodyid[sid]))
+      elif frame.type == "geom":
+        gid = mj_model.geom(frame_name).id
+        info = ("geom", gid, int(mj_model.geom_bodyid[gid]))
+      else:
+        raise ValueError(
+          f"RayCastSensor frame must be 'body', 'site', or 'geom', got '{frame.type}'"
+        )
+      self._frame_infos.append(info)
+    self._num_frames = len(self._frame_infos)
 
     # Generate ray pattern.
     pattern = self.cfg.pattern
     self._local_offsets, self._local_directions = pattern.generate_rays(
       mj_model, device
     )
-    self._num_rays = self._local_offsets.shape[0]
+    self._num_rays_per_frame = self._local_offsets.shape[0]
+    self._num_rays = self._num_frames * self._num_rays_per_frame
 
     self._ray_pnt = wp.zeros((num_envs, self._num_rays), dtype=wp.vec3, device=device)
     self._ray_vec = wp.zeros((num_envs, self._num_rays), dtype=wp.vec3, device=device)
@@ -561,37 +713,33 @@ class RayCastSensor(Sensor[RayCastData]):
       (num_envs, self._num_rays), dtype=wp.vec3, device=device
     )
 
-    body_exclude = (
-      self._frame_body_id
-      if self.cfg.exclude_parent_body and self._frame_body_id is not None
-      else -1
-    )
-    self._ray_bodyexclude = wp.full(
-      (self._num_rays,),
-      body_exclude,
-      dtype=int,  # pyright: ignore[reportArgumentType]
-      device=device,
-    )
-
-    # Convert include_geom_groups to vec6 format (-1 = include, 0 = exclude).
-    if self.cfg.include_geom_groups is not None:
-      groups = [0, 0, 0, 0, 0, 0]
-      for g in self.cfg.include_geom_groups:
-        if 0 <= g <= 5:
-          groups[g] = -1
-      self._geomgroup = vec6(*groups)
+    # Body exclusion: each frame's body_id repeated N times.
+    if self.cfg.exclude_parent_body:
+      body_excludes: list[int] = []
+      for _, _, body_id in self._frame_infos:
+        body_excludes.extend([body_id] * self._num_rays_per_frame)
     else:
-      self._geomgroup = vec6(-1, -1, -1, -1, -1, -1)  # All groups
+      body_excludes = [-1] * self._num_rays
+    self._ray_bodyexclude = wp.array(body_excludes, dtype=int, device=device)
+
+    self._geomgroup = _geom_groups_to_vec6(self.cfg.include_geom_groups)
 
     # Pre-allocate output tensors so shape inference works before
     # the first sense() call.
+    F = self._num_frames
     self._distances = torch.zeros(num_envs, self._num_rays, device=device)
     self._normals_w = torch.zeros(num_envs, self._num_rays, 3, device=device)
     self._hit_pos_w = torch.zeros(num_envs, self._num_rays, 3, device=device)
     self._pos_w = torch.zeros(num_envs, 3, device=device)
     self._quat_w = torch.zeros(num_envs, 4, device=device)
+    self._frame_pos_w = torch.zeros(num_envs, F, 3, device=device)
+    self._frame_quat_w = torch.zeros(num_envs, F, 4, device=device)
 
     assert self._wp_device is not None
+
+  @property
+  def include_geom_groups(self) -> tuple[int, ...] | None:
+    return self.cfg.include_geom_groups
 
   def set_context(self, ctx: SensorContext) -> None:
     """Wire this sensor to a SensorContext for BVH-accelerated raycasting."""
@@ -607,52 +755,61 @@ class RayCastSensor(Sensor[RayCastData]):
     assert self._distances is not None and self._normals_w is not None
     assert self._hit_pos_w is not None
     assert self._pos_w is not None and self._quat_w is not None
+    assert self._frame_pos_w is not None and self._frame_quat_w is not None
     return RayCastData(
       distances=self._distances,
       normals_w=self._normals_w,
       hit_pos_w=self._hit_pos_w,
       pos_w=self._pos_w,
       quat_w=self._quat_w,
+      frame_pos_w=self._frame_pos_w,
+      frame_quat_w=self._frame_quat_w,
     )
 
   @property
   def num_rays(self) -> int:
+    """Total number of rays (num_frames * num_rays_per_frame)."""
     return self._num_rays
 
+  @property
+  def num_frames(self) -> int:
+    """Number of attachment frames."""
+    return self._num_frames
+
+  @property
+  def num_rays_per_frame(self) -> int:
+    """Number of rays per attachment frame."""
+    return self._num_rays_per_frame
+
   def debug_vis(self, visualizer: DebugVisualizer) -> None:
-    if not self.cfg.debug_vis:
+    if not self.cfg.debug_vis or not self._debug_vis_enabled:
       return
     assert self._data is not None
     assert self._local_offsets is not None
     assert self._local_directions is not None
+    assert self._cached_frame_pos is not None
+    assert self._cached_frame_mat is not None
 
     data = self.data
     env_indices = list(visualizer.get_env_indices(data.distances.shape[0]))
     if not env_indices:
       return
 
-    # Gather frame poses for selected environments only.
-    if self._frame_type == "body":
-      frame_pos = self._data.xpos[env_indices, self._frame_body_id]
-      frame_mat = self._data.xmat[env_indices, self._frame_body_id]
-    elif self._frame_type == "site":
-      body_pos = self._data.xpos[env_indices, self._frame_body_id]
-      body_mat = self._data.xmat[env_indices, self._frame_body_id]
-      frame_mat = self._data.site_xmat[env_indices, self._frame_site_id]
-      body_align = self._compute_alignment_rotation(body_mat.view(-1, 3, 3))
-      frame_pos = body_pos + torch.einsum(
-        "bij,j->bi", body_align, self._frame_local_pos
-      )
-    else:  # geom
-      body_pos = self._data.xpos[env_indices, self._frame_body_id]
-      body_mat = self._data.xmat[env_indices, self._frame_body_id]
-      frame_mat = self._data.geom_xmat[env_indices, self._frame_geom_id]
-      body_align = self._compute_alignment_rotation(body_mat.view(-1, 3, 3))
-      frame_pos = body_pos + torch.einsum(
-        "bij,j->bi", body_align, self._frame_local_pos
-      )
+    F = self._num_frames
+    N = self._num_rays_per_frame
 
-    rot_mats = self._compute_alignment_rotation(frame_mat.view(-1, 3, 3)).cpu().numpy()
+    # Use cached frame poses [B, F, 3] / [B, F, 3, 3].
+    frame_pos = self._cached_frame_pos[env_indices]  # [K, F, 3]
+    frame_mat = self._cached_frame_mat[env_indices]  # [K, F, 3, 3]
+
+    K_envs = len(env_indices)
+    # Compute alignment rotation for all frames.
+    rot_mats = (
+      self._compute_alignment_rotation(frame_mat.view(K_envs * F, 3, 3))
+      .view(K_envs, F, 3, 3)
+      .cpu()
+      .numpy()
+    )
     origins = frame_pos.cpu().numpy()
     offsets = self._local_offsets.cpu().numpy()
     directions = self._local_directions.cpu().numpy()
@@ -668,45 +825,46 @@ class RayCastSensor(Sensor[RayCastData]):
     miss_extent = min(0.5, self.cfg.max_distance * 0.05)
     name = self.cfg.name
 
-    for k in range(len(env_indices)):
-      rot = rot_mats[k]
+    for k in range(K_envs):
+      for f in range(F):
+        rot = rot_mats[k, f]
+        for i in range(N):
+          ray_idx = f * N + i
+          origin = origins[k, f] + rot @ offsets[i]
+          hit = distances[k, ray_idx] >= 0
 
-      for i in range(self._num_rays):
-        origin = origins[k] + rot @ offsets[i]
-        hit = distances[k, i] >= 0
+          if hit:
+            end = hit_positions[k, ray_idx]
+            color = self.cfg.viz.hit_color
+          else:
+            end = origin + rot @ directions[i] * miss_extent
+            color = self.cfg.viz.miss_color
 
-        if hit:
-          end = hit_positions[k, i]
-          color = self.cfg.viz.hit_color
-        else:
-          end = origin + rot @ directions[i] * miss_extent
-          color = self.cfg.viz.miss_color
-
-        if self.cfg.viz.show_rays:
-          visualizer.add_arrow(
-            start=origin,
-            end=end,
-            color=color,
-            width=ray_width,
-            label=f"{name}_ray_{i}",
-          )
-
-        if hit:
-          visualizer.add_sphere(
-            center=end,
-            radius=sphere_radius,
-            color=self.cfg.viz.hit_sphere_color,
-            label=f"{name}_hit_{i}",
-          )
-          if self.cfg.viz.show_normals:
-            normal_end = end + normals[k, i] * normal_length
+          if self.cfg.viz.show_rays:
             visualizer.add_arrow(
-              start=end,
-              end=normal_end,
-              color=self.cfg.viz.normal_color,
-              width=normal_width,
-              label=f"{name}_normal_{i}",
+              start=origin,
+              end=end,
+              color=color,
+              width=ray_width,
+              label=f"{name}_ray_{ray_idx}",
             )
+
+          if hit:
+            visualizer.add_sphere(
+              center=end,
+              radius=sphere_radius,
+              color=self.cfg.viz.hit_sphere_color,
+              label=f"{name}_hit_{ray_idx}",
+            )
+            if self.cfg.viz.show_normals:
+              normal_end = end + normals[k, ray_idx] * normal_length
+              visualizer.add_arrow(
+                start=end,
+                end=normal_end,
+                color=self.cfg.viz.normal_color,
+                width=normal_width,
+                label=f"{name}_normal_{ray_idx}",
+              )
 
   # Private methods.
 
@@ -720,39 +878,53 @@ class RayCastSensor(Sensor[RayCastData]):
     assert self._data is not None and self._model is not None
     assert self._local_offsets is not None and self._local_directions is not None
 
-    if self._frame_type == "body":
-      frame_pos = self._data.xpos[:, self._frame_body_id]
-      frame_mat = self._data.xmat[:, self._frame_body_id].view(-1, 3, 3)
-    else:
-      body_pos = self._data.xpos[:, self._frame_body_id]
-      body_mat = self._data.xmat[:, self._frame_body_id].view(-1, 3, 3)
-      if self._frame_type == "site":
-        frame_mat = self._data.site_xmat[:, self._frame_site_id].view(-1, 3, 3)
-      else:
-        frame_mat = self._data.geom_xmat[:, self._frame_geom_id].view(-1, 3, 3)
-      body_align = self._compute_alignment_rotation(body_mat)
-      frame_pos = body_pos + torch.einsum(
-        "bij,j->bi", body_align, self._frame_local_pos
-      )
+    # Gather per-frame poses: [B, F, 3] and [B, F, 3, 3].
+    # Position is always the physical world position. Alignment only
+    # affects ray directions (applied to frame_mat below).
+    pos_list: list[torch.Tensor] = []
+    mat_list: list[torch.Tensor] = []
+    for frame_type, obj_id, _body_id in self._frame_infos:
+      if frame_type == "body":
+        pos_list.append(self._data.xpos[:, obj_id])
+        mat_list.append(self._data.xmat[:, obj_id].view(-1, 3, 3))
+      elif frame_type == "site":
+        pos_list.append(self._data.site_xpos[:, obj_id])
+        mat_list.append(self._data.site_xmat[:, obj_id].view(-1, 3, 3))
+      else:  # geom
+        pos_list.append(self._data.geom_xpos[:, obj_id])
+        mat_list.append(self._data.geom_xmat[:, obj_id].view(-1, 3, 3))
 
-    num_envs = frame_pos.shape[0]
-    rot_mat = self._compute_alignment_rotation(frame_mat)
+    frame_pos = torch.stack(pos_list, dim=1)  # [B, F, 3]
+    frame_mat = torch.stack(mat_list, dim=1)  # [B, F, 3, 3]
 
-    world_offsets = torch.einsum("bij,nj->bni", rot_mat, self._local_offsets)
-    world_origins = frame_pos.unsqueeze(1) + world_offsets
-    world_rays = torch.einsum("bij,nj->bni", rot_mat, self._local_directions)
+    B, F = frame_pos.shape[:2]
+    N = self._num_rays_per_frame
+
+    # Compute alignment rotation for all frames at once.
+    rot_mat = self._compute_alignment_rotation(frame_mat.reshape(B * F, 3, 3)).reshape(
+      B, F, 3, 3
+    )
+
+    # Compute world offsets and directions: [B, F, N, 3].
+    world_offsets = torch.einsum("bfij,nj->bfni", rot_mat, self._local_offsets)
+    world_origins = frame_pos[:, :, None, :] + world_offsets
+    world_rays = torch.einsum("bfij,nj->bfni", rot_mat, self._local_directions)
+
+    # Flatten to [B, F*N, 3] for raycasting.
+    world_origins_flat = world_origins.reshape(B, F * N, 3)
+    world_rays_flat = world_rays.reshape(B, F * N, 3)
 
     assert self._ray_pnt is not None and self._ray_vec is not None
-    pnt_torch = wp.to_torch(self._ray_pnt).view(num_envs, self._num_rays, 3)
-    vec_torch = wp.to_torch(self._ray_vec).view(num_envs, self._num_rays, 3)
-    pnt_torch.copy_(world_origins)
-    vec_torch.copy_(world_rays)
+    pnt_torch = wp.to_torch(self._ray_pnt).view(B, self._num_rays, 3)
+    vec_torch = wp.to_torch(self._ray_vec).view(B, self._num_rays, 3)
+    pnt_torch.copy_(world_origins_flat)
+    vec_torch.copy_(world_rays_flat)
 
-    # Cache for postprocess_rays().
-    self._cached_world_origins = world_origins
-    self._cached_world_rays = world_rays
-    self._cached_frame_pos = frame_pos
-    self._cached_frame_mat = frame_mat
+    # Cache for postprocess_rays() and debug_vis().
+    self._cached_world_origins = world_origins_flat
+    self._cached_world_rays = world_rays_flat
+    self._cached_frame_pos = frame_pos  # [B, F, 3]
+    self._cached_frame_mat = frame_mat  # [B, F, 3, 3]
 
   def raycast_kernel(self, rc: mjwarp.RenderContext) -> None:
     """IN-GRAPH: Execute BVH-accelerated raycast kernel."""
@@ -777,11 +949,12 @@ class RayCastSensor(Sensor[RayCastData]):
     assert self._cached_frame_pos is not None
     assert self._cached_frame_mat is not None
 
-    num_envs = self._cached_frame_pos.shape[0]
+    B = self._cached_frame_pos.shape[0]
+    F = self._num_frames
 
     assert self._ray_dist is not None and self._ray_normal is not None
     self._distances = wp.to_torch(self._ray_dist)
-    self._normals_w = wp.to_torch(self._ray_normal).view(num_envs, self._num_rays, 3)
+    self._normals_w = wp.to_torch(self._ray_normal).view(B, self._num_rays, 3)
     self._distances[self._distances > self.cfg.max_distance] = -1.0
 
     hit_mask = self._distances >= 0
@@ -794,8 +967,16 @@ class RayCastSensor(Sensor[RayCastData]):
     # Zero out normals for misses.
     self._normals_w[~hit_mask] = 0.0
 
-    self._pos_w = self._cached_frame_pos.clone()
-    self._quat_w = quat_from_matrix(self._cached_frame_mat)
+    # All frames: [B, F, 3] / [B, F, 4].
+    self._frame_pos_w = self._cached_frame_pos
+    self._frame_quat_w = quat_from_matrix(
+      self._cached_frame_mat.reshape(B * F, 3, 3)
+    ).reshape(B, F, 4)
+
+    # First frame for backward compat: [B, 3] / [B, 4].
+    assert self._frame_pos_w is not None and self._frame_quat_w is not None
+    self._pos_w = self._frame_pos_w[:, 0]
+    self._quat_w = self._frame_quat_w[:, 0]
 
   def _compute_alignment_rotation(self, frame_mat: torch.Tensor) -> torch.Tensor:
     """Compute rotation matrix based on ray_alignment setting."""

--- a/src/mjlab/sensor/sensor_context.py
+++ b/src/mjlab/sensor/sensor_context.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import warnings
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 import mujoco
@@ -49,7 +50,7 @@ class SensorContext:
     model: mjwarp.Model,
     data: mjwarp.Data,
     camera_sensors: list[CameraSensor],
-    raycast_sensors: list[RayCastSensor],
+    raycast_sensors: Sequence[RayCastSensor],
     device: str,
   ):
     self._model = model
@@ -217,9 +218,9 @@ class SensorContext:
     """Compute the union of geom groups across all raycast sensors."""
     groups: set[int] = set()
     for s in self.raycast_sensors:
-      if s.cfg.include_geom_groups is None:
+      if s.include_geom_groups is None:
         return {0, 1, 2, 3, 4, 5}
-      groups.update(s.cfg.include_geom_groups)
+      groups.update(s.include_geom_groups)
     return groups
 
   def _create_context(self, mj_model: mujoco.MjModel) -> None:

--- a/src/mjlab/tasks/velocity/config/g1/env_cfgs.py
+++ b/src/mjlab/tasks/velocity/config/g1/env_cfgs.py
@@ -9,7 +9,7 @@ from mjlab.envs import mdp as envs_mdp
 from mjlab.envs.mdp.actions import JointPositionActionCfg
 from mjlab.managers.event_manager import EventTermCfg
 from mjlab.managers.reward_manager import RewardTermCfg
-from mjlab.sensor import ContactMatch, ContactSensorCfg, RayCastSensorCfg
+from mjlab.sensor import ContactMatch, ContactSensorCfg, ObjRef, RayCastSensorCfg
 from mjlab.tasks.velocity import mdp
 from mjlab.tasks.velocity.mdp import UniformVelocityCommandCfg
 from mjlab.tasks.velocity.velocity_env_cfg import make_velocity_env_cfg
@@ -29,6 +29,7 @@ def unitree_g1_rough_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
   for sensor in cfg.scene.sensors or ():
     if sensor.name == "terrain_scan":
       assert isinstance(sensor, RayCastSensorCfg)
+      assert isinstance(sensor.frame, ObjRef)
       sensor.frame.name = "pelvis"
 
   site_names = ("left_foot", "right_foot")

--- a/src/mjlab/tasks/velocity/config/go1/env_cfgs.py
+++ b/src/mjlab/tasks/velocity/config/go1/env_cfgs.py
@@ -11,7 +11,7 @@ from mjlab.envs import mdp as envs_mdp
 from mjlab.envs.mdp.actions import JointPositionActionCfg
 from mjlab.managers import TerminationTermCfg
 from mjlab.managers.event_manager import EventTermCfg
-from mjlab.sensor import ContactMatch, ContactSensorCfg, RayCastSensorCfg
+from mjlab.sensor import ContactMatch, ContactSensorCfg, ObjRef, RayCastSensorCfg
 from mjlab.tasks.velocity import mdp
 from mjlab.tasks.velocity.mdp import UniformVelocityCommandCfg
 from mjlab.tasks.velocity.velocity_env_cfg import make_velocity_env_cfg
@@ -34,6 +34,7 @@ def unitree_go1_rough_env_cfg(
   for sensor in cfg.scene.sensors or ():
     if sensor.name == "terrain_scan":
       assert isinstance(sensor, RayCastSensorCfg)
+      assert isinstance(sensor.frame, ObjRef)
       sensor.frame.name = "trunk"
 
   foot_names = ("FR", "FL", "RR", "RL")

--- a/src/mjlab/viewer/viser/viewer.py
+++ b/src/mjlab/viewer/viser/viewer.py
@@ -13,6 +13,7 @@ from threading import Lock
 import viser
 from typing_extensions import override
 
+from mjlab.sensor.raycast_sensor import RayCastSensor
 from mjlab.sim.sim import Simulation
 from mjlab.viewer.base import (
   BaseViewer,
@@ -144,6 +145,7 @@ class ViserPlayViewer(BaseViewer):
       # Add standard visualization options from ViserMujocoScene.
       def _debug_viz_extra() -> None:
         env.command_manager.create_debug_vis_gui(self._server)
+        self._create_sensor_debug_vis_gui()
 
       with self._server.gui.add_folder("Scene"):
         self._scene.create_visualization_gui(
@@ -212,6 +214,28 @@ class ViserPlayViewer(BaseViewer):
         sim.data, self._scene.env_idx, self._scene._scene_offset
       )
     self._camera_update_last_ms = (time.perf_counter() - t0) * 1000.0
+
+  def _create_sensor_debug_vis_gui(self) -> None:
+    """Add per-sensor debug visualization checkboxes."""
+    env = self.env.unwrapped
+    vis_sensors = [
+      s
+      for s in env.scene.sensors.values()
+      if isinstance(s, RayCastSensor) and s.cfg.debug_vis
+    ]
+    if not vis_sensors:
+      return
+    for sensor in vis_sensors:
+      cb = self._server.gui.add_checkbox(
+        sensor.cfg.name,
+        initial_value=sensor._debug_vis_enabled,
+      )
+
+      def _on_update(_ev, _s=sensor, _cb=cb) -> None:
+        _s._debug_vis_enabled = _cb.value
+        self._scene.needs_update = True
+
+      cb.on_update(_on_update)
 
   def _queue_debug_visualizers(self) -> None:
     """Queue environment-specific debug draw calls into the scene.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ import torch
 import warp as wp
 
 from mjlab.entity import Entity, EntityArticulationInfoCfg, EntityCfg
+from mjlab.scene import Scene, SceneCfg
 from mjlab.sim.sim import Simulation, SimulationCfg
 
 
@@ -101,6 +102,32 @@ def initialize_entity(entity: Entity, device: str, num_envs: int = 1):
   sim = Simulation(num_envs=num_envs, cfg=sim_cfg, model=model, device=device)
   entity.initialize(model, sim.model, sim.data, device)
   return entity, sim
+
+
+def make_scene_and_sim(
+  device: str,
+  xml: str,
+  sensors: tuple,
+  num_envs: int = 1,
+  sim_cfg: SimulationCfg | None = None,
+) -> tuple[Scene, Simulation]:
+  """Create a scene and simulation from inline XML with sensors wired up."""
+  entity_cfg = EntityCfg(spec_fn=lambda: mujoco.MjSpec.from_string(xml))
+  scene_cfg = SceneCfg(
+    num_envs=num_envs,
+    env_spacing=5.0,
+    entities={"robot": entity_cfg},
+    sensors=sensors,
+  )
+  scene = Scene(scene_cfg, device)
+  model = scene.compile()
+  if sim_cfg is None:
+    sim_cfg = SimulationCfg(njmax=20)
+  sim = Simulation(num_envs=num_envs, cfg=sim_cfg, model=model, device=device)
+  scene.initialize(sim.mj_model, sim.model, sim.data)
+  if scene.sensor_context is not None:
+    sim.set_sensor_context(scene.sensor_context)
+  return scene, sim
 
 
 # =============================================================================

--- a/tests/test_raycast_sensor.py
+++ b/tests/test_raycast_sensor.py
@@ -4,90 +4,24 @@ from __future__ import annotations
 
 import math
 
-import mujoco
 import pytest
 import torch
-from conftest import get_test_device
+from conftest import get_test_device, make_scene_and_sim
 
-from mjlab.entity import EntityCfg
 from mjlab.envs.mdp.observations import height_scan
-from mjlab.scene import Scene, SceneCfg
 from mjlab.sensor import (
   GridPatternCfg,
   ObjRef,
   PinholeCameraPatternCfg,
   RayCastData,
   RayCastSensorCfg,
+  RingPatternCfg,
 )
-from mjlab.sim.sim import Simulation, SimulationCfg
 
 
 @pytest.fixture(scope="module")
 def device():
-  """Test device fixture."""
   return get_test_device()
-
-
-def _make_scene_and_sim(
-  device: str,
-  xml: str,
-  sensors: tuple,
-  num_envs: int = 1,
-  sim_cfg: SimulationCfg | None = None,
-) -> tuple[Scene, Simulation]:
-  """Create a scene and simulation with sensors wired up."""
-  entity_cfg = EntityCfg(spec_fn=lambda: mujoco.MjSpec.from_string(xml))
-  scene_cfg = SceneCfg(
-    num_envs=num_envs,
-    env_spacing=5.0,
-    entities={"robot": entity_cfg},
-    sensors=sensors,
-  )
-  scene = Scene(scene_cfg, device)
-  model = scene.compile()
-  if sim_cfg is None:
-    sim_cfg = SimulationCfg(njmax=20)
-  sim = Simulation(num_envs=num_envs, cfg=sim_cfg, model=model, device=device)
-  scene.initialize(sim.mj_model, sim.model, sim.data)
-  if scene.sensor_context is not None:
-    sim.set_sensor_context(scene.sensor_context)
-  return scene, sim
-
-
-@pytest.fixture(scope="module")
-def robot_with_floor_xml():
-  """XML for a floating body above a ground plane."""
-  return """
-    <mujoco>
-      <worldbody>
-        <geom name="floor" type="plane" size="10 10 0.1" pos="0 0 0"/>
-        <body name="base" pos="0 0 2">
-          <freejoint name="free_joint"/>
-          <geom name="base_geom" type="box" size="0.2 0.2 0.1" mass="5.0"/>
-          <site name="base_site" pos="0 0 -0.1"/>
-        </body>
-      </worldbody>
-    </mujoco>
-  """
-
-
-@pytest.fixture(scope="module")
-def scene_with_obstacles_xml():
-  """XML for a body above various obstacles."""
-  return """
-    <mujoco>
-      <worldbody>
-        <geom name="floor" type="plane" size="10 10 0.1" pos="0 0 0"/>
-        <geom name="box1" type="box" size="0.5 0.5 0.5" pos="1 0 0.5"/>
-        <geom name="box2" type="box" size="0.3 0.3 0.8" pos="-1 0 0.8"/>
-        <body name="scanner" pos="0 0 3">
-          <freejoint name="free_joint"/>
-          <geom name="scanner_geom" type="sphere" size="0.1" mass="1.0"/>
-          <site name="scan_site" pos="0 0 0"/>
-        </body>
-      </worldbody>
-    </mujoco>
-  """
 
 
 def test_basic_raycast_hit_detection(robot_with_floor_xml, device):
@@ -101,7 +35,7 @@ def test_basic_raycast_hit_detection(robot_with_floor_xml, device):
     max_distance=10.0,
   )
 
-  scene, sim = _make_scene_and_sim(
+  scene, sim = make_scene_and_sim(
     device, robot_with_floor_xml, sensors=(raycast_cfg,), num_envs=2
   )
 
@@ -133,7 +67,7 @@ def test_raycast_normals_point_up(robot_with_floor_xml, device):
     max_distance=10.0,
   )
 
-  scene, sim = _make_scene_and_sim(device, robot_with_floor_xml, sensors=(raycast_cfg,))
+  scene, sim = make_scene_and_sim(device, robot_with_floor_xml, sensors=(raycast_cfg,))
 
   sensor = scene["terrain_scan"]
   sim.step()
@@ -141,15 +75,9 @@ def test_raycast_normals_point_up(robot_with_floor_xml, device):
   data = sensor.data
 
   # Normals should point up (+Z) for a horizontal floor.
-  assert torch.allclose(
-    data.normals_w[:, :, 2], torch.ones_like(data.normals_w[:, :, 2])
-  )
-  assert torch.allclose(
-    data.normals_w[:, :, 0], torch.zeros_like(data.normals_w[:, :, 0])
-  )
-  assert torch.allclose(
-    data.normals_w[:, :, 1], torch.zeros_like(data.normals_w[:, :, 1])
-  )
+  expected = torch.zeros_like(data.normals_w)
+  expected[:, :, 2] = 1.0
+  assert torch.allclose(data.normals_w, expected)
 
 
 def test_raycast_miss_returns_negative_one(device):
@@ -175,7 +103,7 @@ def test_raycast_miss_returns_negative_one(device):
     exclude_parent_body=True,
   )
 
-  scene, sim = _make_scene_and_sim(device, no_floor_xml, sensors=(raycast_cfg,))
+  scene, sim = make_scene_and_sim(device, no_floor_xml, sensors=(raycast_cfg,))
 
   sensor = scene["terrain_scan"]
   sim.step()
@@ -196,7 +124,7 @@ def test_raycast_exclude_parent_body(robot_with_floor_xml, device):
     exclude_parent_body=True,
   )
 
-  scene, sim = _make_scene_and_sim(device, robot_with_floor_xml, sensors=(raycast_cfg,))
+  scene, sim = make_scene_and_sim(device, robot_with_floor_xml, sensors=(raycast_cfg,))
 
   sensor = scene["terrain_scan"]
   sim.step()
@@ -232,7 +160,7 @@ def test_raycast_include_geom_groups(device):
     include_geom_groups=(0,),
   )
 
-  scene, sim = _make_scene_and_sim(device, groups_xml, sensors=(raycast_cfg,))
+  scene, sim = make_scene_and_sim(device, groups_xml, sensors=(raycast_cfg,))
 
   sensor = scene["group_filter_test"]
   sim.step()
@@ -251,7 +179,7 @@ def test_raycast_include_geom_groups(device):
     include_geom_groups=(1,),
   )
 
-  scene2, sim2 = _make_scene_and_sim(device, groups_xml, sensors=(raycast_cfg_group1,))
+  scene2, sim2 = make_scene_and_sim(device, groups_xml, sensors=(raycast_cfg_group1,))
 
   sensor2 = scene2["group1_test"]
   sim2.step()
@@ -285,7 +213,7 @@ def test_raycast_frame_attachment_geom(device):
     max_distance=10.0,
   )
 
-  scene, sim = _make_scene_and_sim(device, geom_xml, sensors=(raycast_cfg,))
+  scene, sim = make_scene_and_sim(device, geom_xml, sensors=(raycast_cfg,))
 
   sensor = scene["geom_scan"]
   sim.step()
@@ -306,7 +234,7 @@ def test_raycast_frame_attachment_site(robot_with_floor_xml, device):
     max_distance=10.0,
   )
 
-  scene, sim = _make_scene_and_sim(device, robot_with_floor_xml, sensors=(raycast_cfg,))
+  scene, sim = make_scene_and_sim(device, robot_with_floor_xml, sensors=(raycast_cfg,))
 
   sensor = scene["site_scan"]
   sim.step()
@@ -342,7 +270,7 @@ def test_raycast_grid_pattern_num_rays(device):
     pattern=GridPatternCfg(size=(1.0, 0.5), resolution=0.5),
   )
 
-  scene, sim = _make_scene_and_sim(device, simple_xml, sensors=(raycast_cfg,))
+  scene, sim = make_scene_and_sim(device, simple_xml, sensors=(raycast_cfg,))
 
   sensor = scene["grid_test"]
   assert sensor.num_rays == 6
@@ -369,7 +297,7 @@ def test_raycast_different_direction(device):
     max_distance=10.0,
   )
 
-  scene, sim = _make_scene_and_sim(device, wall_xml, sensors=(raycast_cfg,))
+  scene, sim = make_scene_and_sim(device, wall_xml, sensors=(raycast_cfg,))
 
   sensor = scene["forward_scan"]
   sim.step()
@@ -388,33 +316,20 @@ def test_raycast_different_direction(device):
 
 def test_raycast_error_on_invalid_frame_type(device):
   """Verify ValueError is raised for invalid frame type."""
+  simple_xml = """
+    <mujoco>
+      <worldbody>
+        <body name="base"><geom type="sphere" size="0.1"/></body>
+      </worldbody>
+    </mujoco>
+  """
+  raycast_cfg = RayCastSensorCfg(
+    name="invalid",
+    frame=ObjRef(type="joint", name="some_joint", entity="robot"),
+    pattern=GridPatternCfg(size=(0.1, 0.1), resolution=0.1),
+  )
   with pytest.raises(ValueError, match="must be 'body', 'site', or 'geom'"):
-    simple_xml = """
-      <mujoco>
-        <worldbody>
-          <body name="base"><geom type="sphere" size="0.1"/></body>
-        </worldbody>
-      </mujoco>
-    """
-    entity_cfg = EntityCfg(spec_fn=lambda: mujoco.MjSpec.from_string(simple_xml))
-
-    raycast_cfg = RayCastSensorCfg(
-      name="invalid",
-      frame=ObjRef(type="joint", name="some_joint", entity="robot"),  # Invalid type
-      pattern=GridPatternCfg(size=(0.1, 0.1), resolution=0.1),
-    )
-
-    scene_cfg = SceneCfg(
-      num_envs=1,
-      entities={"robot": entity_cfg},
-      sensors=(raycast_cfg,),
-    )
-
-    scene = Scene(scene_cfg, device)
-    model = scene.compile()
-    sim_cfg = SimulationCfg(njmax=20)
-    sim = Simulation(num_envs=1, cfg=sim_cfg, model=model, device=device)
-    scene.initialize(sim.mj_model, sim.model, sim.data)
+    make_scene_and_sim(device, simple_xml, sensors=(raycast_cfg,))
 
 
 def test_raycast_hit_pos_w_correctness(robot_with_floor_xml, device):
@@ -426,7 +341,7 @@ def test_raycast_hit_pos_w_correctness(robot_with_floor_xml, device):
     max_distance=10.0,
   )
 
-  scene, sim = _make_scene_and_sim(device, robot_with_floor_xml, sensors=(raycast_cfg,))
+  scene, sim = make_scene_and_sim(device, robot_with_floor_xml, sensors=(raycast_cfg,))
 
   sensor = scene["terrain_scan"]
   sim.step()
@@ -468,7 +383,7 @@ def test_raycast_max_distance_clamping(device):
     max_distance=3.0,
   )
 
-  scene, sim = _make_scene_and_sim(device, far_floor_xml, sensors=(raycast_cfg,))
+  scene, sim = make_scene_and_sim(device, far_floor_xml, sensors=(raycast_cfg,))
 
   sensor = scene["short_range"]
   sim.step()
@@ -502,7 +417,7 @@ def test_raycast_body_rotation_affects_rays(device):
     max_distance=10.0,
   )
 
-  scene, sim = _make_scene_and_sim(device, rotated_body_xml, sensors=(raycast_cfg,))
+  scene, sim = make_scene_and_sim(device, rotated_body_xml, sensors=(raycast_cfg,))
 
   sensor = scene["rotated_scan"]
 
@@ -534,6 +449,11 @@ def test_raycast_body_rotation_affects_rays(device):
   ), f"Expected ~{expected_distance:.2f}m, got {data_rotated.distances}"
 
 
+# ============================================================================
+# Pinhole Camera Pattern Tests
+# ============================================================================
+
+
 def test_pinhole_camera_pattern_num_rays(device):
   """Verify pinhole pattern generates width * height rays."""
   simple_xml = """
@@ -554,26 +474,10 @@ def test_pinhole_camera_pattern_num_rays(device):
     pattern=PinholeCameraPatternCfg(width=16, height=12, fovy=74.0),
   )
 
-  scene, sim = _make_scene_and_sim(device, simple_xml, sensors=(raycast_cfg,))
+  scene, sim = make_scene_and_sim(device, simple_xml, sensors=(raycast_cfg,))
 
   sensor = scene["camera_scan"]
   assert sensor.num_rays == 16 * 12
-
-
-def test_pinhole_camera_fov(robot_with_floor_xml, device):
-  """Verify pinhole pattern ray angles match FOV."""
-  # 90 degree vertical FOV.
-  raycast_cfg = RayCastSensorCfg(
-    name="camera_scan",
-    frame=ObjRef(type="body", name="base", entity="robot"),
-    pattern=PinholeCameraPatternCfg(width=3, height=3, fovy=90.0),
-    max_distance=10.0,
-  )
-
-  scene, sim = _make_scene_and_sim(device, robot_with_floor_xml, sensors=(raycast_cfg,))
-
-  sensor = scene["camera_scan"]
-  assert sensor.num_rays == 9
 
 
 def test_pinhole_from_intrinsic_matrix():
@@ -617,7 +521,7 @@ def test_pinhole_from_mujoco_camera(device):
     max_distance=10.0,
   )
 
-  scene, sim = _make_scene_and_sim(device, camera_xml, sensors=(raycast_cfg,))
+  scene, sim = make_scene_and_sim(device, camera_xml, sensors=(raycast_cfg,))
 
   sensor = scene["camera_scan"]
   # Should have 64 * 48 = 3072 rays.
@@ -653,7 +557,7 @@ def test_pinhole_from_mujoco_camera_fovy_mode(device):
     max_distance=10.0,
   )
 
-  scene, sim = _make_scene_and_sim(device, camera_xml, sensors=(raycast_cfg,))
+  scene, sim = make_scene_and_sim(device, camera_xml, sensors=(raycast_cfg,))
 
   sensor = scene["camera_scan"]
   # Should have 32 * 24 = 768 rays.
@@ -664,6 +568,11 @@ def test_pinhole_from_mujoco_camera_fovy_mode(device):
   sim.sense()
   data = sensor.data
   assert torch.all(data.distances >= 0)  # Should hit floor
+
+
+# ============================================================================
+# Ray Alignment Tests
+# ============================================================================
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="Likely bug on CPU MjWarp")
@@ -691,7 +600,7 @@ def test_ray_alignment_yaw(device):
     max_distance=10.0,
   )
 
-  scene, sim = _make_scene_and_sim(device, rotated_body_xml, sensors=(raycast_cfg,))
+  scene, sim = make_scene_and_sim(device, rotated_body_xml, sensors=(raycast_cfg,))
 
   sensor = scene["yaw_scan"]
 
@@ -742,7 +651,7 @@ def test_ray_alignment_world(device):
     max_distance=10.0,
   )
 
-  scene, sim = _make_scene_and_sim(device, rotated_body_xml, sensors=(raycast_cfg,))
+  scene, sim = make_scene_and_sim(device, rotated_body_xml, sensors=(raycast_cfg,))
 
   sensor = scene["world_scan"]
 
@@ -814,7 +723,7 @@ def test_ray_alignment_yaw_singularity(device):
     max_distance=10.0,
   )
 
-  scene, sim = _make_scene_and_sim(device, xml, sensors=(raycast_cfg,))
+  scene, sim = make_scene_and_sim(device, xml, sensors=(raycast_cfg,))
 
   sensor = scene["yaw_scan"]
 
@@ -878,7 +787,7 @@ def test_height_scan_hits(robot_with_floor_xml, device):
     max_distance=10.0,
   )
 
-  scene, sim = _make_scene_and_sim(
+  scene, sim = make_scene_and_sim(
     device, robot_with_floor_xml, sensors=(raycast_cfg,), num_envs=2
   )
 
@@ -921,7 +830,7 @@ def test_height_scan_misses(device):
     exclude_parent_body=True,
   )
 
-  scene, sim = _make_scene_and_sim(device, no_floor_xml, sensors=(raycast_cfg,))
+  scene, sim = make_scene_and_sim(device, no_floor_xml, sensors=(raycast_cfg,))
 
   sim.step()
   sim.sense()
@@ -935,119 +844,378 @@ def test_height_scan_misses(device):
   )
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="Likely bug on CPU MjWarp")
-def test_ray_alignment_yaw_site_offset(device):
-  """Verify yaw alignment correctly aligns frame offset for sites.
+# ============================================================================
+# Multi-Frame Tests
+# ============================================================================
 
-  When a site has a large Z offset from its parent body, the frame position should be
-  recomputed using the body's yaw-only rotation so that pitch/roll does not swing the
-  ray origin.
+MULTI_SITE_XML = """
+  <mujoco>
+    <worldbody>
+      <geom name="floor" type="plane" size="10 10 0.1" pos="0 0 0"/>
+      <body name="base" pos="0 0 3">
+        <freejoint name="free_joint"/>
+        <geom name="base_geom" type="box" size="0.2 0.2 0.1" mass="5.0"/>
+        <site name="site_top" pos="0 0 0.5"/>
+        <site name="site_mid" pos="0 0 0"/>
+        <site name="site_bot" pos="0 0 -0.5"/>
+      </body>
+    </worldbody>
+  </mujoco>
+"""
+
+
+def test_multi_frame_shapes(device):
+  """Multi-frame sensor produces correct output shapes."""
+  cfg = RayCastSensorCfg(
+    name="multi",
+    frame=(
+      ObjRef(type="site", name="site_top", entity="robot"),
+      ObjRef(type="site", name="site_mid", entity="robot"),
+      ObjRef(type="site", name="site_bot", entity="robot"),
+    ),
+    pattern=GridPatternCfg(size=(0.0, 0.0), resolution=0.1),
+    max_distance=10.0,
+  )
+
+  scene, sim = make_scene_and_sim(device, MULTI_SITE_XML, (cfg,), num_envs=2)
+  sim.step()
+  sim.sense()
+
+  sensor = scene["multi"]
+  data = sensor.data
+
+  assert sensor.num_frames == 3
+  assert sensor.num_rays_per_frame == 1
+  assert sensor.num_rays == 3
+
+  assert data.distances.shape == (2, 3)
+  assert data.frame_pos_w.shape == (2, 3, 3)
+  assert data.frame_quat_w.shape == (2, 3, 4)
+  # Backward compat: pos_w/quat_w equal first frame.
+  assert data.pos_w.shape == (2, 3)
+  assert data.quat_w.shape == (2, 4)
+  assert torch.allclose(data.pos_w, data.frame_pos_w[:, 0])
+  assert torch.allclose(data.quat_w, data.frame_quat_w[:, 0])
+
+
+def test_multi_frame_heights(device):
+  """Sites at different Z offsets produce proportional distances."""
+  cfg = RayCastSensorCfg(
+    name="multi",
+    frame=(
+      ObjRef(type="site", name="site_top", entity="robot"),
+      ObjRef(type="site", name="site_mid", entity="robot"),
+      ObjRef(type="site", name="site_bot", entity="robot"),
+    ),
+    pattern=GridPatternCfg(size=(0.0, 0.0), resolution=0.1),
+    max_distance=10.0,
+  )
+
+  scene, sim = make_scene_and_sim(device, MULTI_SITE_XML, (cfg,))
+  sim.step()
+  sim.sense()
+
+  distances = scene["multi"].data.distances[0]
+  # site_top at z=3.5, site_mid at z=3, site_bot at z=2.5.
+  assert distances[0].item() == pytest.approx(3.5, abs=0.1)
+  assert distances[1].item() == pytest.approx(3.0, abs=0.1)
+  assert distances[2].item() == pytest.approx(2.5, abs=0.1)
+
+
+def test_multi_frame_body_exclusion(device):
+  """Each frame excludes only its own parent body, not others.
+
+  body_a has a platform geom directly below site_b. Frame B's rays
+  should skip body_b's own geom but HIT body_a's platform. Frame A's
+  rays should skip body_a and hit the floor.
+  """
+  xml = """
+    <mujoco>
+      <worldbody>
+        <geom name="floor" type="plane" size="10 10 0.1" pos="0 0 0"/>
+        <body name="body_a" pos="0 0 1">
+          <freejoint name="free_a"/>
+          <geom name="geom_a" type="box" size="2 2 0.1" mass="5.0"/>
+          <site name="site_a" pos="0 0 0"/>
+        </body>
+        <body name="body_b" pos="0 0 3">
+          <freejoint name="free_b"/>
+          <geom name="geom_b" type="box" size="0.5 0.5 0.5" mass="5.0"/>
+          <site name="site_b" pos="0 0 0"/>
+        </body>
+      </worldbody>
+    </mujoco>
+  """
+
+  cfg = RayCastSensorCfg(
+    name="multi",
+    frame=(
+      ObjRef(type="site", name="site_a", entity="robot"),
+      ObjRef(type="site", name="site_b", entity="robot"),
+    ),
+    pattern=GridPatternCfg(size=(0.0, 0.0), resolution=0.1),
+    max_distance=10.0,
+    exclude_parent_body=True,
+  )
+
+  scene, sim = make_scene_and_sim(device, xml, (cfg,))
+  sim.step()
+  sim.sense()
+
+  distances = scene["multi"].data.distances[0]
+  # Frame A (site_a at z=1): excludes body_a, hits floor at z=0 -> dist ~1.0.
+  assert distances[0].item() == pytest.approx(1.0, abs=0.15)
+  # Frame B (site_b at z=3): excludes body_b, hits body_a's platform
+  # at z=1.1 -> dist ~1.9.
+  assert distances[1].item() == pytest.approx(1.9, abs=0.15)
+
+
+def test_multi_frame_height_scan(device):
+  """height_scan works correctly with multi-frame sensors."""
+  cfg = RayCastSensorCfg(
+    name="multi",
+    frame=(
+      ObjRef(type="site", name="site_top", entity="robot"),
+      ObjRef(type="site", name="site_mid", entity="robot"),
+      ObjRef(type="site", name="site_bot", entity="robot"),
+    ),
+    pattern=GridPatternCfg(size=(0.0, 0.0), resolution=0.1),
+    max_distance=10.0,
+  )
+
+  scene, sim = make_scene_and_sim(device, MULTI_SITE_XML, (cfg,), num_envs=2)
+  sim.step()
+  sim.sense()
+
+  env = _FakeEnv(scene)
+  heights = height_scan(env, "multi")  # type: ignore[invalid-argument-type]
+
+  assert heights.shape == (2, 3)
+  # Each frame's height = frame_z - hit_z.
+  # site_top at z=3.5, site_mid at z=3, site_bot at z=2.5; floor at z=0.
+  assert heights[0, 0].item() == pytest.approx(3.5, abs=0.1)
+  assert heights[0, 1].item() == pytest.approx(3.0, abs=0.1)
+  assert heights[0, 2].item() == pytest.approx(2.5, abs=0.1)
+
+
+# ============================================================================
+# Ring Pattern Tests
+# ============================================================================
+
+
+def test_ring_pattern_num_rays(device):
+  """Ring with 8 samples + center = 9 rays."""
+  cfg = RayCastSensorCfg(
+    name="ring",
+    frame=ObjRef(type="body", name="base", entity="robot"),
+    pattern=RingPatternCfg.single_ring(radius=0.1, num_samples=8, include_center=True),
+  )
+
+  simple_xml = """
+    <mujoco>
+      <worldbody>
+        <geom name="floor" type="plane" size="10 10 0.1"/>
+        <body name="base" pos="0 0 1">
+          <freejoint name="free_joint"/>
+          <geom name="base_geom" type="sphere" size="0.1"/>
+        </body>
+      </worldbody>
+    </mujoco>
+  """
+
+  scene, sim = make_scene_and_sim(device, simple_xml, (cfg,))
+  sensor = scene["ring"]
+  assert sensor.num_rays == 9
+  assert sensor.num_rays_per_frame == 9
+
+
+def test_ring_pattern_concentric(device):
+  """Concentric rings: 1 center + 4 + 6 + 8 = 19 rays."""
+  cfg = RayCastSensorCfg(
+    name="ring",
+    frame=ObjRef(type="body", name="base", entity="robot"),
+    pattern=RingPatternCfg(
+      rings=(
+        RingPatternCfg.Ring(radius=0.05, num_samples=4),
+        RingPatternCfg.Ring(radius=0.10, num_samples=6),
+        RingPatternCfg.Ring(radius=0.20, num_samples=8),
+      ),
+      include_center=True,
+    ),
+  )
+
+  simple_xml = """
+    <mujoco>
+      <worldbody>
+        <geom name="floor" type="plane" size="10 10 0.1"/>
+        <body name="base" pos="0 0 1">
+          <freejoint name="free_joint"/>
+          <geom name="base_geom" type="sphere" size="0.1"/>
+        </body>
+      </worldbody>
+    </mujoco>
+  """
+
+  scene, sim = make_scene_and_sim(device, simple_xml, (cfg,))
+  sensor = scene["ring"]
+  assert sensor.num_rays == 19
+
+
+def test_ring_pattern_hits_floor(device):
+  """Ring pattern hits floor and ring offsets lie on a circle."""
+  radius = 0.1
+  cfg = RayCastSensorCfg(
+    name="ring",
+    frame=ObjRef(type="body", name="base", entity="robot"),
+    pattern=RingPatternCfg.single_ring(
+      radius=radius, num_samples=4, include_center=True
+    ),
+    max_distance=10.0,
+  )
+
+  simple_xml = """
+    <mujoco>
+      <worldbody>
+        <geom name="floor" type="plane" size="10 10 0.1"/>
+        <body name="base" pos="0 0 2">
+          <freejoint name="free_joint"/>
+          <geom name="base_geom" type="sphere" size="0.05"/>
+        </body>
+      </worldbody>
+    </mujoco>
+  """
+
+  scene, sim = make_scene_and_sim(device, simple_xml, (cfg,))
+  sim.step()
+  sim.sense()
+
+  data = scene["ring"].data
+  # All 5 rays (1 center + 4 ring) should hit the floor.
+  assert torch.all(data.distances >= 0)
+  assert torch.allclose(data.distances, torch.full_like(data.distances, 2.0), atol=0.1)
+
+  # Verify ring geometry: non-center hits should lie on a circle of
+  # the given radius around the body's XY position.
+  hit_xy = data.hit_pos_w[0, :, :2]  # [5, 2]
+  body_xy = data.pos_w[0, :2]  # [2]
+  dists_from_center = (hit_xy - body_xy).norm(dim=1)
+  # Center ray (index 0) should be at ~0 offset.
+  assert dists_from_center[0].item() == pytest.approx(0.0, abs=0.02)
+  # Ring rays (indices 1-4) should be at ~radius offset.
+  for i in range(1, 5):
+    assert dists_from_center[i].item() == pytest.approx(radius, abs=0.02)
+
+
+def test_ring_pattern_no_center(device):
+  """Ring with include_center=False omits the center ray."""
+  cfg = RayCastSensorCfg(
+    name="ring",
+    frame=ObjRef(type="body", name="base", entity="robot"),
+    pattern=RingPatternCfg.single_ring(radius=0.1, num_samples=4, include_center=False),
+  )
+  simple_xml = """
+    <mujoco>
+      <worldbody>
+        <geom name="floor" type="plane" size="10 10 0.1"/>
+        <body name="base" pos="0 0 1">
+          <freejoint name="free_joint"/>
+          <geom name="base_geom" type="sphere" size="0.1"/>
+        </body>
+      </worldbody>
+    </mujoco>
+  """
+  scene, sim = make_scene_and_sim(device, simple_xml, (cfg,))
+  assert scene["ring"].num_rays == 4
+
+
+def test_multi_frame_multiple_rays_per_frame(device):
+  """Multi-frame with grid pattern: verifies reshape ordering."""
+  cfg = RayCastSensorCfg(
+    name="multi",
+    frame=(
+      ObjRef(type="site", name="site_top", entity="robot"),
+      ObjRef(type="site", name="site_bot", entity="robot"),
+    ),
+    pattern=GridPatternCfg(size=(0.2, 0.2), resolution=0.1),
+    max_distance=10.0,
+  )
+
+  scene, sim = make_scene_and_sim(device, MULTI_SITE_XML, (cfg,))
+  sim.step()
+  sim.sense()
+
+  sensor = scene["multi"]
+  N = sensor.num_rays_per_frame
+  assert N == 9  # 3x3 grid
+  assert sensor.num_rays == 18  # 2 frames * 9
+
+  data = sensor.data
+  # First frame (site_top, z=3.5) rays should all be ~3.5.
+  top_dists = data.distances[0, :N]
+  assert torch.allclose(top_dists, torch.full_like(top_dists, 3.5), atol=0.1)
+  # Second frame (site_bot, z=2.5) rays should all be ~2.5.
+  bot_dists = data.distances[0, N:]
+  assert torch.allclose(bot_dists, torch.full_like(bot_dists, 2.5), atol=0.1)
+
+  # height_scan should also produce correct per-frame heights.
+  env = _FakeEnv(scene)
+  heights = height_scan(env, "multi")  # type: ignore[invalid-argument-type]
+  assert heights.shape == (1, 18)
+  top_heights = heights[0, :N]
+  bot_heights = heights[0, N:]
+  assert torch.allclose(top_heights, torch.full_like(top_heights, 3.5), atol=0.1)
+  assert torch.allclose(bot_heights, torch.full_like(bot_heights, 2.5), atol=0.1)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Likely bug on CPU MjWarp")
+def test_site_origin_is_physical_with_world_alignment(device):
+  """ray_alignment only controls direction, not origin position.
+
+  When a calf body pitches, the foot site swings to its physical
+  position (site_xpos). Rays still point -Z (world-aligned), giving
+  the correct distance from the actual foot to the ground.
   """
   xml = """
     <mujoco>
       <option gravity="0 0 0"/>
       <worldbody>
         <geom name="floor" type="plane" size="50 50 0.1" pos="0 0 0"/>
-        <body name="base" pos="0 0 2">
+        <body name="calf" pos="0 0 1">
           <freejoint name="free_joint"/>
-          <geom name="base_geom" type="sphere" size="0.1" mass="1.0"/>
-          <site name="high_site" pos="0 0 20"/>
+          <geom name="calf_geom" type="sphere" size="0.05" mass="1.0"/>
+          <site name="foot" pos="0 0 -0.5"/>
         </body>
       </worldbody>
     </mujoco>
   """
 
-  raycast_cfg = RayCastSensorCfg(
-    name="yaw_site_scan",
-    frame=ObjRef(type="site", name="high_site", entity="robot"),
-    pattern=GridPatternCfg(size=(0.0, 0.0), resolution=0.1, direction=(0.0, 0.0, -1.0)),
-    ray_alignment="yaw",
-    max_distance=50.0,
+  cfg = RayCastSensorCfg(
+    name="scan",
+    frame=ObjRef(type="site", name="foot", entity="robot"),
+    pattern=GridPatternCfg(size=(0.0, 0.0), resolution=0.1),
+    ray_alignment="world",
+    max_distance=5.0,
   )
 
-  scene, sim = _make_scene_and_sim(device, xml, sensors=(raycast_cfg,))
-  sensor = scene["yaw_site_scan"]
+  scene, sim = make_scene_and_sim(device, xml, (cfg,))
 
-  # Baseline: unrotated body. Site at z=22, floor at z=0 -> distance ~22m.
+  # Baseline: body upright, site at z=0.5.
   sim.step()
   scene.update(dt=sim.cfg.mujoco.timestep)
   sim.sense()
-  baseline_dist = sensor.data.distances.clone()
-  assert torch.allclose(baseline_dist, torch.full_like(baseline_dist, 22.0), atol=0.2)
+  data = scene["scan"].data
+  assert data.pos_w[0, 2].item() == pytest.approx(0.5, abs=0.05)
+  assert data.distances[0, 0].item() == pytest.approx(0.5, abs=0.05)
 
-  # Tilt body 30 degrees around X axis (pitch).
-  angle = math.pi / 6
+  # Pitch calf 90 degrees. Site swings to (0, -0.5, 1.0).
+  # Ray points -Z (world), distance to floor = 1.0.
+  angle = math.pi / 2
   quat = [math.cos(angle / 2), math.sin(angle / 2), 0, 0]
   sim.data.qpos[0, 3:7] = torch.tensor(quat, device=device)
   sim.step()
   scene.update(dt=sim.cfg.mujoco.timestep)
   sim.sense()
-  tilted_dist = sensor.data.distances.clone()
+  data = scene["scan"].data
 
-  # With the fix, distance should remain ~22m because yaw alignment prevents the site
-  # offset from swinging with pitch.
-  assert torch.allclose(tilted_dist, baseline_dist, atol=0.5), (
-    f"Expected ~22m after pitch, got {tilted_dist}"
-  )
-
-
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="Likely bug on CPU MjWarp")
-def test_ray_alignment_world_site_offset(device):
-  """Verify world alignment correctly aligns frame offset for sites.
-
-  With world alignment the site offset should be rotated by the identity matrix, so
-  combined pitch and roll on the body should not move the ray origin away from directly
-  above the body.
-  """
-  xml = """
-    <mujoco>
-      <option gravity="0 0 0"/>
-      <worldbody>
-        <geom name="floor" type="plane" size="50 50 0.1" pos="0 0 0"/>
-        <body name="base" pos="0 0 2">
-          <freejoint name="free_joint"/>
-          <geom name="base_geom" type="sphere" size="0.1" mass="1.0"/>
-          <site name="high_site" pos="0 0 20"/>
-        </body>
-      </worldbody>
-    </mujoco>
-  """
-
-  raycast_cfg = RayCastSensorCfg(
-    name="world_site_scan",
-    frame=ObjRef(type="site", name="high_site", entity="robot"),
-    pattern=GridPatternCfg(size=(0.0, 0.0), resolution=0.1, direction=(0.0, 0.0, -1.0)),
-    ray_alignment="world",
-    max_distance=50.0,
-  )
-
-  scene, sim = _make_scene_and_sim(device, xml, sensors=(raycast_cfg,))
-  sensor = scene["world_site_scan"]
-
-  # Baseline: unrotated body. Site at z=22 -> distance ~22m.
-  sim.step()
-  scene.update(dt=sim.cfg.mujoco.timestep)
-  sim.sense()
-  baseline_dist = sensor.data.distances.clone()
-  assert torch.allclose(baseline_dist, torch.full_like(baseline_dist, 22.0), atol=0.2)
-
-  # Apply combined pitch (30 deg) + roll (20 deg).
-  pitch = math.pi / 6
-  roll = math.pi / 9
-  cp, sp = math.cos(pitch / 2), math.sin(pitch / 2)
-  cr, sr = math.cos(roll / 2), math.sin(roll / 2)
-  # q_pitch (around X) then q_roll (around Y): q = q_roll * q_pitch
-  qw = cr * cp
-  qx = cr * sp
-  qy = sr * cp
-  qz = -sr * sp
-  sim.data.qpos[0, 3:7] = torch.tensor([qw, qx, qy, qz], device=device)
-  sim.step()
-  scene.update(dt=sim.cfg.mujoco.timestep)
-  sim.sense()
-  rotated_dist = sensor.data.distances.clone()
-
-  # With world alignment, distance should remain ~22m.
-  assert torch.allclose(rotated_dist, baseline_dist, atol=0.5), (
-    f"Expected ~22m after pitch+roll, got {rotated_dist}"
-  )
+  assert data.pos_w[0, 2].item() == pytest.approx(1.0, abs=0.1)
+  assert data.distances[0, 0].item() == pytest.approx(1.0, abs=0.1)


### PR DESCRIPTION
Generalizes `RayCastSensor` to support multiple attachment frames from a single sensor instance, so you can cast rays from e.g. all four feet on a quadruped without creating separate sensors.

**Multi-frame sensing.** `frame` now accepts a tuple of `ObjRef`. The ray pattern is tiled across all frames, each frame's parent body is excluded independently, and output distances are `[B, F*N]`. New `frame_pos_w` and `frame_quat_w` fields on `RayCastData` expose per-frame world poses. `height_scan` automatically uses each frame's Z for terrain-relative height computation.

**Ring pattern.** New `RingPatternCfg` places rays in concentric rings around each attachment frame.

**Direction and origin are now decoupled.** `ray_alignment` controls ray direction only. The ray origin is always the physical frame position (`site_xpos` / `geom_xpos`). Previously (#778), non-base alignment modes also projected the site offset through the alignment rotation to stabilize the origin for trunk-mounted sensors. That projection gives wrong positions for sensors on articulated limbs (e.g. foot sites on bent legs), because it ignores the parent body's rotation. Since every terrain scan config in practice attaches to a body frame (which is unaffected), this change is safe. If a stable projected origin is needed for a site with a large offset, use a body frame instead.

**Per-sensor debug viz toggles.** Raycast sensors with `debug_vis=True` now get individual checkboxes in the Viser viewer's Debug Viz panel, matching the existing pattern for command terms. Toggling while paused triggers an immediate redraw.