### PR TITLE
Add per-foot height sensor for terrain-aware gait rewards

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -128,6 +128,11 @@ Added
   ``frame_pos_w`` and ``frame_quat_w``.
 - ``RingPatternCfg`` ray pattern for concentric ring sampling around each
   frame.
+- ``TerrainHeightSensor``, a ``RayCastSensor`` subclass that computes
+  per-frame vertical clearance above terrain (``sensor.data.heights``).
+  Velocity task configs now use it for ``feet_clearance``,
+  ``feet_swing_height``, and ``foot_height``, replacing the previous
+  world-Z proxy that was incorrect on rough terrain.
 - Cloud training support via `SkyPilot <https://skypilot.readthedocs.io/>`_
   and Lambda Cloud, with documentation covering setup, monitoring, and
   cost management.

--- a/docs/source/sensors/raycast_sensor.rst
+++ b/docs/source/sensors/raycast_sensor.rst
@@ -265,3 +265,35 @@ Examples
         max_distance=3.0,
         include_geom_groups=(0,),
     )
+
+
+TerrainHeightSensor
+-------------------
+
+``TerrainHeightSensor`` is a thin ``RayCastSensor`` subclass that adds
+per-frame vertical clearance to the sensor data. It computes
+``frame_z - hit_z`` for each ray, replaces misses with ``max_distance``,
+and reduces across rays per frame.
+
+.. code-block:: python
+
+    from mjlab.sensor import TerrainHeightSensorCfg, RingPatternCfg, ObjRef
+
+    cfg = TerrainHeightSensorCfg(
+        name="foot_height",
+        frame=(
+            ObjRef(type="site", name="left_foot", entity="robot"),
+            ObjRef(type="site", name="right_foot", entity="robot"),
+        ),
+        pattern=RingPatternCfg.single_ring(radius=0.04, num_samples=4),
+        max_distance=1.0,
+        include_geom_groups=(0,),
+    )
+
+    # At runtime:
+    sensor = env.scene["foot_height"]
+    sensor.data.heights    # [B, F] vertical clearance per foot
+    sensor.data.distances  # [B, N] raw ray distances (inherited)
+
+The ``reduction`` config field controls how rays are aggregated within
+each frame: ``"min"`` (default), ``"max"``, or ``"mean"``.

--- a/src/mjlab/sensor/__init__.py
+++ b/src/mjlab/sensor/__init__.py
@@ -19,3 +19,10 @@ from mjlab.sensor.raycast_sensor import RingPatternCfg as RingPatternCfg
 from mjlab.sensor.sensor import Sensor as Sensor
 from mjlab.sensor.sensor import SensorCfg as SensorCfg
 from mjlab.sensor.sensor_context import SensorContext as SensorContext
+from mjlab.sensor.terrain_height_sensor import TerrainHeightData as TerrainHeightData
+from mjlab.sensor.terrain_height_sensor import (
+  TerrainHeightSensor as TerrainHeightSensor,
+)
+from mjlab.sensor.terrain_height_sensor import (
+  TerrainHeightSensorCfg as TerrainHeightSensorCfg,
+)

--- a/src/mjlab/sensor/raycast_sensor.py
+++ b/src/mjlab/sensor/raycast_sensor.py
@@ -1,190 +1,10 @@
 """Raycast sensor for terrain and obstacle detection.
 
-Ray Patterns
-------------
+Provides :class:`RayCastSensor` and :class:`RayCastSensorCfg` for BVH-accelerated
+raycasting with grid, pinhole camera, and ring patterns. Supports multi-frame
+attachment, configurable ray alignment, and geom group filtering.
 
-This module provides three ray pattern types for different use cases:
-
-**Grid Pattern** - Parallel rays in a 2D grid::
-
-    Camera at any height:
-          ↓   ↓   ↓   ↓   ↓      ← All rays point same direction
-          ↓   ↓   ↓   ↓   ↓
-          ↓   ↓   ↓   ↓   ↓
-        ──●───●───●───●───●──    ← Fixed spacing (e.g., 10cm apart)
-             Ground
-
-- Rays are parallel (all point in the same direction, e.g., -Z down)
-- Spacing is defined in world units (meters)
-- Height doesn't affect the hit pattern - same footprint regardless of altitude
-- Good for: height maps, terrain scanning with consistent spatial sampling
-
-**Pinhole Camera Pattern** - Diverging rays from a single point::
-
-    Camera LOW:                    Camera HIGH:
-             📷                            📷
-            /|\\                          /  |  \\
-           / | \\                        /   |   \\
-          /  |  \\                      /    |    \\
-        ─●───●───●─                 ───●─────●─────●───
-        (small footprint)           (large footprint)
-
-- Rays diverge from a single point (like light entering a camera)
-- FOV is fixed in angular units (degrees)
-- Higher altitude → wider ground coverage, more spread between hits
-- Lower altitude → tighter ground coverage, denser hits
-- Good for: simulating depth cameras, LiDAR with angular resolution
-
-**Ring Pattern** - Rays in concentric rings around the origin::
-
-    Ring (8 samples):
-         ●   ●
-       ●       ●     ← evenly spaced on circle
-       ●       ●
-         ●   ●
-           ●         ← center (optional)
-
-- Rays cast from offsets arranged in rings around the attachment frame
-- Supports multiple concentric rings at different radii
-- Good for: per-site height sensing, foot clearance, terrain sampling
-
-**Pattern Comparison**:
-
-============== ==================== ========================== =================
-Aspect         Grid                 Pinhole                    Ring
-============== ==================== ========================== =================
-Ray direction  All parallel         Diverge from origin        All parallel
-Spacing        Meters               Degrees (FOV)              Radius + count
-Height affect  No                   Yes                        No
-Real-world     Orthographic proj.   Perspective camera / LiDAR Terrain probe
-============== ==================== ========================== =================
-
-The pinhole behavior matches real depth sensors (RealSense, LiDAR) - when
-you're farther from an object, each pixel covers more area.
-
-
-Frame Attachment
-----------------
-
-Rays are attached to one or more frames in the scene via ``ObjRef``. Supported
-frame types:
-
-- **body**: Attach to a body's origin. Rays follow body position and orientation.
-- **site**: Attach to a site. Useful for precise placement or offset from body.
-- **geom**: Attach to a geometry. Useful for sensors mounted on specific parts.
-
-Single frame::
-
-    from mjlab.sensor import ObjRef, RayCastSensorCfg, GridPatternCfg
-
-    cfg = RayCastSensorCfg(
-        name="terrain_scan",
-        frame=ObjRef(type="body", name="base", entity="robot"),
-        pattern=GridPatternCfg(size=(1.0, 1.0), resolution=0.1),
-    )
-
-Multiple frames (e.g. per-foot height sensing)::
-
-    cfg = RayCastSensorCfg(
-        name="foot_heights",
-        frame=(
-            ObjRef(type="site", name="left_foot", entity="robot"),
-            ObjRef(type="site", name="right_foot", entity="robot"),
-        ),
-        pattern=RingPatternCfg.single_ring(radius=0.05, num_samples=8),
-    )
-
-With multiple frames, the output ``distances`` has shape ``[B, F*N]`` where
-F is the number of frames and N is rays per frame. Each frame's parent body
-is excluded independently when ``exclude_parent_body`` is True.
-
-The ``exclude_parent_body`` option (default: True) prevents rays from hitting
-the body they're attached to.
-
-
-Ray Alignment
--------------
-
-The ``ray_alignment`` setting controls how rays orient relative to the frame::
-
-    Robot tilted 30°:
-
-    "base" (default)          "yaw"                    "world"
-    Rays tilt with body       Rays stay level          Rays fixed to world
-          ↘ ↓ ↙                    ↓ ↓ ↓                    ↓ ↓ ↓
-           \\|/                     |||                      |||
-            🤖  ← tilted            🤖  ← tilted             🤖  ← tilted
-           /                       /                        /
-
-- **base**: Full position + rotation. Rays rotate with the body. Good for
-  body-mounted sensors that should scan relative to the robot's orientation.
-
-- **yaw**: Position + yaw only, ignores pitch/roll. Rays always point straight
-  down regardless of body tilt. Good for height maps where you want consistent
-  vertical sampling even when the robot is on a slope.
-
-- **world**: Fixed in world frame, only position follows body. Rays always
-  point in a fixed world direction. Good for gravity-aligned measurements.
-
-
-Debug Visualization
--------------------
-
-Enable visualization with ``debug_vis=True`` and customize via ``VizCfg``::
-
-    cfg = RayCastSensorCfg(
-        name="scan",
-        frame=ObjRef(type="body", name="base", entity="robot"),
-        pattern=GridPatternCfg(),
-        debug_vis=True,
-        viz=RayCastSensorCfg.VizCfg(
-            hit_color=(0, 1, 0, 0.8),      # Green for hits
-            miss_color=(1, 0, 0, 0.4),     # Red for misses
-            show_rays=True,                 # Draw ray arrows
-            show_normals=True,              # Draw surface normals
-            normal_color=(1, 1, 0, 1),     # Yellow normals
-        ),
-    )
-
-Visualization options:
-
-- ``hit_color`` / ``miss_color``: RGBA colors for ray arrows
-- ``hit_sphere_color`` / ``hit_sphere_radius``: Spheres at hit points
-- ``show_rays``: Draw arrows from origin to hit/miss points
-- ``show_normals`` / ``normal_color`` / ``normal_length``: Surface normal arrows
-
-
-Geom Group Filtering
---------------------
-
-MuJoCo geoms can be assigned to groups 0-5. Use ``include_geom_groups`` to
-filter which groups the rays can hit::
-
-    cfg = RayCastSensorCfg(
-        name="terrain_only",
-        frame=ObjRef(type="body", name="base", entity="robot"),
-        pattern=GridPatternCfg(),
-        include_geom_groups=(0, 1),  # Only hit geoms in groups 0 and 1
-    )
-
-This is useful for ignoring certain geometry (e.g., visual-only geoms in
-group 3) while still detecting collisions with terrain (group 0).
-
-
-Output Data
------------
-
-Access sensor data via the ``data`` property, which returns ``RayCastData``:
-
-- ``distances``: [B, N] Distance to hit, or -1 if no hit / beyond max_distance
-- ``hit_pos_w``: [B, N, 3] World-space hit positions
-- ``normals_w``: [B, N, 3] Surface normals at hit points (world frame)
-- ``pos_w``: [B, 3] First frame position (backward compat)
-- ``quat_w``: [B, 4] First frame orientation (backward compat)
-- ``frame_pos_w``: [B, F, 3] All frame positions
-- ``frame_quat_w``: [B, F, 4] All frame orientations
-
-Where B = environments, F = frames, N = F * num_rays_per_frame (total rays).
+See :doc:`/sensors/raycast_sensor` for usage guide and examples.
 """
 
 from __future__ import annotations
@@ -883,7 +703,7 @@ class RayCastSensor(Sensor[RayCastData]):
     # affects ray directions (applied to frame_mat below).
     pos_list: list[torch.Tensor] = []
     mat_list: list[torch.Tensor] = []
-    for frame_type, obj_id, _body_id in self._frame_infos:
+    for frame_type, obj_id, _ in self._frame_infos:
       if frame_type == "body":
         pos_list.append(self._data.xpos[:, obj_id])
         mat_list.append(self._data.xmat[:, obj_id].view(-1, 3, 3))
@@ -953,19 +773,21 @@ class RayCastSensor(Sensor[RayCastData]):
     F = self._num_frames
 
     assert self._ray_dist is not None and self._ray_normal is not None
-    self._distances = wp.to_torch(self._ray_dist)
-    self._normals_w = wp.to_torch(self._ray_normal).view(B, self._num_rays, 3)
-    self._distances[self._distances > self.cfg.max_distance] = -1.0
+    distances = wp.to_torch(self._ray_dist)
+    normals_w = wp.to_torch(self._ray_normal).view(B, self._num_rays, 3)
+    distances[distances > self.cfg.max_distance] = -1.0
 
-    hit_mask = self._distances >= 0
+    hit_mask = distances >= 0
     hit_pos_w = self._cached_world_origins.clone()
     hit_pos_w[hit_mask] = self._cached_world_origins[
       hit_mask
-    ] + self._cached_world_rays[hit_mask] * self._distances[hit_mask].unsqueeze(-1)
+    ] + self._cached_world_rays[hit_mask] * distances[hit_mask].unsqueeze(-1)
     self._hit_pos_w = hit_pos_w
 
     # Zero out normals for misses.
-    self._normals_w[~hit_mask] = 0.0
+    normals_w[~hit_mask] = 0.0
+    self._distances = distances
+    self._normals_w = normals_w
 
     # All frames: [B, F, 3] / [B, F, 4].
     self._frame_pos_w = self._cached_frame_pos

--- a/src/mjlab/sensor/terrain_height_sensor.py
+++ b/src/mjlab/sensor/terrain_height_sensor.py
@@ -1,0 +1,83 @@
+"""Terrain height sensor for per-frame vertical clearance."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+
+from mjlab.sensor.raycast_sensor import RayCastData, RayCastSensor, RayCastSensorCfg
+
+
+@dataclass
+class TerrainHeightData(RayCastData):
+  """Raycast data extended with per-frame terrain clearance.
+
+  Inherits all fields from :class:`RayCastData` (distances, hit positions, normals,
+  frame poses) and adds :attr:`heights`.
+  """
+
+  heights: torch.Tensor
+  """Vertical clearance per frame. Shape is ``[B, F]`` when a reduction is
+  applied, or ``[B, F, N]`` with ``reduction="none"``."""
+
+
+@dataclass
+class TerrainHeightSensorCfg(RayCastSensorCfg):
+  """RayCastSensor that reports per-frame vertical clearance above terrain.
+
+  Inherits all raycasting configuration from :class:`RayCastSensorCfg`. The sensor
+  computes ``frame_z - hit_z`` for each ray and reduces across rays per frame using
+  the chosen :attr:`reduction`.
+  """
+
+  reduction: str = "min"
+  """How to aggregate rays within each frame: ``"min"``, ``"max"``, ``"mean"``,
+  or ``"none"`` (no reduction, returns ``[B, F, N]``).
+  Defaults to ``"min"`` (closest terrain point)."""
+
+  def build(self) -> TerrainHeightSensor:
+    return TerrainHeightSensor(self)
+
+
+class TerrainHeightSensor(RayCastSensor):
+  """Per-frame vertical clearance above terrain.
+
+  Inherits all raycasting from :class:`RayCastSensor`. Access terrain heights via
+  ``sensor.data.heights`` (shape ``[B, F]``).
+  """
+
+  cfg: TerrainHeightSensorCfg
+
+  @property
+  def data(self) -> TerrainHeightData:
+    """Raycast data with per-frame terrain clearance heights."""
+    return super().data  # type: ignore[return-value]
+
+  def _compute_data(self) -> TerrainHeightData:
+    raw = super()._compute_data()
+    F, N = self.num_frames, self.num_rays_per_frame
+    B = raw.distances.shape[0]
+
+    frame_z = raw.frame_pos_w[:, :, 2]  # [B, F]
+    hit_z = raw.hit_pos_w[:, :, 2].view(B, F, N)  # [B, F, N]
+    heights = frame_z.unsqueeze(-1) - hit_z  # [B, F, N]
+
+    miss = raw.distances.view(B, F, N) < 0
+    heights = torch.where(
+      miss, torch.full_like(heights, self.cfg.max_distance), heights
+    )
+
+    reduction = self.cfg.reduction
+    if reduction == "min":
+      reduced = heights.min(dim=-1).values
+    elif reduction == "max":
+      reduced = heights.max(dim=-1).values
+    elif reduction == "mean":
+      reduced = heights.mean(dim=-1)
+    elif reduction == "none":
+      reduced = heights
+    else:
+      raise ValueError(f"Unknown reduction: {reduction!r}")
+
+    return TerrainHeightData(**vars(raw), heights=reduced)

--- a/src/mjlab/tasks/velocity/config/g1/env_cfgs.py
+++ b/src/mjlab/tasks/velocity/config/g1/env_cfgs.py
@@ -9,7 +9,14 @@ from mjlab.envs import mdp as envs_mdp
 from mjlab.envs.mdp.actions import JointPositionActionCfg
 from mjlab.managers.event_manager import EventTermCfg
 from mjlab.managers.reward_manager import RewardTermCfg
-from mjlab.sensor import ContactMatch, ContactSensorCfg, ObjRef, RayCastSensorCfg
+from mjlab.sensor import (
+  ContactMatch,
+  ContactSensorCfg,
+  ObjRef,
+  RayCastSensorCfg,
+  RingPatternCfg,
+  TerrainHeightSensorCfg,
+)
 from mjlab.tasks.velocity import mdp
 from mjlab.tasks.velocity.mdp import UniformVelocityCommandCfg
 from mjlab.tasks.velocity.velocity_env_cfg import make_velocity_env_cfg
@@ -21,7 +28,7 @@ def unitree_g1_rough_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
 
   cfg.sim.mujoco.ccd_iterations = 500
   cfg.sim.contact_sensor_maxmatch = 500
-  cfg.sim.nconmax = 45
+  cfg.sim.nconmax = 70
 
   cfg.scene.entities = {"robot": get_g1_robot_cfg()}
 
@@ -36,6 +43,15 @@ def unitree_g1_rough_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
   geom_names = tuple(
     f"{side}_foot{i}_collision" for side in ("left", "right") for i in range(1, 8)
   )
+
+  # Wire foot height scan to per-foot sites.
+  for sensor in cfg.scene.sensors or ():
+    if sensor.name == "foot_height_scan":
+      assert isinstance(sensor, TerrainHeightSensorCfg)
+      sensor.frame = tuple(
+        ObjRef(type="site", name=s, entity="robot") for s in site_names
+      )
+      sensor.pattern = RingPatternCfg.single_ring(radius=0.03, num_samples=6)
 
   feet_ground_cfg = ContactSensorCfg(
     name="feet_ground_contact",
@@ -76,10 +92,6 @@ def unitree_g1_rough_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
   twist_cmd = cfg.commands["twist"]
   assert isinstance(twist_cmd, UniformVelocityCommandCfg)
   twist_cmd.viz.z_offset = 1.15
-
-  cfg.observations["critic"].terms["foot_height"].params[
-    "asset_cfg"
-  ].site_names = site_names
 
   cfg.events["foot_friction"].params["asset_cfg"].geom_names = geom_names
   cfg.events["base_com"].params["asset_cfg"].body_names = ("torso_link",)
@@ -135,7 +147,7 @@ def unitree_g1_rough_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
   cfg.rewards["upright"].params["asset_cfg"].body_names = ("torso_link",)
   cfg.rewards["body_ang_vel"].params["asset_cfg"].body_names = ("torso_link",)
 
-  for reward_name in ["foot_clearance", "foot_swing_height", "foot_slip"]:
+  for reward_name in ["foot_clearance", "foot_slip"]:
     cfg.rewards[reward_name].params["asset_cfg"].site_names = site_names
 
   cfg.rewards["body_ang_vel"].weight = -0.05

--- a/src/mjlab/tasks/velocity/config/go1/env_cfgs.py
+++ b/src/mjlab/tasks/velocity/config/go1/env_cfgs.py
@@ -11,7 +11,14 @@ from mjlab.envs import mdp as envs_mdp
 from mjlab.envs.mdp.actions import JointPositionActionCfg
 from mjlab.managers import TerminationTermCfg
 from mjlab.managers.event_manager import EventTermCfg
-from mjlab.sensor import ContactMatch, ContactSensorCfg, ObjRef, RayCastSensorCfg
+from mjlab.sensor import (
+  ContactMatch,
+  ContactSensorCfg,
+  ObjRef,
+  RayCastSensorCfg,
+  RingPatternCfg,
+  TerrainHeightSensorCfg,
+)
 from mjlab.tasks.velocity import mdp
 from mjlab.tasks.velocity.mdp import UniformVelocityCommandCfg
 from mjlab.tasks.velocity.velocity_env_cfg import make_velocity_env_cfg
@@ -40,6 +47,15 @@ def unitree_go1_rough_env_cfg(
   foot_names = ("FR", "FL", "RR", "RL")
   site_names = ("FR", "FL", "RR", "RL")
   geom_names = tuple(f"{name}_foot_collision" for name in foot_names)
+
+  # Wire foot height scan to per-foot sites.
+  for sensor in cfg.scene.sensors or ():
+    if sensor.name == "foot_height_scan":
+      assert isinstance(sensor, TerrainHeightSensorCfg)
+      sensor.frame = tuple(
+        ObjRef(type="site", name=s, entity="robot") for s in site_names
+      )
+      sensor.pattern = RingPatternCfg.single_ring(radius=0.04, num_samples=4)
 
   feet_ground_cfg = ContactSensorCfg(
     name="feet_ground_contact",
@@ -82,10 +98,6 @@ def unitree_go1_rough_env_cfg(
   cfg.viewer.distance = 1.5
   cfg.viewer.elevation = -10.0
 
-  cfg.observations["critic"].terms["foot_height"].params[
-    "asset_cfg"
-  ].site_names = site_names
-
   cfg.events["foot_friction"].params["asset_cfg"].geom_names = geom_names
   cfg.events["base_com"].params["asset_cfg"].body_names = ("trunk",)
 
@@ -105,7 +117,7 @@ def unitree_go1_rough_env_cfg(
   cfg.rewards["upright"].params["asset_cfg"].body_names = ("trunk",)
   cfg.rewards["body_ang_vel"].params["asset_cfg"].body_names = ("trunk",)
 
-  for reward_name in ["foot_clearance", "foot_swing_height", "foot_slip"]:
+  for reward_name in ["foot_clearance", "foot_slip"]:
     cfg.rewards[reward_name].params["asset_cfg"].site_names = site_names
 
   cfg.rewards["body_ang_vel"].weight = 0.0

--- a/src/mjlab/tasks/velocity/mdp/observations.py
+++ b/src/mjlab/tasks/velocity/mdp/observations.py
@@ -4,21 +4,24 @@ from typing import TYPE_CHECKING
 
 import torch
 
-from mjlab.entity import Entity
-from mjlab.managers.scene_entity_config import SceneEntityCfg
 from mjlab.sensor import ContactSensor
+from mjlab.sensor.terrain_height_sensor import TerrainHeightSensor
 
 if TYPE_CHECKING:
   from mjlab.envs import ManagerBasedRlEnv
 
-_DEFAULT_ASSET_CFG = SceneEntityCfg("robot")
 
+def foot_height(env: ManagerBasedRlEnv, sensor_name: str) -> torch.Tensor:
+  """Per-foot vertical clearance above terrain.
 
-def foot_height(
-  env: ManagerBasedRlEnv, asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG
-) -> torch.Tensor:
-  asset: Entity = env.scene[asset_cfg.name]
-  return asset.data.site_pos_w[:, asset_cfg.site_ids, 2]  # (num_envs, num_sites)
+  Returns:
+    Tensor of shape [B, F] where F is the number of frames (feet).
+  """
+  sensor = env.scene[sensor_name]
+  assert isinstance(sensor, TerrainHeightSensor), (
+    f"foot_height requires a TerrainHeightSensor, got {type(sensor).__name__}"
+  )
+  return sensor.data.heights
 
 
 def foot_air_time(env: ManagerBasedRlEnv, sensor_name: str) -> torch.Tensor:

--- a/src/mjlab/tasks/velocity/mdp/rewards.py
+++ b/src/mjlab/tasks/velocity/mdp/rewards.py
@@ -8,6 +8,7 @@ from mjlab.entity import Entity
 from mjlab.managers.reward_manager import RewardTermCfg
 from mjlab.managers.scene_entity_config import SceneEntityCfg
 from mjlab.sensor import BuiltinSensor, ContactSensor
+from mjlab.sensor.terrain_height_sensor import TerrainHeightSensor
 from mjlab.utils.lab_api.math import quat_apply_inverse
 from mjlab.utils.lab_api.string import (
   resolve_matching_names_values,
@@ -167,16 +168,21 @@ def feet_air_time(
 def feet_clearance(
   env: ManagerBasedRlEnv,
   target_height: float,
+  height_sensor_name: str,
   command_name: str | None = None,
   command_threshold: float = 0.01,
   asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
 ) -> torch.Tensor:
   """Penalize deviation from target clearance height, weighted by foot velocity."""
   asset: Entity = env.scene[asset_cfg.name]
-  foot_z = asset.data.site_pos_w[:, asset_cfg.site_ids, 2]  # [B, N]
-  foot_vel_xy = asset.data.site_lin_vel_w[:, asset_cfg.site_ids, :2]  # [B, N, 2]
-  vel_norm = torch.norm(foot_vel_xy, dim=-1)  # [B, N]
-  delta = torch.abs(foot_z - target_height)  # [B, N]
+  height_sensor = env.scene[height_sensor_name]
+  assert isinstance(height_sensor, TerrainHeightSensor), (
+    f"feet_clearance requires a TerrainHeightSensor, got {type(height_sensor).__name__}"
+  )
+  foot_height = height_sensor.data.heights  # [B, F]
+  foot_vel_xy = asset.data.site_lin_vel_w[:, asset_cfg.site_ids, :2]  # [B, F, 2]
+  vel_norm = torch.norm(foot_vel_xy, dim=-1)  # [B, F]
+  delta = torch.abs(foot_height - target_height)  # [B, F]
   cost = torch.sum(delta * vel_norm, dim=1)  # [B]
   if command_name is not None:
     command = env.command_manager.get_command(command_name)
@@ -193,10 +199,13 @@ class feet_swing_height:
   """Penalize deviation from target swing height, evaluated at landing."""
 
   def __init__(self, cfg: RewardTermCfg, env: ManagerBasedRlEnv):
-    self.sensor_name = cfg.params["sensor_name"]
-    self.site_names = cfg.params["asset_cfg"].site_names
+    height_sensor = env.scene[cfg.params["height_sensor_name"]]
+    assert isinstance(height_sensor, TerrainHeightSensor), (
+      f"feet_swing_height requires a TerrainHeightSensor, got {type(height_sensor).__name__}"
+    )
+    num_feet = height_sensor.num_frames
     self.peak_heights = torch.zeros(
-      (env.num_envs, len(self.site_names)), device=env.device, dtype=torch.float32
+      (env.num_envs, num_feet), device=env.device, dtype=torch.float32
     )
     self.step_dt = env.step_dt
 
@@ -204,16 +213,16 @@ class feet_swing_height:
     self,
     env: ManagerBasedRlEnv,
     sensor_name: str,
+    height_sensor_name: str,
     target_height: float,
     command_name: str,
     command_threshold: float,
-    asset_cfg: SceneEntityCfg,
   ) -> torch.Tensor:
-    asset: Entity = env.scene[asset_cfg.name]
     contact_sensor: ContactSensor = env.scene[sensor_name]
     command = env.command_manager.get_command(command_name)
     assert command is not None
-    foot_heights = asset.data.site_pos_w[:, asset_cfg.site_ids, 2]
+    height_sensor: TerrainHeightSensor = env.scene[height_sensor_name]
+    foot_heights = height_sensor.data.heights
     in_air = contact_sensor.data.found == 0
     self.peak_heights = torch.where(
       in_air,

--- a/src/mjlab/tasks/velocity/velocity_env_cfg.py
+++ b/src/mjlab/tasks/velocity/velocity_env_cfg.py
@@ -21,7 +21,12 @@ from mjlab.managers.reward_manager import RewardTermCfg
 from mjlab.managers.scene_entity_config import SceneEntityCfg
 from mjlab.managers.termination_manager import TerminationTermCfg
 from mjlab.scene import SceneCfg
-from mjlab.sensor import GridPatternCfg, ObjRef, RayCastSensorCfg
+from mjlab.sensor import (
+  GridPatternCfg,
+  ObjRef,
+  RayCastSensorCfg,
+  TerrainHeightSensorCfg,
+)
 from mjlab.sim import MujocoCfg, SimulationCfg
 from mjlab.tasks.velocity import mdp
 from mjlab.tasks.velocity.mdp import UniformVelocityCommandCfg
@@ -45,8 +50,23 @@ def make_velocity_env_cfg() -> ManagerBasedRlEnvCfg:
     pattern=GridPatternCfg(size=(1.6, 1.0), resolution=0.1),
     max_distance=5.0,
     exclude_parent_body=True,
+    include_geom_groups=(0,),  # Terrain only.
     debug_vis=True,
-    viz=RayCastSensorCfg.VizCfg(show_normals=True),
+  )
+
+  foot_height_scan = TerrainHeightSensorCfg(
+    name="foot_height_scan",
+    frame=(),  # Set per-robot: frame and pattern.
+    ray_alignment="yaw",
+    max_distance=1.0,
+    exclude_parent_body=True,
+    include_geom_groups=(0,),  # Terrain only.
+    debug_vis=True,
+    viz=TerrainHeightSensorCfg.VizCfg(
+      show_rays=True,
+      hit_color=(1.0, 0.0, 1.0, 0.8),  # Magenta rays.
+      hit_sphere_color=(1.0, 0.0, 1.0, 1.0),
+    ),
   )
 
   ##
@@ -98,7 +118,7 @@ def make_velocity_env_cfg() -> ManagerBasedRlEnvCfg:
     ),
     "foot_height": ObservationTermCfg(
       func=mdp.foot_height,
-      params={"asset_cfg": SceneEntityCfg("robot", site_names=())},  # Set per-robot.
+      params={"sensor_name": "foot_height_scan"},
     ),
     "foot_air_time": ObservationTermCfg(
       func=mdp.foot_air_time,
@@ -311,6 +331,7 @@ def make_velocity_env_cfg() -> ManagerBasedRlEnvCfg:
       weight=-2.0,
       params={
         "target_height": 0.1,
+        "height_sensor_name": "foot_height_scan",
         "command_name": "twist",
         "command_threshold": 0.05,
         "asset_cfg": SceneEntityCfg("robot", site_names=()),  # Set per-robot.
@@ -321,10 +342,10 @@ def make_velocity_env_cfg() -> ManagerBasedRlEnvCfg:
       weight=-0.25,
       params={
         "sensor_name": "feet_ground_contact",
+        "height_sensor_name": "foot_height_scan",
         "target_height": 0.1,
         "command_name": "twist",
         "command_threshold": 0.05,
-        "asset_cfg": SceneEntityCfg("robot", site_names=()),  # Set per-robot.
       },
     ),
     "foot_slip": RewardTermCfg(
@@ -393,7 +414,7 @@ def make_velocity_env_cfg() -> ManagerBasedRlEnvCfg:
         terrain_generator=replace(ROUGH_TERRAINS_CFG),
         max_init_terrain_level=5,
       ),
-      sensors=(terrain_scan,),
+      sensors=(terrain_scan, foot_height_scan),
       num_envs=1,
       extent=2.0,
     ),

--- a/tests/test_foot_height_sensor.py
+++ b/tests/test_foot_height_sensor.py
@@ -1,0 +1,172 @@
+"""Tests for per-foot height sensor and terrain-aware rewards."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+from conftest import get_test_device, make_scene_and_sim
+
+from mjlab.sensor import ObjRef, RingPatternCfg, TerrainHeightSensorCfg
+from mjlab.sensor.terrain_height_sensor import TerrainHeightSensor
+
+# Platform top at z=0.5 (box center z=0.25, half-height 0.25).
+# Body at z=1.0, left_foot at z=0.8 (offset -0.2), right_foot at z=0.6 (offset -0.4).
+# Expected: left 0.3m above platform, right 0.1m above platform.
+# Both within max_distance=1.0.
+TWO_FEET_ABOVE_PLATFORM_XML = """
+  <mujoco>
+    <worldbody>
+      <geom name="platform" type="box" size="5 5 0.25" pos="0 0 0.25"/>
+      <body name="base" pos="0 0 1">
+        <freejoint name="free_joint"/>
+        <geom name="base_geom" type="sphere" size="0.05" mass="1.0"/>
+        <site name="left_foot" pos="-0.1 0 -0.2"/>
+        <site name="right_foot" pos="0.1 0 -0.4"/>
+      </body>
+    </worldbody>
+  </mujoco>
+"""
+
+# Stepped terrain: step top at z=0.4 for x<0, ground at z=0 for x>0.
+# Body at x=0, z=0.8. left_foot at x=-0.5 (over step), right_foot at x=0.5 (over ground).
+# Expected: left 0.4m above step, right 0.8m above ground.
+STEPPED_TERRAIN_XML = """
+  <mujoco>
+    <worldbody>
+      <geom name="ground" type="plane" size="5 5 0.1" pos="0 0 0"/>
+      <geom name="step" type="box" size="5 5 0.2" pos="-5 0 0.2"/>
+      <body name="base" pos="0 0 0.8">
+        <freejoint name="free_joint"/>
+        <geom name="base_geom" type="sphere" size="0.05" mass="1.0"/>
+        <site name="left_foot" pos="-0.5 0 0"/>
+        <site name="right_foot" pos="0.5 0 0"/>
+      </body>
+    </worldbody>
+  </mujoco>
+"""
+
+
+def _foot_sensor_cfg() -> TerrainHeightSensorCfg:
+  """Match the shipped config: yaw alignment, max_distance=1.0, group 0."""
+  return TerrainHeightSensorCfg(
+    name="foot_height_scan",
+    frame=(
+      ObjRef(type="site", name="left_foot", entity="robot"),
+      ObjRef(type="site", name="right_foot", entity="robot"),
+    ),
+    ray_alignment="yaw",
+    pattern=RingPatternCfg.single_ring(radius=0.04, num_samples=4),
+    max_distance=1.0,
+    exclude_parent_body=True,
+    include_geom_groups=(0,),
+  )
+
+
+@pytest.fixture(scope="module")
+def device():
+  return get_test_device()
+
+
+class _FakeEnv:
+  def __init__(self, scene):
+    self.scene = scene
+
+
+def test_foot_height_flat_platform(device):
+  """Two feet at different heights above a flat platform."""
+  cfg = _foot_sensor_cfg()
+  scene, sim = make_scene_and_sim(device, TWO_FEET_ABOVE_PLATFORM_XML, (cfg,))
+  sim.step()
+  sim.sense()
+
+  sensor: TerrainHeightSensor = scene["foot_height_scan"]
+  heights = sensor.data.heights
+
+  assert heights.shape == (1, 2)
+  # Left foot: z=0.8, platform top at z=0.5, height = 0.3.
+  assert heights[0, 0].item() == pytest.approx(0.3, abs=0.05)
+  # Right foot: z=0.6, platform top at z=0.5, height = 0.1.
+  assert heights[0, 1].item() == pytest.approx(0.1, abs=0.05)
+
+
+def test_foot_height_stepped_terrain(device):
+  """Feet over different terrain heights give different readings."""
+  cfg = _foot_sensor_cfg()
+  scene, sim = make_scene_and_sim(device, STEPPED_TERRAIN_XML, (cfg,))
+  sim.step()
+  sim.sense()
+
+  sensor: TerrainHeightSensor = scene["foot_height_scan"]
+  heights = sensor.data.heights
+
+  assert heights.shape == (1, 2)
+  # Left foot at x=-0.5, z=0.8, over step top at z=0.4 -> height ~0.4.
+  assert heights[0, 0].item() == pytest.approx(0.4, abs=0.1)
+  # Right foot at x=0.5, z=0.8, over ground at z=0 -> height ~0.8.
+  assert heights[0, 1].item() == pytest.approx(0.8, abs=0.1)
+
+
+def test_foot_height_observation(device):
+  """foot_height observation delegates to sensor.data.heights."""
+  from mjlab.tasks.velocity.mdp.observations import foot_height
+
+  cfg = _foot_sensor_cfg()
+  scene, sim = make_scene_and_sim(device, TWO_FEET_ABOVE_PLATFORM_XML, (cfg,))
+  sim.step()
+  sim.sense()
+
+  env = _FakeEnv(scene)
+  obs = foot_height(env, "foot_height_scan")  # type: ignore[invalid-argument-type]
+  sensor: TerrainHeightSensor = scene["foot_height_scan"]
+  direct = sensor.data.heights
+
+  assert torch.allclose(obs, direct)
+
+
+def test_foot_height_multi_env(device):
+  """Sensor works correctly across multiple environments."""
+  cfg = _foot_sensor_cfg()
+  scene, sim = make_scene_and_sim(
+    device, TWO_FEET_ABOVE_PLATFORM_XML, (cfg,), num_envs=4
+  )
+  sim.step()
+  sim.sense()
+
+  sensor: TerrainHeightSensor = scene["foot_height_scan"]
+  heights = sensor.data.heights
+
+  assert heights.shape == (4, 2)
+  # All envs should report same heights (identical geometry).
+  for i in range(4):
+    assert heights[i, 0].item() == pytest.approx(0.3, abs=0.05)
+    assert heights[i, 1].item() == pytest.approx(0.1, abs=0.05)
+
+
+def test_foot_height_miss_returns_max_distance(device):
+  """Feet beyond max_distance report max_distance, not -1."""
+  # Body at z=3 with feet at z=2.8 and z=2.6.
+  # max_distance=1.0, ground at z=0, so both feet are >1m above ground.
+  miss_xml = """
+    <mujoco>
+      <worldbody>
+        <geom name="floor" type="plane" size="5 5 0.1" pos="0 0 0"/>
+        <body name="base" pos="0 0 3">
+          <freejoint name="free_joint"/>
+          <geom name="base_geom" type="sphere" size="0.05" mass="1.0"/>
+          <site name="left_foot" pos="-0.1 0 -0.2"/>
+          <site name="right_foot" pos="0.1 0 -0.4"/>
+        </body>
+      </worldbody>
+    </mujoco>
+  """
+  cfg = _foot_sensor_cfg()
+  scene, sim = make_scene_and_sim(device, miss_xml, (cfg,))
+  sim.step()
+  sim.sense()
+
+  sensor: TerrainHeightSensor = scene["foot_height_scan"]
+  heights = sensor.data.heights
+
+  # Both feet are >1m above ground, beyond max_distance=1.0.
+  assert heights[0, 0].item() == pytest.approx(1.0, abs=0.01)
+  assert heights[0, 1].item() == pytest.approx(1.0, abs=0.01)


### PR DESCRIPTION
Foot height sensing now correctly measures vertical clearance above terrain instead of raw ray distances. This fixes feet_clearance, feet_swing_height, and foot_height observations which were computing incorrect values on non-flat terrain.

Adds RayCastSensor.per_frame_height() to compute true vertical heights (frame_z - hit_z) per frame.