### PR TITLE
Add per-terrain-type logging to terrain curriculum

### DIFF
--- a/src/mjlab/tasks/velocity/mdp/curriculums.py
+++ b/src/mjlab/tasks/velocity/mdp/curriculums.py
@@ -27,7 +27,7 @@ def terrain_levels_vel(
   env_ids: torch.Tensor,
   command_name: str,
   asset_cfg: SceneEntityCfg = _DEFAULT_SCENE_CFG,
-) -> torch.Tensor:
+) -> dict[str, torch.Tensor]:
   asset: Entity = env.scene[asset_cfg.name]
 
   terrain = env.scene.terrain
@@ -40,14 +40,15 @@ def terrain_levels_vel(
 
   # Compute the distance the robot walked.
   distance = torch.norm(
-    asset.data.root_link_pos_w[env_ids, :2] - env.scene.env_origins[env_ids, :2], dim=1
+    asset.data.root_link_pos_w[env_ids, :2] - env.scene.env_origins[env_ids, :2],
+    dim=1,
   )
 
   # Robots that walked far enough progress to harder terrains.
   move_up = distance > terrain_generator.size[0] / 2
 
-  # Robots that walked less than half of their required distance go to simpler
-  # terrains.
+  # Robots that walked less than half of their required distance go to
+  # simpler terrains.
   move_down = (
     distance < torch.norm(command[env_ids, :2], dim=1) * env.max_episode_length_s * 0.5
   )
@@ -56,7 +57,27 @@ def terrain_levels_vel(
   # Update terrain levels.
   terrain.update_env_origins(env_ids, move_up, move_down)
 
-  return torch.mean(terrain.terrain_levels.float())
+  # Compute per-terrain-type mean levels.
+  levels = terrain.terrain_levels.float()
+  result: dict[str, torch.Tensor] = {
+    "mean": torch.mean(levels),
+    "max": torch.max(levels),
+  }
+
+  # In curriculum mode num_cols == num_terrains (one column per type),
+  # so the column index directly maps to the sub-terrain name.
+  sub_terrain_names = list(terrain_generator.sub_terrains.keys())
+  terrain_origins = terrain.terrain_origins
+  assert terrain_origins is not None
+  num_cols = terrain_origins.shape[1]
+  if num_cols == len(sub_terrain_names):
+    types = terrain.terrain_types
+    for i, name in enumerate(sub_terrain_names):
+      mask = types == i
+      if mask.any():
+        result[name] = torch.mean(levels[mask])
+
+  return result
 
 
 def commands_vel(


### PR DESCRIPTION
Previously we only logged a single `Curriculum/terrain_levels` scalar (the overall mean). Now we log per-terrain-type means (e.g. `Curriculum/terrain_levels/flat`, `Curriculum/terrain_levels/stairs`) so we can see which terrain types robots are progressing on vs struggling with.

Histogram logging is left for a follow-up PR.