### PR TITLE
Update mujoco-warp to 875c4caf

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,7 +135,7 @@ torch = [
   { index = "pytorch-cpu", extra = "cpu", marker = "sys_platform != 'darwin'" },
 ]
 mujoco = { index = "mujoco" }
-mujoco-warp = { git = "https://github.com/google-deepmind/mujoco_warp", rev = "652abe0e41be5894a27156661d1ed936e36ebde3" }
+mujoco-warp = { git = "https://github.com/google-deepmind/mujoco_warp", rev = "875c4caf06d71b12b2036c327e7a07ce08a78b9a" }
 
 [tool.ruff]
 src = ["src"]  # Helpful for recognizing first-party imports.

--- a/uv.lock
+++ b/uv.lock
@@ -1686,7 +1686,7 @@ requires-dist = [
     { name = "imageio-ffmpeg" },
     { name = "mediapy", specifier = ">=1.2.6" },
     { name = "mujoco", specifier = ">=3.6.0", index = "https://py.mujoco.org/" },
-    { name = "mujoco-warp", git = "https://github.com/google-deepmind/mujoco_warp?rev=652abe0e41be5894a27156661d1ed936e36ebde3" },
+    { name = "mujoco-warp", git = "https://github.com/google-deepmind/mujoco_warp?rev=875c4caf06d71b12b2036c327e7a07ce08a78b9a" },
     { name = "onnxscript", specifier = ">=0.5.4" },
     { name = "prettytable" },
     { name = "rsl-rl-lib", specifier = "==5.0.1" },
@@ -1894,7 +1894,7 @@ wheels = [
 [[package]]
 name = "mujoco-warp"
 version = "3.6.0"
-source = { git = "https://github.com/google-deepmind/mujoco_warp?rev=652abe0e41be5894a27156661d1ed936e36ebde3#652abe0e41be5894a27156661d1ed936e36ebde3" }
+source = { git = "https://github.com/google-deepmind/mujoco_warp?rev=875c4caf06d71b12b2036c327e7a07ce08a78b9a#875c4caf06d71b12b2036c327e7a07ce08a78b9a" }
 dependencies = [
     { name = "absl-py" },
     { name = "etils", extra = ["epath"] },


### PR DESCRIPTION
Updates the mujoco-warp dependency to commit 875c4caf06d71b12b2036c327e7a07ce08a78b9a.

This should eliminate the GJK/EPA stdout spam.