### PR TITLE
Modify Go1 feet contact params

### DIFF
--- a/src/mjlab/asset_zoo/robots/unitree_go1/go1_constants.py
+++ b/src/mjlab/asset_zoo/robots/unitree_go1/go1_constants.py
@@ -115,16 +115,16 @@ FEET_ONLY_COLLISION = CollisionCfg(
   solimp=(0.9, 0.95, 0.023),
 )
 
-# This enables all collisions, excluding self collisions.
-# Foot collisions are given custom condim, friction and solimp.
+# This enables all collisions.
+# Foot collisions are given custom condim, friction.
 FULL_COLLISION = CollisionCfg(
   geom_names_expr=(".*_collision",),
-  condim={_foot_regex: 3, ".*_collision": 1},
+  # Harden all collision geoms.
+  solref=(0.01, 1),
+  # Configure feet colliders. Other colliders are frictionless (condim=1).
+  condim={_foot_regex: 6, ".*_collision": 1},
   priority={_foot_regex: 1},
-  friction={_foot_regex: (0.6,)},
-  solimp={_foot_regex: (0.9, 0.95, 0.023)},
-  contype=1,
-  conaffinity=0,
+  friction={_foot_regex: (1, 5e-3, 5e-4)},
 )
 
 ##

--- a/src/mjlab/tasks/velocity/config/go1/env_cfgs.py
+++ b/src/mjlab/tasks/velocity/config/go1/env_cfgs.py
@@ -11,6 +11,7 @@ from mjlab.envs import mdp as envs_mdp
 from mjlab.envs.mdp.actions import JointPositionActionCfg
 from mjlab.managers import TerminationTermCfg
 from mjlab.managers.event_manager import EventTermCfg
+from mjlab.managers.scene_entity_config import SceneEntityCfg
 from mjlab.sensor import (
   ContactMatch,
   ContactSensorCfg,
@@ -33,6 +34,8 @@ def unitree_go1_rough_env_cfg(
   cfg = make_velocity_env_cfg()
 
   cfg.sim.mujoco.ccd_iterations = 500
+  cfg.sim.mujoco.impratio = 10
+  cfg.sim.mujoco.cone = "elliptic"
   cfg.sim.contact_sensor_maxmatch = 500
 
   cfg.scene.entities = {"robot": get_go1_robot_cfg()}
@@ -98,7 +101,43 @@ def unitree_go1_rough_env_cfg(
   cfg.viewer.distance = 1.5
   cfg.viewer.elevation = -10.0
 
-  cfg.events["foot_friction"].params["asset_cfg"].geom_names = geom_names
+  # Replace the base foot_friction with per-axis friction events for condim 6.
+  del cfg.events["foot_friction"]
+  cfg.events["foot_friction_slide"] = EventTermCfg(
+    mode="startup",
+    func=envs_mdp.dr.geom_friction,
+    params={
+      "asset_cfg": SceneEntityCfg("robot", geom_names=geom_names),
+      "operation": "abs",
+      "axes": [0],
+      "ranges": (0.3, 1.5),
+      "shared_random": True,
+    },
+  )
+  cfg.events["foot_friction_spin"] = EventTermCfg(
+    mode="startup",
+    func=envs_mdp.dr.geom_friction,
+    params={
+      "asset_cfg": SceneEntityCfg("robot", geom_names=geom_names),
+      "operation": "abs",
+      "distribution": "log_uniform",
+      "axes": [1],
+      "ranges": (1e-4, 2e-2),
+      "shared_random": True,
+    },
+  )
+  cfg.events["foot_friction_roll"] = EventTermCfg(
+    mode="startup",
+    func=envs_mdp.dr.geom_friction,
+    params={
+      "asset_cfg": SceneEntityCfg("robot", geom_names=geom_names),
+      "operation": "abs",
+      "distribution": "log_uniform",
+      "axes": [2],
+      "ranges": (1e-5, 5e-3),
+      "shared_random": True,
+    },
+  )
   cfg.events["base_com"].params["asset_cfg"].body_names = ("trunk",)
 
   cfg.rewards["pose"].params["std_standing"] = {

--- a/tests/test_go1_constants.py
+++ b/tests/test_go1_constants.py
@@ -72,9 +72,9 @@ def test_foot_collision_geoms(go1_model) -> None:
   for i in range(go1_model.ngeom):
     geom = go1_model.geom(i)
     if re.match(foot_pattern, geom.name):
-      assert geom.condim == 3
+      assert geom.condim == 6
       assert geom.priority == 1
-      assert geom.friction[0] == 0.6
+      assert geom.friction[0] == 1.0
 
 
 def test_collision_geom_count(go1_model) -> None:


### PR DESCRIPTION
Switch Go1 foot colliders from condim 3 to condim 6 with torsional and rolling friction, harden contact solref globally, add per-axis friction domain randomization (slide/spin/roll), and enable elliptic friction cone with impratio 10.