### PR TITLE
Add world-frame and forward-only velocity command sampling

### DIFF
--- a/src/mjlab/tasks/velocity/mdp/velocity_command.py
+++ b/src/mjlab/tasks/velocity/mdp/velocity_command.py
@@ -36,12 +36,15 @@ class UniformVelocityCommand(CommandTerm):
     self.robot: Entity = env.scene[cfg.entity_name]
 
     self.vel_command_b = torch.zeros(self.num_envs, 3, device=self.device)
+    self.vel_command_w = torch.zeros(self.num_envs, 3, device=self.device)
     self.heading_target = torch.zeros(self.num_envs, device=self.device)
     self.heading_error = torch.zeros(self.num_envs, device=self.device)
     self.is_heading_env = torch.zeros(
       self.num_envs, dtype=torch.bool, device=self.device
     )
     self.is_standing_env = torch.zeros_like(self.is_heading_env)
+    self.is_world_env = torch.zeros_like(self.is_heading_env)
+    self.is_forward_env = torch.zeros_like(self.is_heading_env)
 
     self.metrics["error_vel_xy"] = torch.zeros(self.num_envs, device=self.device)
     self.metrics["error_vel_yaw"] = torch.zeros(self.num_envs, device=self.device)
@@ -80,6 +83,21 @@ class UniformVelocityCommand(CommandTerm):
       self.is_heading_env[env_ids] = r.uniform_(0.0, 1.0) <= self.cfg.rel_heading_envs
     self.is_standing_env[env_ids] = r.uniform_(0.0, 1.0) <= self.cfg.rel_standing_envs
 
+    # Randomly assign world-frame envs.
+    self.is_world_env[env_ids] = r.uniform_(0.0, 1.0) <= self.cfg.rel_world_envs
+    # Copy sampled velocities as world-frame reference for world envs.
+    self.vel_command_w[env_ids] = self.vel_command_b[env_ids]
+
+    # Forward-only envs: positive lin_vel_x, zero lateral and angular.
+    self.is_forward_env[env_ids] = r.uniform_(0.0, 1.0) <= self.cfg.rel_forward_envs
+    fwd_ids = env_ids[self.is_forward_env[env_ids]]
+    if len(fwd_ids) > 0:
+      self.vel_command_b[fwd_ids, 0] = (
+        self.vel_command_b[fwd_ids, 0].abs().clamp(min=0.3)
+      )
+      self.vel_command_b[fwd_ids, 1] = 0.0
+      self.vel_command_b[fwd_ids, 2] = 0.0
+
     init_vel_mask = r.uniform_(0.0, 1.0) < self.cfg.init_velocity_prob
     init_vel_env_ids = env_ids[init_vel_mask]
     if len(init_vel_env_ids) > 0:
@@ -104,8 +122,20 @@ class UniformVelocityCommand(CommandTerm):
         min=self.cfg.ranges.ang_vel_z[0],
         max=self.cfg.ranges.ang_vel_z[1],
       )
+    # World-frame envs: rotate world-frame linear vel into body frame.
+    if self.is_world_env.any():
+      w_ids = self.is_world_env.nonzero(as_tuple=False).flatten()
+      heading = self.robot.data.heading_w[w_ids]
+      cos_h = torch.cos(heading)
+      sin_h = torch.sin(heading)
+      vx_w = self.vel_command_w[w_ids, 0]
+      vy_w = self.vel_command_w[w_ids, 1]
+      self.vel_command_b[w_ids, 0] = cos_h * vx_w + sin_h * vy_w
+      self.vel_command_b[w_ids, 1] = -sin_h * vx_w + cos_h * vy_w
+
     standing_env_ids = self.is_standing_env.nonzero(as_tuple=False).flatten()
     self.vel_command_b[standing_env_ids, :] = 0.0
+    self.vel_command_w[standing_env_ids, :] = 0.0
 
   # GUI.
 
@@ -252,6 +282,14 @@ class UniformVelocityCommandCfg(CommandTermCfg):
   heading_control_stiffness: float = 1.0
   rel_standing_envs: float = 0.0
   rel_heading_envs: float = 1.0
+  rel_world_envs: float = 0.0
+  """Fraction of environments that use world-frame velocity commands.
+  World-frame envs sample linear velocity in world frame and rotate to body
+  frame each step, so the command direction stays fixed in the world."""
+  rel_forward_envs: float = 0.0
+  """Fraction of environments that receive forward-only commands (positive
+  lin_vel_x, zero lin_vel_y and ang_vel_z). Increases training coverage for
+  straight-line walking, which is important for stair climbing."""
   init_velocity_prob: float = 0.0
 
   @dataclass

--- a/src/mjlab/tasks/velocity/velocity_env_cfg.py
+++ b/src/mjlab/tasks/velocity/velocity_env_cfg.py
@@ -180,6 +180,7 @@ def make_velocity_env_cfg() -> ManagerBasedRlEnvCfg:
       resampling_time_range=(3.0, 8.0),
       rel_standing_envs=0.1,
       rel_heading_envs=0.3,
+      rel_forward_envs=0.2,
       heading_command=True,
       heading_control_stiffness=0.5,
       debug_vis=True,


### PR DESCRIPTION
Add rel_world_envs and rel_forward_envs options to UniformVelocityCommandCfg. World-frame envs sample linear velocity in world frame and rotate it into body frame each step, keeping the commanded direction fixed as the robot turns. Forward-only envs receive positive lin_vel_x with zero lateral and angular velocity, increasing training coverage for straight-line gaits needed for stair climbing. Set rel_forward_envs=0.2 in the base velocity config.