### PR TITLE
Replace out_of_terrain_bounds with terrain_edge_reached

### DIFF
--- a/src/mjlab/tasks/velocity/config/go1/env_cfgs.py
+++ b/src/mjlab/tasks/velocity/config/go1/env_cfgs.py
@@ -225,17 +225,12 @@ def unitree_go1_rough_env_cfg(
   )
 
   # On rough terrain the quadruped tilts significantly; don't terminate on
-  # orientation alone. Let out_of_terrain_bounds handle bad episodes.
+  # orientation alone. Let terrain_edge_reached handle resets.
   cfg.terminations.pop("fell_over", None)
 
   cfg.terminations["illegal_contact"] = TerminationTermCfg(
     func=mdp.illegal_contact,
     params={"sensor_name": thigh_ground_cfg.name},
-  )
-  cfg.terminations["out_of_terrain_bounds"] = TerminationTermCfg(
-    func=mdp.out_of_terrain_bounds,
-    time_out=True,
-    params={"margin": 0.3},
   )
 
   # Apply play mode overrides.
@@ -297,7 +292,7 @@ def unitree_go1_flat_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
 
   # On flat terrain fell_over is sufficient; thigh contact implies fallen.
   cfg.terminations.pop("illegal_contact", None)
-  cfg.terminations.pop("out_of_terrain_bounds", None)
+  cfg.terminations.pop("terrain_edge_reached", None)
   cfg.terminations["fell_over"] = TerminationTermCfg(
     func=mdp.bad_orientation,
     params={"limit_angle": math.radians(70.0)},

--- a/src/mjlab/tasks/velocity/mdp/terminations.py
+++ b/src/mjlab/tasks/velocity/mdp/terminations.py
@@ -29,38 +29,35 @@ def illegal_contact(
   return torch.any(data.found, dim=-1)
 
 
-def out_of_terrain_bounds(
+def terrain_edge_reached(
   env: ManagerBasedRlEnv,
-  margin: float = 0.3,
+  threshold_fraction: float = 0.95,
   asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
 ) -> torch.Tensor:
-  """Check if robot root moved outside the generated terrain footprint.
+  """Terminate when robot displacement from spawn exceeds sub-terrain size.
 
-  Returns all-false for non-generator terrains (e.g. plane).
+  Intended as ``time_out=True`` (successful traversal, not penalized). Skips the first
+  2 steps after reset to avoid stale-position triggers.
   """
   terrain = env.scene.terrain
   if terrain is None or terrain.cfg.terrain_type != "generator":
-    return torch.zeros(
-      (env.num_envs,),
-      device=env.scene.env_origins.device,
-      dtype=torch.bool,
-    )
+    return torch.zeros(env.num_envs, device=env.device, dtype=torch.bool)
 
   terrain_generator = terrain.cfg.terrain_generator
   if terrain_generator is None:
-    return torch.zeros(
-      (env.num_envs,),
-      device=env.scene.env_origins.device,
-      dtype=torch.bool,
-    )
+    return torch.zeros(env.num_envs, device=env.device, dtype=torch.bool)
 
   asset: Entity = env.scene[asset_cfg.name]
-  root_xy_w = asset.data.root_link_pos_w[:, :2]
+  displacement = (
+    asset.data.root_link_pos_w[:, :2] - env.scene.env_origins[:, :2]
+  ).abs()
 
-  # Use playable terrain footprint only (exclude outer border region).
-  half_x = 0.5 * (terrain_generator.num_rows * terrain_generator.size[0])
-  half_y = 0.5 * (terrain_generator.num_cols * terrain_generator.size[1])
-  limit_x = max(0.0, half_x - margin)
-  limit_y = max(0.0, half_y - margin)
+  half_x = terrain_generator.size[0] / 2.0 * threshold_fraction
+  half_y = terrain_generator.size[1] / 2.0 * threshold_fraction
 
-  return (root_xy_w[:, 0].abs() > limit_x) | (root_xy_w[:, 1].abs() > limit_y)
+  at_edge = (displacement[:, 0] > half_x) | (displacement[:, 1] > half_y)
+
+  # Don't fire on the first 2 steps after reset (position may be stale).
+  at_edge &= env.episode_length_buf > 2
+
+  return at_edge

--- a/src/mjlab/tasks/velocity/velocity_env_cfg.py
+++ b/src/mjlab/tasks/velocity/velocity_env_cfg.py
@@ -380,6 +380,10 @@ def make_velocity_env_cfg() -> ManagerBasedRlEnvCfg:
       func=mdp.bad_orientation,
       params={"limit_angle": math.radians(70.0)},
     ),
+    "terrain_edge_reached": TerminationTermCfg(
+      func=mdp.terrain_edge_reached,
+      time_out=True,
+    ),
   }
 
   ##

--- a/tests/test_terminations.py
+++ b/tests/test_terminations.py
@@ -10,6 +10,7 @@ from conftest import get_test_device
 from mjlab.envs.mdp.terminations import nan_detection
 from mjlab.managers.termination_manager import TerminationManager, TerminationTermCfg
 from mjlab.sim.sim import Simulation, SimulationCfg
+from mjlab.tasks.velocity.mdp.terminations import terrain_edge_reached
 
 
 @pytest.fixture
@@ -100,3 +101,59 @@ def test_nan_detection_with_termination_manager(mock_env_with_sim):
   # Reset should log multiple terminations.
   reset_info = manager.reset(torch.tensor([0, 2], device=env.device))
   assert reset_info["Episode_Termination/nan_term"] == 2
+
+
+@pytest.fixture
+def mock_terrain_env():
+  device = get_test_device()
+  num_envs = 4
+
+  env = Mock()
+  env.num_envs = num_envs
+  env.device = device
+  env.episode_length_buf = torch.full((num_envs,), 10, dtype=torch.long, device=device)
+
+  # Terrain with 8x8m sub-terrains.
+  terrain = Mock()
+  terrain.cfg.terrain_type = "generator"
+  terrain.cfg.terrain_generator.size = (8.0, 8.0)
+
+  env.scene.terrain = terrain
+  env.scene.env_origins = torch.zeros(num_envs, 3, device=device)
+
+  # Robot at spawn origin.
+  asset = Mock()
+  asset.data.root_link_pos_w = torch.zeros(num_envs, 3, device=device)
+  env.scene.__getitem__ = Mock(return_value=asset)
+
+  return env, asset
+
+
+def test_terrain_edge_reached_within_bounds(mock_terrain_env):
+  env, asset = mock_terrain_env
+  result = terrain_edge_reached(env, threshold_fraction=0.95)
+  assert not result.any()
+
+
+def test_terrain_edge_reached_at_edge(mock_terrain_env):
+  env, asset = mock_terrain_env
+  # Move env 1 past 95% of half-size (4.0 * 0.95 = 3.8m).
+  asset.data.root_link_pos_w[1, 0] = 3.9
+  result = terrain_edge_reached(env, threshold_fraction=0.95)
+  assert result[1] and not result[0] and not result[2] and not result[3]
+
+
+def test_terrain_edge_reached_skips_early_steps(mock_terrain_env):
+  env, asset = mock_terrain_env
+  asset.data.root_link_pos_w[0, 0] = 5.0
+  env.episode_length_buf[:] = 1  # Too early.
+  result = terrain_edge_reached(env, threshold_fraction=0.95)
+  assert not result.any()
+
+
+def test_terrain_edge_reached_no_terrain(mock_terrain_env):
+  env, asset = mock_terrain_env
+  env.scene.terrain = None
+  asset.data.root_link_pos_w[0, 0] = 100.0
+  result = terrain_edge_reached(env, threshold_fraction=0.95)
+  assert not result.any()


### PR DESCRIPTION
Replace out_of_terrain_bounds with terrain_edge_reached. The old termination compared absolute world position against the full terrain grid, penalizing robots that walked too far. The new one measures displacement from spawn origin against sub-terrain size, works correctly per patch, and is marked as time_out so successful traversal isn't penalized.