### PR TITLE
Fix terrain boundary termination for training

### DIFF
--- a/src/mjlab/tasks/velocity/config/g1/env_cfgs.py
+++ b/src/mjlab/tasks/velocity/config/g1/env_cfgs.py
@@ -167,6 +167,7 @@ def unitree_g1_rough_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
 
     cfg.observations["actor"].enable_corruption = False
     cfg.events.pop("push_robot", None)
+    cfg.terminations.pop("out_of_terrain_bounds", None)
     cfg.curriculum = {}
     cfg.events["randomize_terrain"] = EventTermCfg(
       func=envs_mdp.randomize_terrain,
@@ -204,6 +205,8 @@ def unitree_g1_flat_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
   )
   del cfg.observations["actor"].terms["height_scan"]
   del cfg.observations["critic"].terms["height_scan"]
+
+  cfg.terminations.pop("out_of_terrain_bounds", None)
 
   # Disable terrain curriculum (not present in play mode since rough clears all).
   cfg.curriculum.pop("terrain_levels", None)

--- a/src/mjlab/tasks/velocity/config/go1/env_cfgs.py
+++ b/src/mjlab/tasks/velocity/config/go1/env_cfgs.py
@@ -225,7 +225,7 @@ def unitree_go1_rough_env_cfg(
   )
 
   # On rough terrain the quadruped tilts significantly; don't terminate on
-  # orientation alone. Let terrain_edge_reached handle resets.
+  # orientation alone. Let out_of_terrain_bounds handle resets.
   cfg.terminations.pop("fell_over", None)
 
   cfg.terminations["illegal_contact"] = TerminationTermCfg(
@@ -240,6 +240,7 @@ def unitree_go1_rough_env_cfg(
 
     cfg.observations["actor"].enable_corruption = False
     cfg.events.pop("push_robot", None)
+    cfg.terminations.pop("out_of_terrain_bounds", None)
     cfg.curriculum = {}
     cfg.events["randomize_terrain"] = EventTermCfg(
       func=envs_mdp.randomize_terrain,
@@ -292,7 +293,7 @@ def unitree_go1_flat_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
 
   # On flat terrain fell_over is sufficient; thigh contact implies fallen.
   cfg.terminations.pop("illegal_contact", None)
-  cfg.terminations.pop("terrain_edge_reached", None)
+  cfg.terminations.pop("out_of_terrain_bounds", None)
   cfg.terminations["fell_over"] = TerminationTermCfg(
     func=mdp.bad_orientation,
     params={"limit_angle": math.radians(70.0)},

--- a/src/mjlab/tasks/velocity/mdp/terminations.py
+++ b/src/mjlab/tasks/velocity/mdp/terminations.py
@@ -29,6 +29,42 @@ def illegal_contact(
   return torch.any(data.found, dim=-1)
 
 
+def out_of_terrain_bounds(
+  env: ManagerBasedRlEnv,
+  margin: float = 0.3,
+  asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
+) -> torch.Tensor:
+  """Truncate if robot leaves the generated terrain footprint.
+
+  Returns all-false for non-generator terrains (e.g. plane).
+  """
+  terrain = env.scene.terrain
+  if terrain is None or terrain.cfg.terrain_type != "generator":
+    return torch.zeros(
+      (env.num_envs,),
+      device=env.device,
+      dtype=torch.bool,
+    )
+
+  terrain_generator = terrain.cfg.terrain_generator
+  if terrain_generator is None:
+    return torch.zeros(
+      (env.num_envs,),
+      device=env.device,
+      dtype=torch.bool,
+    )
+
+  asset: Entity = env.scene[asset_cfg.name]
+  root_xy_w = asset.data.root_link_pos_w[:, :2]
+
+  half_x = 0.5 * (terrain_generator.num_rows * terrain_generator.size[0])
+  half_y = 0.5 * (terrain_generator.num_cols * terrain_generator.size[1])
+  limit_x = max(0.0, half_x - margin)
+  limit_y = max(0.0, half_y - margin)
+
+  return (root_xy_w[:, 0].abs() > limit_x) | (root_xy_w[:, 1].abs() > limit_y)
+
+
 def terrain_edge_reached(
   env: ManagerBasedRlEnv,
   threshold_fraction: float = 0.95,

--- a/src/mjlab/tasks/velocity/velocity_env_cfg.py
+++ b/src/mjlab/tasks/velocity/velocity_env_cfg.py
@@ -380,8 +380,8 @@ def make_velocity_env_cfg() -> ManagerBasedRlEnvCfg:
       func=mdp.bad_orientation,
       params={"limit_angle": math.radians(70.0)},
     ),
-    "terrain_edge_reached": TerminationTermCfg(
-      func=mdp.terrain_edge_reached,
+    "out_of_terrain_bounds": TerminationTermCfg(
+      func=mdp.out_of_terrain_bounds,
       time_out=True,
     ),
   }

--- a/tests/test_terminations.py
+++ b/tests/test_terminations.py
@@ -10,7 +10,10 @@ from conftest import get_test_device
 from mjlab.envs.mdp.terminations import nan_detection
 from mjlab.managers.termination_manager import TerminationManager, TerminationTermCfg
 from mjlab.sim.sim import Simulation, SimulationCfg
-from mjlab.tasks.velocity.mdp.terminations import terrain_edge_reached
+from mjlab.tasks.velocity.mdp.terminations import (
+  out_of_terrain_bounds,
+  terrain_edge_reached,
+)
 
 
 @pytest.fixture
@@ -157,3 +160,42 @@ def test_terrain_edge_reached_no_terrain(mock_terrain_env):
   asset.data.root_link_pos_w[0, 0] = 100.0
   result = terrain_edge_reached(env, threshold_fraction=0.95)
   assert not result.any()
+
+
+@pytest.fixture
+def mock_grid_terrain_env():
+  device = get_test_device()
+  num_envs = 4
+
+  env = Mock()
+  env.num_envs = num_envs
+  env.device = device
+
+  # 10x10 grid of 8x8m sub-terrains → half_x = 40m, limit = 39.7m.
+  terrain = Mock()
+  terrain.cfg.terrain_type = "generator"
+  terrain.cfg.terrain_generator.size = (8.0, 8.0)
+  terrain.cfg.terrain_generator.num_rows = 10
+  terrain.cfg.terrain_generator.num_cols = 10
+
+  env.scene.terrain = terrain
+
+  asset = Mock()
+  asset.data.root_link_pos_w = torch.zeros(num_envs, 3, device=device)
+  env.scene.__getitem__ = Mock(return_value=asset)
+
+  return env, asset
+
+
+def test_out_of_terrain_bounds_within(mock_grid_terrain_env):
+  env, asset = mock_grid_terrain_env
+  result = out_of_terrain_bounds(env)
+  assert not result.any()
+
+
+def test_out_of_terrain_bounds_outside(mock_grid_terrain_env):
+  env, asset = mock_grid_terrain_env
+  # Past the grid edge (limit_x = 40 - 0.3 = 39.7m).
+  asset.data.root_link_pos_w[2, 0] = 40.0
+  result = out_of_terrain_bounds(env)
+  assert result[2] and not result[0] and not result[1] and not result[3]


### PR DESCRIPTION
Replace terrain_edge_reached with out_of_terrain_bounds in the base velocity config. terrain_edge_reached fires at the sub-terrain patch edge (~3.8m), cutting episodes short and halving curriculum progression. out_of_terrain_bounds only fires at the full terrain grid boundary (~40m), acting as a safety truncation for bad physics without interfering with training.