### PR TITLE
Fix sensor name prefix duplicated on deepcopy

### DIFF
--- a/src/mjlab/scene/scene.py
+++ b/src/mjlab/scene/scene.py
@@ -260,7 +260,7 @@ class Scene:
     for sensor_cfg in self._cfg.sensors:
       sns = sensor_cfg.build()
       sns.edit_spec(self._spec, self._entities)
-      self._sensors[sensor_cfg.name] = sns
+      self._sensors[sensor_cfg.prefixed_name] = sns
 
     for sns in self._spec.sensors:
       if sns.name not in self._sensors:

--- a/src/mjlab/sensor/builtin_sensor.py
+++ b/src/mjlab/sensor/builtin_sensor.py
@@ -203,11 +203,14 @@ class BuiltinSensorCfg(SensorCfg):
   cutoff: float = 0.0
   """When this value is positive, it limits the absolute value of the sensor output."""
 
-  def __post_init__(self) -> None:
-    # Auto-prefix sensor name if it references an entity.
+  @property
+  def prefixed_name(self) -> str:
+    """The sensor name with entity prefix if applicable."""
     if self.obj is not None and self.obj.entity is not None:
-      self.name = f"{self.obj.entity}/{self.name}"
+      return f"{self.obj.entity}/{self.name}"
+    return self.name
 
+  def __post_init__(self) -> None:
     if self.sensor_type in _SENSORS_REQUIRING_SITE:
       if self.obj is None:
         raise ValueError(
@@ -278,7 +281,7 @@ class BuiltinSensor(Sensor[torch.Tensor]):
   ) -> None:
     super().__init__()
     if cfg is not None:
-      self._name = cfg.name
+      self._name = cfg.prefixed_name
       self.cfg: BuiltinSensorCfg | None = cfg
     else:
       assert name is not None, "Must provide either cfg or name"
@@ -299,23 +302,23 @@ class BuiltinSensor(Sensor[torch.Tensor]):
 
     # Check for duplicate sensors.
     for sensor in scene_spec.sensors:
-      if sensor.name == self.cfg.name:
+      if sensor.name == self.cfg.prefixed_name:
         is_entity_scoped = self.cfg.obj is not None and self.cfg.obj.entity is not None
         if is_entity_scoped:
           raise ValueError(
-            f"Sensor '{self.cfg.name}' is defined in both entity XML and scene config. "
-            f"Remove the sensor definition from the entity XML file, or remove the "
-            f"BuiltinSensorCfg from scene.sensors."
+            f"Sensor '{self.cfg.prefixed_name}' is defined in both entity XML and "
+            f"scene config. Remove the sensor definition from the entity XML file, "
+            f"or remove the BuiltinSensorCfg from scene.sensors."
           )
         else:
           raise ValueError(
-            f"Sensor '{self.cfg.name}' already exists in the scene. "
+            f"Sensor '{self.cfg.prefixed_name}' already exists in the scene. "
             f"Rename this sensor to avoid conflicts."
           )
 
     # Add sensor to spec.
     scene_spec.add_sensor(
-      name=self.cfg.name,
+      name=self.cfg.prefixed_name,
       type=_SENSOR_TYPE_MAP[self.cfg.sensor_type],
       objtype=(
         _OBJECT_TYPE_MAP[self.cfg.obj.type] if self.cfg.obj is not None else None

--- a/src/mjlab/sensor/sensor.py
+++ b/src/mjlab/sensor/sensor.py
@@ -24,6 +24,11 @@ class SensorCfg(ABC):
 
   name: str
 
+  @property
+  def prefixed_name(self) -> str:
+    """The sensor name as it appears in the MuJoCo model."""
+    return self.name
+
   @abstractmethod
   def build(self) -> Sensor[Any]:
     """Build sensor instance from this config."""

--- a/tests/test_builtin_sensor.py
+++ b/tests/test_builtin_sensor.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import copy
+
 import mujoco
 import pytest
 import torch
@@ -354,3 +356,17 @@ def test_cutoff_parameter(articulated_robot_xml, device):
 
   sensor = sim.mj_model.sensor("robot/joint1_pos")
   assert sensor.cutoff[0] == 0.01
+
+
+def test_deepcopy_no_double_prefix():
+  """Regression test for #850: deepcopy should not double-prefix sensor name."""
+  cfg = BuiltinSensorCfg(
+    name="joint1_pos",
+    sensor_type="jointpos",
+    obj=ObjRef(type="joint", name="joint1", entity="robot"),
+  )
+  assert cfg.prefixed_name == "robot/joint1_pos"
+
+  cfg_copy = copy.deepcopy(cfg)
+  assert cfg_copy.prefixed_name == "robot/joint1_pos"
+  assert cfg_copy.name == "joint1_pos"


### PR DESCRIPTION
BuiltinSensorCfg.__post_init__ mutated self.name by prepending the entity prefix, which caused double-prefixing when deepcopy re-triggered __post_init__ (e.g., in the task registry). Replaced the mutation with a prefixed_name property that computes the prefix dynamically, following the same pattern as ObjRef.prefixed_name(). Added a base prefixed_name property on SensorCfg that returns self.name by default, so the scene can use it uniformly for all sensor types.

Fixes #850