### PR TITLE
Add RNN model support to RslRlModelCfg

### DIFF
--- a/src/mjlab/rl/config.py
+++ b/src/mjlab/rl/config.py
@@ -28,8 +28,14 @@ class RslRlModelCfg:
 
   ``None`` means deterministic output (use for critic).
   """
+  rnn_type: str | None = None
+  """RNN type ("lstm" or "gru"). When set, class_name should be "RNNModel"."""
+  rnn_hidden_dim: int = 256
+  """Hidden state dimension for the RNN."""
+  rnn_num_layers: int = 1
+  """Number of stacked RNN layers."""
   class_name: str = "MLPModel"
-  """Model class name resolved by RSL-RL (MLPModel or CNNModel)."""
+  """Model class name resolved by RSL-RL (MLPModel, CNNModel, or RNNModel)."""
 
 
 @dataclass

--- a/src/mjlab/rl/runner.py
+++ b/src/mjlab/rl/runner.py
@@ -25,6 +25,9 @@ class MjlabOnPolicyRunner(OnPolicyRunner):
         for opt in ("cnn_cfg", "distribution_cfg"):
           if train_cfg[key].get(opt) is None:
             train_cfg[key].pop(opt, None)
+        if train_cfg[key].get("rnn_type") is None:
+          for opt in ("rnn_type", "rnn_hidden_dim", "rnn_num_layers"):
+            train_cfg[key].pop(opt, None)
     super().__init__(env, train_cfg, log_dir, device)
 
   def export_policy_to_onnx(


### PR DESCRIPTION
Adds rnn_type, rnn_hidden_dim, and rnn_num_layers fields to RslRlModelCfg so users can configure RNNModel policies through the standard config path. When rnn_type is None (the default), all three fields are stripped before passing the config to rsl_rl so that MLPModel and CNNModel don't receive unexpected kwargs.

Fixes #844