### PR TITLE
Support per-substep metric evaluation

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -34,6 +34,10 @@ Added
   (:issue:`776`).
 - Added ``RewardBarPanel`` to the Viser viewer, showing horizontal bars for
   each reward term with a running mean over ~1 second (:issue:`800`).
+- Added ``per_substep`` flag to ``MetricsTermCfg`` for evaluating metrics
+  once per physics substep inside the decimation loop. The per substep
+  values are averaged within each environment step, so episode averages
+  remain comparable to regular per step metrics.
 
 Changed
 ^^^^^^^

--- a/src/mjlab/envs/manager_based_rl_env.py
+++ b/src/mjlab/envs/manager_based_rl_env.py
@@ -375,6 +375,7 @@ class ManagerBasedRlEnv:
       self.scene.write_data_to_sim()
       self.sim.step()
       self.scene.update(dt=self.physics_dt)
+      self.metrics_manager.compute_substep()
 
     # Update env counters.
     self.episode_length_buf += 1

--- a/src/mjlab/managers/metrics_manager.py
+++ b/src/mjlab/managers/metrics_manager.py
@@ -17,9 +17,16 @@ if TYPE_CHECKING:
 
 @dataclass(kw_only=True)
 class MetricsTermCfg(ManagerTermBaseCfg):
-  """Configuration for a metrics term."""
+  """Configuration for a metrics term.
 
-  pass
+  Attributes:
+    per_substep: If True, evaluate this term once per physics substep inside the
+    decimation loop and report the per-step mean. Only the integrated state
+    (qpos, qvel, act) is current mid-loop; all derived quantities (xpos, xquat,
+    site_xpos, actuator_force, contacts, ...) are stale.
+  """
+
+  per_substep: bool = False
 
 
 class MetricsManager(ManagerBase):
@@ -37,6 +44,8 @@ class MetricsManager(ManagerBase):
     self._term_names: list[str] = list()
     self._term_cfgs: list[MetricsTermCfg] = list()
     self._class_term_cfgs: list[MetricsTermCfg] = list()
+    self._step_term_indices: list[int] = list()
+    self._substep_term_indices: list[int] = list()
 
     self.cfg = deepcopy(cfg)
     super().__init__(env=env)
@@ -46,6 +55,16 @@ class MetricsManager(ManagerBase):
       self._episode_sums[term_name] = torch.zeros(
         self.num_envs, dtype=torch.float, device=self.device
       )
+    # Pre-resolved tensor refs for substep terms to avoid dict lookups in
+    # the hot loop.
+    self._substep_accum: list[torch.Tensor] = []
+    self._substep_episode_sums: list[torch.Tensor] = []
+    for idx in self._substep_term_indices:
+      name = self._term_names[idx]
+      buf = torch.zeros(self.num_envs, dtype=torch.float, device=self.device)
+      self._substep_accum.append(buf)
+      self._substep_episode_sums.append(self._episode_sums[name])
+    self._substep_count: int = 0
     self._step_count = torch.zeros(self.num_envs, dtype=torch.long, device=self.device)
     self._step_values = torch.zeros(
       (self.num_envs, len(self._term_names)), dtype=torch.float, device=self.device
@@ -85,18 +104,39 @@ class MetricsManager(ManagerBase):
       extras["Episode_Metrics/" + key] = episode_avg
       self._episode_sums[key][env_ids] = 0.0
     self._step_count[env_ids] = 0
+    for buf in self._substep_accum:
+      buf[env_ids] = 0.0
     for term_cfg in self._class_term_cfgs:
       term_cfg.func.reset(env_ids=env_ids)
     return extras
 
+  def compute_substep(self) -> None:
+    """Accumulate per-substep metric values inside the decimation loop.
+
+    No-op when no ``per_substep`` terms are configured.
+    """
+    if not self._substep_term_indices:
+      return
+    for i, idx in enumerate(self._substep_term_indices):
+      value = self._term_cfgs[idx].func(self._env, **self._term_cfgs[idx].params)
+      self._substep_accum[i] += value
+    self._substep_count += 1
+
   def compute(self) -> None:
     self._step_count += 1
-    for term_idx, (name, term_cfg) in enumerate(
-      zip(self._term_names, self._term_cfgs, strict=False)
-    ):
+    if self._substep_term_indices and self._substep_count > 0:
+      for i, idx in enumerate(self._substep_term_indices):
+        avg = self._substep_accum[i] / self._substep_count
+        self._substep_episode_sums[i] += avg
+        self._step_values[:, idx] = avg
+        self._substep_accum[i].zero_()
+      self._substep_count = 0
+    for idx in self._step_term_indices:
+      name = self._term_names[idx]
+      term_cfg = self._term_cfgs[idx]
       value = term_cfg.func(self._env, **term_cfg.params)
       self._episode_sums[name] += value
-      self._step_values[:, term_idx] = value
+      self._step_values[:, idx] = value
 
   def get_active_iterable_terms(
     self, env_idx: int
@@ -113,8 +153,13 @@ class MetricsManager(ManagerBase):
         print(f"term: {term_name} set to None, skipping...")
         continue
       self._resolve_common_term_cfg(term_name, term_cfg)
+      idx = len(self._term_names)
       self._term_names.append(term_name)
       self._term_cfgs.append(term_cfg)
+      if term_cfg.per_substep:
+        self._substep_term_indices.append(idx)
+      else:
+        self._step_term_indices.append(idx)
       if hasattr(term_cfg.func, "reset") and callable(term_cfg.func.reset):
         self._class_term_cfgs.append(term_cfg)
 
@@ -139,6 +184,9 @@ class NullMetricsManager:
 
   def reset(self, env_ids: torch.Tensor | None = None) -> dict[str, float]:
     return {}
+
+  def compute_substep(self) -> None:
+    pass
 
   def compute(self) -> None:
     pass

--- a/tests/test_metrics_manager.py
+++ b/tests/test_metrics_manager.py
@@ -122,3 +122,74 @@ def test_none_terms_are_skipped(mock_env):
   }
   manager = MetricsManager(cfg, mock_env)  # type: ignore[arg-type]
   assert manager._term_names == ["valid"]
+
+
+def test_per_substep_averaging(mock_env):
+  """Substep terms are averaged across substeps; step terms evaluated once."""
+  substep_call = [0]
+
+  def rising_metric(env):
+    substep_call[0] += 1
+    return torch.full((env.num_envs,), float(substep_call[0]), device=env.device)
+
+  cfg = {
+    "step_term": MetricsTermCfg(
+      func=lambda env: torch.ones(env.num_envs, device=env.device) * 2.0,
+      params={},
+    ),
+    "substep_term": MetricsTermCfg(func=rising_metric, params={}, per_substep=True),
+  }
+  manager = MetricsManager(cfg, mock_env)
+
+  for _ in range(2):  # 2 env steps
+    for _ in range(4):  # 4 substeps each
+      manager.compute_substep()
+    manager.compute()
+
+  info = manager.reset(env_ids=torch.tensor([0]))
+  assert info["Episode_Metrics/step_term"].item() == pytest.approx(2.0)
+  # Substeps: step 0 -> [1,2,3,4] avg=2.5; step 1 -> [5,6,7,8] avg=6.5.
+  # Episode avg = (2.5 + 6.5) / 2 = 4.5.  A broken single-eval path
+  # would give (1 + 2) / 2 = 1.5.
+  assert info["Episode_Metrics/substep_term"].item() == pytest.approx(4.5)
+
+
+def test_substep_reset_zeroes_accumulators(mock_env):
+  """Reset zeroes substep accumulators for the given env_ids."""
+  cfg = {
+    "sub": MetricsTermCfg(
+      func=lambda env: torch.ones(env.num_envs, device=env.device),
+      params={},
+      per_substep=True,
+    ),
+  }
+  manager = MetricsManager(cfg, mock_env)
+
+  # Accumulate some substep values without calling compute().
+  for _ in range(3):
+    manager.compute_substep()
+
+  # Reset env 0 -- its substep accum should be zeroed.
+  manager.reset(env_ids=torch.tensor([0]))
+  assert manager._substep_accum[0][0].item() == 0.0
+  # Env 1 still has its accumulated value.
+  assert manager._substep_accum[0][1].item() == pytest.approx(3.0)
+
+
+def test_no_substep_terms_no_overhead(mock_env):
+  """When no per_substep terms exist, compute_substep is a no-op."""
+  cfg = {
+    "step_only": MetricsTermCfg(
+      func=lambda env: torch.ones(env.num_envs, device=env.device),
+      params={},
+    ),
+  }
+  manager = MetricsManager(cfg, mock_env)
+
+  # Should not raise or change state.
+  manager.compute_substep()
+  assert manager._substep_count == 0
+
+  manager.compute()
+  info = manager.reset(env_ids=torch.tensor([0]))
+  assert info["Episode_Metrics/step_only"].item() == pytest.approx(1.0)


### PR DESCRIPTION
Logging sim quantities (joint torques, contact forces, actuator states) at every physics substep is useful for controls analysis, but the existing MetricsManager only calls compute() after the decimation loop, so high frequency dynamics are invisible to the logger.

This adds a per_substep flag to MetricsTermCfg. When set, the term is evaluated inside the decimation loop via a new compute_substep() method. The substep values are mean-aggregated within each environment step before entering the episode sum, so episode averages remain directly comparable to regular per-step metrics.

compute_substep() is a no-op (single falsy-list check) when no substep terms are configured. When present, pre-resolved tensor lists replace dictionary lookups in the inner loop.

Substep terms see the integrated state (qpos, qvel, act), but all derived quantities (xpos, xquat, site_xpos, actuator_force, contacts, ...) are stale. This matches the existing tradeoff documented in step().