### PR TITLE
Fix export-scene writing assets to wrong location

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -68,6 +68,11 @@ Changed
 Fixed
 ^^^^^
 
+- ``export-scene`` now writes only referenced assets and places them
+  correctly under the output directory. Previously, asset keys containing
+  path traversal could write files outside the output directory, and all
+  spec assets were included regardless of whether the scene XML referenced
+  them (:issue:`858`).
 - ``electrical_power_cost`` now uses ``qfrc_actuator`` (joint space) instead
   of ``actuator_force`` (actuation space) for mechanical power computation.
   Previously the reward was incorrect for actuators with gear ratios other

--- a/src/mjlab/scene/scene.py
+++ b/src/mjlab/scene/scene.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-import shutil
 import warnings
-import zipfile
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable
@@ -17,7 +15,7 @@ from mjlab.sensor import BuiltinSensor, RayCastSensor, Sensor, SensorCfg
 from mjlab.sensor.camera_sensor import CameraSensor
 from mjlab.sensor.sensor_context import SensorContext
 from mjlab.terrains.terrain_entity import TerrainEntity, TerrainEntityCfg
-from mjlab.utils.xml import fix_spec_xml, strip_buffer_textures
+from mjlab.utils.spec import export_spec
 
 _SCENE_XML = Path(__file__).parent / "scene.xml"
 
@@ -75,34 +73,16 @@ class Scene:
   def write(self, output_dir: Path, *, zip: bool = False) -> None:
     """Write the scene XML and mesh assets to a directory.
 
-    Creates ``scene.xml`` and an ``assets/`` subdirectory containing
-    all mesh files referenced by the spec. When *zip* is True the
-    directory is compressed into a ``.zip`` archive and the directory
-    is removed. Operates on a copy of the spec to avoid mutation.
+    Creates ``scene.xml`` and an ``assets/`` subdirectory containing mesh files
+    referenced by the scene. When *zip* is True the directory is compressed into a
+    ``.zip`` archive and the directory is removed. Operates on a copy of the spec to
+    avoid mutation.
 
     Args:
       output_dir: Destination directory (created if it doesn't exist).
       zip: If True, produce ``<output_dir>.zip`` instead of a directory.
     """
-    output_dir.mkdir(parents=True, exist_ok=True)
-    tmp = self._spec.copy()
-    strip_buffer_textures(tmp)
-    xml = fix_spec_xml(tmp.to_xml(), meshdir="assets")
-    (output_dir / "scene.xml").write_text(xml)
-    assets_dir = output_dir / "assets"
-    assets_dir.mkdir(parents=True, exist_ok=True)
-    for name, data in tmp.assets.items():
-      clean = name.removeprefix("assets/")
-      path = assets_dir / clean
-      path.parent.mkdir(parents=True, exist_ok=True)
-      path.write_bytes(data)
-    if zip:
-      zip_path = output_dir.with_suffix(".zip")
-      with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
-        for file in sorted(output_dir.rglob("*")):
-          if file.is_file():
-            zf.write(file, file.relative_to(output_dir))
-      shutil.rmtree(output_dir)
+    export_spec(self._spec, output_dir, zip=zip)
 
   def to_zip(self, path: Path) -> None:
     """Deprecated. Use ``write(output_dir, zip=True)`` instead."""

--- a/src/mjlab/utils/spec.py
+++ b/src/mjlab/utils/spec.py
@@ -1,11 +1,67 @@
 """MjSpec utils."""
 
+import shutil
+import xml.etree.ElementTree as ET
+import zipfile
+from pathlib import Path
 from typing import Callable
 
 import mujoco
 import numpy as np
 
 from mjlab.actuator.actuator import TransmissionType
+from mjlab.utils.xml import fix_spec_xml, strip_buffer_textures
+
+
+def export_spec(
+  spec: mujoco.MjSpec,
+  output_dir: Path,
+  *,
+  zip: bool = False,
+) -> None:
+  """Write a spec's XML and referenced mesh assets to a directory.
+
+  Creates ``scene.xml`` and an ``assets/`` subdirectory containing only the assets
+  referenced by the generated XML. When *zip* is True the directory is compressed into
+  a ``.zip`` archive and removed.
+
+  Operates on a copy of spec to avoid mutation.
+  """
+  output_dir.mkdir(parents=True, exist_ok=True)
+  tmp = spec.copy()
+  strip_buffer_textures(tmp)
+  xml = fix_spec_xml(tmp.to_xml(), meshdir="assets")
+  (output_dir / "scene.xml").write_text(xml)
+
+  # Collect file paths referenced in the XML.
+  root = ET.fromstring(xml)
+  referenced: set[str] = set()
+  for elem in root.iter():
+    file_val = elem.get("file")
+    if file_val:
+      referenced.add(file_val)
+
+  # Write only referenced assets. Match asset keys to XML file attributes by path
+  # suffix because keys may carry the original meshdir prefix (e.g.
+  # "../../meshes/robot/arm.stl" for a file attribute of "robot/arm.stl").
+  assets_dir = output_dir / "assets"
+  for ref_path in sorted(referenced):
+    for key, data in tmp.assets.items():
+      norm = key.replace("\\", "/")
+      if norm == ref_path or norm.endswith("/" + ref_path):
+        out = assets_dir / ref_path
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_bytes(data)
+        break
+
+  if zip:
+    zip_path = output_dir.with_suffix(".zip")
+    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+      for file in sorted(output_dir.rglob("*")):
+        if file.is_file():
+          zf.write(file, file.relative_to(output_dir))
+    shutil.rmtree(output_dir)
+
 
 _TRANSMISSION_TYPE_MAP = {
   TransmissionType.JOINT: mujoco.mjtTrn.mjTRN_JOINT,

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -191,6 +191,29 @@ def test_write_zip(minimal_scene_cfg, tmp_path, device):
   assert out.with_suffix(".zip").exists()
 
 
+def test_write_skips_unreferenced_assets(minimal_scene_cfg, tmp_path, device):
+  """write() only includes assets referenced in the generated XML."""
+  scene = Scene(minimal_scene_cfg, device)
+  scene._spec.assets["unused_mesh.stl"] = b"fake"
+  out = tmp_path / "out"
+  scene.write(out)
+  assert (out / "scene.xml").exists()
+  assets_dir = out / "assets"
+  asset_files = list(assets_dir.rglob("*")) if assets_dir.exists() else []
+  assert not any(f.is_file() for f in asset_files)
+
+
+def test_write_no_traversal_escape(minimal_scene_cfg, tmp_path, device):
+  """Asset keys with path traversal must not escape the output directory."""
+  scene = Scene(minimal_scene_cfg, device)
+  scene._spec.assets["../../assets/robot/mesh.stl"] = b"fake"
+  out = tmp_path / "subdir" / "out"
+  scene.write(out)
+  for f in tmp_path.rglob("*"):
+    if f.is_file() and f.name != "scene.xml":
+      assert str(f).startswith(str(out)), f"File escaped output dir: {f}"
+
+
 # ============================================================================
 # Entity Access Tests
 # ============================================================================


### PR DESCRIPTION
Scene.write() had two bugs when asset keys carried the original meshdir prefix (e.g. "../../meshes/robot/arm.stl"):

1. Path traversal in keys caused assets to be written outside the output directory.
2. All spec assets were dumped, not just the ones referenced in the generated XML.

The fix parses the XML for `file` attributes and only writes matching assets, using suffix matching to handle arbitrary meshdir prefixes. The export logic is extracted from Scene into `export_spec()` in `utils/spec.py`.

This only affected entities loaded from XML files with relative meshdir paths. The built-in robots (g1, go1, yam) were unaffected because they build clean asset keys via `update_assets()`.

Fixes #858