### PR TITLE
Add motion reference scrubber to viser viewer

### DIFF
--- a/src/mjlab/managers/command_manager.py
+++ b/src/mjlab/managers/command_manager.py
@@ -67,17 +67,29 @@ class CommandTerm(ManagerTermBase):
   def create_gui(
     self,
     name: str,
-    server: "viser.ViserServer",
+    server: viser.ViserServer,
     get_env_idx: Callable[[], int],
+    on_change: Callable[[], None] | None = None,
+    request_action: Callable[[str, Any], None] | None = None,
   ) -> None:
     """Create interactive GUI controls for this command term.
 
-    Override in subclasses to add task-specific controls (e.g., velocity
-    sliders) to the Viser viewer. Called once during viewer setup.
+    Override in subclasses to add task-specific controls (e.g., velocity sliders) to
+    the Viser viewer. Called once during viewer setup.
 
-    The *name* argument is the term's key in the command manager config
-    (e.g., ``"twist"``).
+    The *name* argument is the term's key in the command manager config (e.g.,
+    ``"twist"``).
     """
+
+  def on_viewer_pause(self, paused: bool) -> None:
+    """Called when the viewer pause state changes."""
+
+  def apply_gui_reset(self, env_ids: torch.Tensor) -> bool:
+    """Apply GUI-selected state as an env reset override.
+
+    Returns True if this term wrote state to sim.
+    """
+    return False
 
   @property
   @abc.abstractmethod
@@ -161,16 +173,36 @@ class CommandManager(ManagerBase):
 
   def create_gui(
     self,
-    server: "viser.ViserServer",
+    server: viser.ViserServer,
     get_env_idx: Callable[[], int],
+    on_change: Callable[[], None] | None = None,
+    request_action: Callable[[str, Any], None] | None = None,
   ) -> None:
     """Let each command term create its GUI controls."""
     for name, term in self._terms.items():
-      term.create_gui(name, server, get_env_idx)
+      term.create_gui(
+        name,
+        server,
+        get_env_idx,
+        on_change=on_change,
+        request_action=request_action,
+      )
+
+  def on_viewer_pause(self, paused: bool) -> None:
+    """Notify all command terms of viewer pause state change."""
+    for term in self._terms.values():
+      term.on_viewer_pause(paused)
+
+  def apply_gui_reset(self, env_ids: torch.Tensor) -> bool:
+    """Apply GUI-selected state from all terms. Returns True if any applied."""
+    applied = False
+    for term in self._terms.values():
+      applied |= term.apply_gui_reset(env_ids)
+    return applied
 
   def create_debug_vis_gui(
     self,
-    server: "viser.ViserServer",
+    server: viser.ViserServer,
     on_change: Callable[[], None] | None = None,
   ) -> None:
     """Add per-term debug visualization checkboxes."""
@@ -260,14 +292,22 @@ class NullCommandManager:
 
   def create_gui(
     self,
-    server: "viser.ViserServer",
+    server: viser.ViserServer,
     get_env_idx: Callable[[], int],
+    on_change: Callable[[], None] | None = None,
+    request_action: Callable[[str, Any], None] | None = None,
   ) -> None:
     pass
 
+  def on_viewer_pause(self, paused: bool) -> None:
+    pass
+
+  def apply_gui_reset(self, env_ids: torch.Tensor) -> bool:
+    return False
+
   def create_debug_vis_gui(
     self,
-    server: "viser.ViserServer",
+    server: viser.ViserServer,
     on_change: Callable[[], None] | None = None,
   ) -> None:
     pass

--- a/src/mjlab/tasks/tracking/mdp/commands.py
+++ b/src/mjlab/tasks/tracking/mdp/commands.py
@@ -23,6 +23,11 @@ from mjlab.utils.lab_api.math import (
 from mjlab.viewer.debug_visualizer import DebugVisualizer
 
 if TYPE_CHECKING:
+  from collections.abc import Callable
+  from typing import Any
+
+  import viser
+
   from mjlab.entity import Entity
   from mjlab.envs import ManagerBasedRlEnv
 
@@ -294,6 +299,25 @@ class MotionCommand(CommandTerm):
     self.metrics["sampling_top1_prob"][:] = 1.0 / self.bin_count
     self.metrics["sampling_top1_bin"][:] = 0.5  # No specific bin preference.
 
+  def _write_reference_state_to_sim(
+    self,
+    env_ids: torch.Tensor,
+    root_pos: torch.Tensor,
+    root_ori: torch.Tensor,
+    root_lin_vel: torch.Tensor,
+    root_ang_vel: torch.Tensor,
+    joint_pos: torch.Tensor,
+    joint_vel: torch.Tensor,
+  ) -> None:
+    """Clip joint positions and write root + joint state to sim."""
+    soft_limits = self.robot.data.soft_joint_pos_limits[env_ids]
+    joint_pos = torch.clip(joint_pos, soft_limits[:, :, 0], soft_limits[:, :, 1])
+    self.robot.write_joint_state_to_sim(joint_pos, joint_vel, env_ids=env_ids)
+
+    root_state = torch.cat([root_pos, root_ori, root_lin_vel, root_ang_vel], dim=-1)
+    self.robot.write_root_state_to_sim(root_state, env_ids=env_ids)
+    self.robot.reset(env_ids=env_ids)
+
   def _resample_command(self, env_ids: torch.Tensor):
     if self.cfg.sampling_mode == "start":
       self.time_steps[env_ids] = 0
@@ -303,10 +327,10 @@ class MotionCommand(CommandTerm):
       assert self.cfg.sampling_mode == "adaptive"
       self._adaptive_sampling(env_ids)
 
-    root_pos = self.body_pos_w[:, 0].clone()
-    root_ori = self.body_quat_w[:, 0].clone()
-    root_lin_vel = self.body_lin_vel_w[:, 0].clone()
-    root_ang_vel = self.body_ang_vel_w[:, 0].clone()
+    root_pos = self.body_pos_w[env_ids, 0].clone()
+    root_ori = self.body_quat_w[env_ids, 0].clone()
+    root_lin_vel = self.body_lin_vel_w[env_ids, 0].clone()
+    root_ang_vel = self.body_ang_vel_w[env_ids, 0].clone()
 
     range_list = [
       self.cfg.pose_range.get(key, (0.0, 0.0))
@@ -316,11 +340,11 @@ class MotionCommand(CommandTerm):
     rand_samples = sample_uniform(
       ranges[:, 0], ranges[:, 1], (len(env_ids), 6), device=self.device
     )
-    root_pos[env_ids] += rand_samples[:, 0:3]
+    root_pos += rand_samples[:, 0:3]
     orientations_delta = quat_from_euler_xyz(
       rand_samples[:, 3], rand_samples[:, 4], rand_samples[:, 5]
     )
-    root_ori[env_ids] = quat_mul(orientations_delta, root_ori[env_ids])
+    root_ori = quat_mul(orientations_delta, root_ori)
     range_list = [
       self.cfg.velocity_range.get(key, (0.0, 0.0))
       for key in ["x", "y", "z", "roll", "pitch", "yaw"]
@@ -329,11 +353,11 @@ class MotionCommand(CommandTerm):
     rand_samples = sample_uniform(
       ranges[:, 0], ranges[:, 1], (len(env_ids), 6), device=self.device
     )
-    root_lin_vel[env_ids] += rand_samples[:, :3]
-    root_ang_vel[env_ids] += rand_samples[:, 3:]
+    root_lin_vel += rand_samples[:, :3]
+    root_ang_vel += rand_samples[:, 3:]
 
-    joint_pos = self.joint_pos.clone()
-    joint_vel = self.joint_vel.clone()
+    joint_pos = self.joint_pos[env_ids].clone()
+    joint_vel = self.joint_vel[env_ids]
 
     joint_pos += sample_uniform(
       lower=self.cfg.joint_position_range[0],
@@ -341,33 +365,23 @@ class MotionCommand(CommandTerm):
       size=joint_pos.shape,
       device=joint_pos.device,  # type: ignore
     )
-    soft_joint_pos_limits = self.robot.data.soft_joint_pos_limits[env_ids]
-    joint_pos[env_ids] = torch.clip(
-      joint_pos[env_ids], soft_joint_pos_limits[:, :, 0], soft_joint_pos_limits[:, :, 1]
+
+    self._write_reference_state_to_sim(
+      env_ids,
+      root_pos,
+      root_ori,
+      root_lin_vel,
+      root_ang_vel,
+      joint_pos,
+      joint_vel,
     )
-    self.robot.write_joint_state_to_sim(
-      joint_pos[env_ids], joint_vel[env_ids], env_ids=env_ids
-    )
 
-    root_state = torch.cat(
-      [
-        root_pos[env_ids],
-        root_ori[env_ids],
-        root_lin_vel[env_ids],
-        root_ang_vel[env_ids],
-      ],
-      dim=-1,
-    )
-    self.robot.write_root_state_to_sim(root_state, env_ids=env_ids)
+  def update_relative_body_poses(self) -> None:
+    """Recompute ``body_pos_relative_w`` and ``body_quat_relative_w``.
 
-    self.robot.reset(env_ids=env_ids)
-
-  def _update_command(self):
-    self.time_steps += 1
-    env_ids = torch.where(self.time_steps >= self.motion.time_step_total)[0]
-    if env_ids.numel() > 0:
-      self._resample_command(env_ids)
-
+    Called after ``reset_to_frame`` so that termination checks that
+    compare relative body positions see the correct state.
+    """
     anchor_pos_w_repeat = self.anchor_pos_w[:, None, :].repeat(
       1, len(self.cfg.body_names), 1
     )
@@ -391,6 +405,14 @@ class MotionCommand(CommandTerm):
     self.body_pos_relative_w = delta_pos_w + quat_apply(
       delta_ori_w, self.body_pos_w - anchor_pos_w_repeat
     )
+
+  def _update_command(self):
+    self.time_steps += 1
+    env_ids = torch.where(self.time_steps >= self.motion.time_step_total)[0]
+    if env_ids.numel() > 0:
+      self._resample_command(env_ids)
+
+    self.update_relative_body_poses()
 
     if self.cfg.sampling_mode == "adaptive":
       self.bin_failed_count = (
@@ -468,6 +490,81 @@ class MotionCommand(CommandTerm):
           scale=0.15,
           label=f"current_anchor_{batch}",
         )
+
+  def create_gui(
+    self,
+    name: str,
+    server: viser.ViserServer,
+    get_env_idx: Callable[[], int],
+    on_change: Callable[[], None] | None = None,
+    request_action: Callable[[str, Any], None] | None = None,
+  ) -> None:
+    """Create motion scrubber controls in the Viser viewer."""
+    max_frame = int(self.motion.time_step_total) - 1
+
+    with server.gui.add_folder(name.capitalize()):
+      scrubber = server.gui.add_slider(
+        "Frame",
+        min=0,
+        max=max_frame,
+        step=1,
+        initial_value=0,
+      )
+
+      @scrubber.on_update
+      def _(_) -> None:
+        idx = get_env_idx()
+        self.time_steps[idx] = int(scrubber.value)
+        if on_change is not None:
+          on_change()
+
+      all_envs_cb = server.gui.add_checkbox("All envs", initial_value=True)
+      start_btn = server.gui.add_button("Start Here")
+
+      @start_btn.on_click
+      def _(_) -> None:
+        if request_action is not None:
+          request_action(
+            "CUSTOM",
+            {"type": "gui_reset", "all_envs": all_envs_cb.value},
+          )
+
+    self._scrubber_handles = (scrubber, all_envs_cb, start_btn)
+    self._set_scrubber_disabled(True)
+
+  def _set_scrubber_disabled(self, disabled: bool) -> None:
+    """Enable or disable the motion scrubber GUI controls."""
+    for handle in self._scrubber_handles:
+      handle.disabled = disabled
+
+  def on_viewer_pause(self, paused: bool) -> None:
+    if hasattr(self, "_scrubber_handles"):
+      self._set_scrubber_disabled(not paused)
+
+  def apply_gui_reset(self, env_ids: torch.Tensor) -> bool:
+    if not hasattr(self, "_scrubber_handles"):
+      return False
+    frame = int(self._scrubber_handles[0].value)
+    self.reset_to_frame(env_ids, frame)
+    self.update_relative_body_poses()
+    return True
+
+  def reset_to_frame(self, env_ids: torch.Tensor, frame: int) -> None:
+    """Reset to exact reference state at a specific frame.
+
+    Like ``_resample_command`` but deterministic: no random
+    perturbations to pose, velocity, or joint positions.
+    """
+    self.time_steps[env_ids] = frame
+    self._write_reference_state_to_sim(
+      env_ids,
+      self.body_pos_w[env_ids, 0],
+      self.body_quat_w[env_ids, 0],
+      self.body_lin_vel_w[env_ids, 0],
+      self.body_ang_vel_w[env_ids, 0],
+      self.joint_pos[env_ids],
+      self.joint_vel[env_ids],
+    )
 
 
 @dataclass(kw_only=True)

--- a/src/mjlab/tasks/velocity/mdp/velocity_command.py
+++ b/src/mjlab/tasks/velocity/mdp/velocity_command.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import torch
@@ -142,8 +142,10 @@ class UniformVelocityCommand(CommandTerm):
   def create_gui(
     self,
     name: str,
-    server: "viser.ViserServer",
+    server: viser.ViserServer,
     get_env_idx: Callable[[], int],
+    on_change: Callable[[], None] | None = None,
+    request_action: Callable[[str, Any], None] | None = None,
   ) -> None:
     """Create velocity joystick sliders in the Viser viewer."""
     from viser import Icon

--- a/src/mjlab/viewer/viser/viewer.py
+++ b/src/mjlab/viewer/viser/viewer.py
@@ -13,6 +13,7 @@ from enum import Enum, auto
 from threading import Event, Lock
 from typing import Any, Optional
 
+import torch
 import viser
 from typing_extensions import override
 
@@ -166,7 +167,12 @@ class ViserPlayViewer(BaseViewer):
       env = self.env.unwrapped
       if env.command_manager.active_terms:
         with self._server.gui.add_folder("Commands"):
-          env.command_manager.create_gui(self._server, lambda: self._scene.env_idx)
+          env.command_manager.create_gui(
+            self._server,
+            lambda: self._scene.env_idx,
+            on_change=self._scene.request_update,
+            request_action=self.request_action,
+          )
 
       # Add standard visualization options from MjlabViserScene.
       def _debug_viz_extra() -> None:
@@ -267,6 +273,9 @@ class ViserPlayViewer(BaseViewer):
     action: ViewerAction,
     payload: Optional[Any],
   ) -> bool:
+    if isinstance(payload, dict) and payload.get("type") == "gui_reset":
+      self._handle_gui_reset(payload.get("all_envs", False))
+      return True
     if action != ViewerAction.FETCH_CHECKPOINT:
       return False
     if self._ckpt_mgr is None:
@@ -306,6 +315,26 @@ class ViserPlayViewer(BaseViewer):
       print(f"[INFO]: Loaded {name}")
     return True
 
+  def _handle_gui_reset(self, all_envs: bool) -> None:
+    """Reset environment(s) and apply GUI-selected command state."""
+    env = self.env.unwrapped
+    if all_envs:
+      env_ids = torch.arange(env.num_envs, dtype=torch.int64, device=env.device)
+    else:
+      env_ids = torch.tensor(
+        [self._scene.env_idx], dtype=torch.int64, device=env.device
+      )
+
+    with self._sim_lock:
+      env.reset(env_ids=env_ids)
+      if env.command_manager.apply_gui_reset(env_ids):
+        env.scene.write_data_to_sim()
+        env.sim.forward()
+        env.sim.sense()
+
+    self._pending_update_reasons.add(UpdateReason.ACTION)
+    self._sync_ui_state()
+
   @override
   def _process_actions(self) -> None:
     """Process queued actions and sync UI state."""
@@ -322,6 +351,7 @@ class ViserPlayViewer(BaseViewer):
       viser.Icon.PLAYER_PLAY if self._is_paused else viser.Icon.PLAYER_PAUSE
     )
     self._update_status_display()
+    self.env.unwrapped.command_manager.on_viewer_pause(self._is_paused)
 
   def _update_env_dependent_plots(self) -> None:
     """Refresh reward/metric plots and histories for the selected environment."""


### PR DESCRIPTION
When playing back tracking policies, there was no way to preview the motion reference or start tracking from a specific frame.

Adds a frame slider, "All envs" checkbox, and "Start Here" button to the viser viewer Commands folder for tracking tasks. The controls are disabled while running and enabled when paused. Scrubbing updates the ghost mesh in real time. "Start Here" resets the robot to the exact reference pose at the chosen frame.

Two generic hooks added to `CommandTerm` so the viewer stays task agnostic:
- `on_viewer_pause(paused)` for toggling GUI state
- `apply_gui_reset(env_ids)` for applying GUI selected state on reset

Also refactors `_resample_command` and `reset_to_frame` to share state writing logic via `_write_reference_state_to_sim`.

https://github.com/user-attachments/assets/a5ccf05d-c75b-4a2a-a704-48b618231a3d