### PR TITLE
Speed up terrain proportion spawning tests

### DIFF
--- a/tests/test_terrain_proportion_spawning.py
+++ b/tests/test_terrain_proportion_spawning.py
@@ -11,8 +11,9 @@ from mjlab.terrains.terrain_entity import TerrainEntity, TerrainEntityCfg
 from mjlab.terrains.terrain_generator import TerrainGenerator, TerrainGeneratorCfg
 
 
-def _make_terrain_entity(num_envs: int) -> TerrainEntity:
-  cfg = TerrainEntityCfg(terrain_type="plane", num_envs=num_envs, env_spacing=2.0)
+@pytest.fixture(scope="module")
+def terrain_entity() -> TerrainEntity:
+  cfg = TerrainEntityCfg(terrain_type="plane", num_envs=1, env_spacing=2.0)
   return TerrainEntity(cfg, device="cpu")
 
 
@@ -37,41 +38,38 @@ def _get_counts(entity: TerrainEntity, num_cols: int) -> list[int]:
 # Fallback (no proportions).
 
 
-def test_even_distribution_without_proportions() -> None:
+def test_even_distribution_without_proportions(terrain_entity: TerrainEntity) -> None:
   num_envs = 30
   num_cols = 3
-  entity = _make_terrain_entity(num_envs)
   origins = _make_origins(5, num_cols)
 
-  entity._compute_env_origins_curriculum(num_envs, origins, None)
+  terrain_entity._compute_env_origins_curriculum(num_envs, origins, None)
 
-  assert _get_counts(entity, num_cols) == [10, 10, 10]
+  assert _get_counts(terrain_entity, num_cols) == [10, 10, 10]
 
 
 # Proportional distribution.
 
 
-def test_basic_proportions() -> None:
+def test_basic_proportions(terrain_entity: TerrainEntity) -> None:
   num_envs = 100
   proportions = _normalized([0.5, 0.3, 0.2])
-  entity = _make_terrain_entity(num_envs)
   origins = _make_origins(5, len(proportions))
 
-  entity._compute_env_origins_curriculum(num_envs, origins, proportions)
+  terrain_entity._compute_env_origins_curriculum(num_envs, origins, proportions)
 
-  assert _get_counts(entity, len(proportions)) == [50, 30, 20]
+  assert _get_counts(terrain_entity, len(proportions)) == [50, 30, 20]
 
 
 @pytest.mark.parametrize("num_envs", [3, 7, 32, 64, 100, 512, 1024, 4096])
-def test_counts_sum_to_num_envs(num_envs: int) -> None:
+def test_counts_sum_to_num_envs(terrain_entity: TerrainEntity, num_envs: int) -> None:
   """Total terrain_types length must always equal num_envs."""
   proportions = _normalized([0.6, 0.25, 0.1, 0.05])
-  entity = _make_terrain_entity(num_envs)
   origins = _make_origins(5, len(proportions))
 
-  entity._compute_env_origins_curriculum(num_envs, origins, proportions)
+  terrain_entity._compute_env_origins_curriculum(num_envs, origins, proportions)
 
-  assert len(entity.terrain_types) == num_envs
+  assert len(terrain_entity.terrain_types) == num_envs
 
 
 @pytest.mark.parametrize(
@@ -84,69 +82,70 @@ def test_counts_sum_to_num_envs(num_envs: int) -> None:
   ],
 )
 def test_every_column_gets_at_least_one(
-  num_envs: int, proportions: list[float]
+  terrain_entity: TerrainEntity, num_envs: int, proportions: list[float]
 ) -> None:
   """When num_envs >= num_cols, every column gets at least 1 robot."""
   p = _normalized(proportions)
-  entity = _make_terrain_entity(num_envs)
   origins = _make_origins(5, len(p))
 
-  entity._compute_env_origins_curriculum(num_envs, origins, p)
+  terrain_entity._compute_env_origins_curriculum(num_envs, origins, p)
 
-  counts = _get_counts(entity, len(p))
+  counts = _get_counts(terrain_entity, len(p))
   for col, count in enumerate(counts):
     assert count >= 1, f"Column {col} got 0 envs (counts={counts})"
 
 
-def test_fewer_envs_than_cols() -> None:
+def test_fewer_envs_than_cols(terrain_entity: TerrainEntity) -> None:
   """When num_envs < num_cols, should still work without errors."""
   num_envs = 2
   proportions = _normalized([0.5, 0.3, 0.1, 0.1])
-  entity = _make_terrain_entity(num_envs)
   origins = _make_origins(5, len(proportions))
 
-  result = entity._compute_env_origins_curriculum(num_envs, origins, proportions)
+  result = terrain_entity._compute_env_origins_curriculum(
+    num_envs, origins, proportions
+  )
 
-  assert len(entity.terrain_types) == num_envs
+  assert len(terrain_entity.terrain_types) == num_envs
   assert result.shape == (num_envs, 3)
 
 
-def test_equal_proportions_gives_equal_counts() -> None:
+def test_equal_proportions_gives_equal_counts(terrain_entity: TerrainEntity) -> None:
   num_envs = 30
   proportions = _normalized([1.0, 1.0, 1.0, 1.0])
-  entity = _make_terrain_entity(num_envs)
   origins = _make_origins(5, len(proportions))
 
-  entity._compute_env_origins_curriculum(num_envs, origins, proportions)
+  terrain_entity._compute_env_origins_curriculum(num_envs, origins, proportions)
 
-  counts = _get_counts(entity, len(proportions))
+  counts = _get_counts(terrain_entity, len(proportions))
   for c in counts:
     assert 7 <= c <= 8, f"Expected 7 or 8 envs per column, got {c}"
 
 
-def test_env_origins_shape() -> None:
+def test_env_origins_shape(terrain_entity: TerrainEntity) -> None:
   num_envs = 20
   proportions = _normalized([0.5, 0.3, 0.2])
-  entity = _make_terrain_entity(num_envs)
   origins = _make_origins(5, len(proportions))
 
-  result = entity._compute_env_origins_curriculum(num_envs, origins, proportions)
+  result = terrain_entity._compute_env_origins_curriculum(
+    num_envs, origins, proportions
+  )
 
   assert result.shape == (num_envs, 3)
 
 
-def test_env_origins_match_terrain_origins() -> None:
+def test_env_origins_match_terrain_origins(terrain_entity: TerrainEntity) -> None:
   """Each env_origin must correspond to a valid (level, type) in origins."""
   num_envs = 50
   proportions = _normalized([0.6, 0.3, 0.1])
-  entity = _make_terrain_entity(num_envs)
   origins = _make_origins(5, len(proportions))
 
-  result = entity._compute_env_origins_curriculum(num_envs, origins, proportions)
+  result = terrain_entity._compute_env_origins_curriculum(
+    num_envs, origins, proportions
+  )
 
   for i in range(num_envs):
-    level = int(entity.terrain_levels[i].item())
-    ttype = int(entity.terrain_types[i].item())
+    level = int(terrain_entity.terrain_levels[i].item())
+    ttype = int(terrain_entity.terrain_types[i].item())
     expected = origins[level, ttype]
     assert torch.allclose(result[i], expected), (
       f"env {i}: origin {result[i].tolist()} != "
@@ -154,31 +153,31 @@ def test_env_origins_match_terrain_origins() -> None:
     )
 
 
-def test_mismatched_cols_falls_back_to_even() -> None:
+def test_mismatched_cols_falls_back_to_even(terrain_entity: TerrainEntity) -> None:
   """When proportions length != num_cols, should fall back to even."""
   num_envs = 30
   num_cols = 3
   # 4 proportions but only 3 columns in origins.
   proportions = _normalized([0.4, 0.3, 0.2, 0.1])
-  entity = _make_terrain_entity(num_envs)
   origins = _make_origins(5, num_cols)
 
-  entity._compute_env_origins_curriculum(num_envs, origins, proportions)
+  terrain_entity._compute_env_origins_curriculum(num_envs, origins, proportions)
 
-  assert _get_counts(entity, num_cols) == [10, 10, 10]
+  assert _get_counts(terrain_entity, num_cols) == [10, 10, 10]
 
 
-def test_proportions_are_respected_approximately() -> None:
+def test_proportions_are_respected_approximately(
+  terrain_entity: TerrainEntity,
+) -> None:
   """With large num_envs, actual distribution should track proportions."""
   num_envs = 10000
   raw = [0.5, 0.3, 0.15, 0.05]
   proportions = _normalized(raw)
-  entity = _make_terrain_entity(num_envs)
   origins = _make_origins(5, len(proportions))
 
-  entity._compute_env_origins_curriculum(num_envs, origins, proportions)
+  terrain_entity._compute_env_origins_curriculum(num_envs, origins, proportions)
 
-  counts = _get_counts(entity, len(proportions))
+  counts = _get_counts(terrain_entity, len(proportions))
   for col, (count, prop) in enumerate(zip(counts, proportions, strict=True)):
     expected = prop * num_envs
     assert abs(count - expected) < 10, (


### PR DESCRIPTION
Each test constructed a fresh `TerrainEntity` with the test's `num_envs`, triggering `_add_env_origin_sites()` — a loop that calls `add_site()` once per environment. For the parametrized cases (up to 10,000 envs) this dominated runtime, even though all tests just call `_compute_env_origins_curriculum` directly and don't need the MuJoCo spec to be populated.

The fix is a module-scoped fixture that builds one `TerrainEntity(num_envs=1)` for the whole file. The suite now runs in ~0.03s.