### PR TITLE
Cache Warp kernels in CI to speed up test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,13 @@ jobs:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
           version: "0.9.27"
+      - name: Restore Warp kernel cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/warp
+          key: warp-kernels-${{ runner.os }}-${{ runner.arch }}-${{ matrix.python-version }}-${{ hashFiles('uv.lock', 'mjlab/**/*.py') }}
+          restore-keys: |
+            warp-kernels-${{ runner.os }}-${{ runner.arch }}-${{ matrix.python-version }}-
       - name: Test with python ${{ matrix.python-version }}
         run: uv run --extra cpu pytest
 


### PR DESCRIPTION
Warp JIT-compiles kernels on first use. By caching `~/.cache/warp` keyed on `uv.lock` and the mjlab source files, subsequent CI runs that don't touch Warp-related code skip recompilation entirely. The `restore-keys` fallback ensures a partial cache hit on dependency bumps, so only newly changed kernels recompile. Inspired by the same pattern in Newton's CI.