### PR TITLE
Use wandb Run.load() instead of Run.update() to refresh checkpoint list

### DIFF
--- a/src/mjlab/scripts/play.py
+++ b/src/mjlab/scripts/play.py
@@ -248,7 +248,7 @@ def run_play(task_id: str, cfg: PlayConfig):
       _log_root = log_root_path  # pyright: ignore[reportPossiblyUnboundVariable]
 
       def fetch_available_wandb() -> list[tuple[str, str]]:
-        wandb_run.update()
+        wandb_run.load()
         now = datetime.now(tz=timezone.utc)
         entries: list[tuple[str, str, int]] = []
         for f in wandb_run.files():


### PR DESCRIPTION
Run.update() pushes metadata changes to the server and requires write permissions, causing HTTP/permission errors for users with read-only access to the run. Run.load() just re-fetches the run's data from the server, which is all we need when refreshing the available checkpoint list in the viewer.

Thanks @chungmin99 for catching this in #751.