### PR TITLE
Remove redundant spec.assets loading

### DIFF
--- a/docs/source/entity/index.rst
+++ b/docs/source/entity/index.rst
@@ -118,16 +118,14 @@ For simple cases a lambda suffices:
 
     spec_fn = lambda: mujoco.MjSpec.from_file("robot.xml")
 
-For anything more involved, use a regular function. The asset zoo robots
-all follow this pattern: load the XML, attach mesh assets, and return
-the spec.
+For anything more involved, use a regular function. MuJoCo resolves mesh
+assets from disk automatically, so ``get_spec`` only needs to load the
+XML:
 
 .. code-block:: python
 
     def get_spec() -> mujoco.MjSpec:
-        spec = mujoco.MjSpec.from_file(str(ROBOT_XML))
-        spec.assets = get_assets(spec.meshdir)
-        return spec
+        return mujoco.MjSpec.from_file(str(ROBOT_XML))
 
 Because ``spec_fn`` is an arbitrary callable, you can perform any
 `MjSpec edits <https://mujoco.readthedocs.io/en/stable/python.html#spec>`_

--- a/src/mjlab/asset_zoo/robots/i2rt_yam/yam_constants.py
+++ b/src/mjlab/asset_zoo/robots/i2rt_yam/yam_constants.py
@@ -11,7 +11,6 @@ from mjlab.utils.actuator import (
   ElectricActuator,
   reflect_rotary_to_linear,
 )
-from mjlab.utils.os import update_assets
 from mjlab.utils.spec_config import CollisionCfg
 
 ##
@@ -24,16 +23,8 @@ YAM_XML: Path = (
 assert YAM_XML.exists()
 
 
-def get_assets(meshdir: str) -> dict[str, bytes]:
-  assets: dict[str, bytes] = {}
-  update_assets(assets, YAM_XML.parent / "assets", meshdir)
-  return assets
-
-
 def get_spec() -> mujoco.MjSpec:
-  spec = mujoco.MjSpec.from_file(str(YAM_XML))
-  spec.assets = get_assets(spec.meshdir)
-  return spec
+  return mujoco.MjSpec.from_file(str(YAM_XML))
 
 
 ##

--- a/src/mjlab/asset_zoo/robots/unitree_g1/g1_constants.py
+++ b/src/mjlab/asset_zoo/robots/unitree_g1/g1_constants.py
@@ -11,7 +11,6 @@ from mjlab.utils.actuator import (
   ElectricActuator,
   reflected_inertia_from_two_stage_planetary,
 )
-from mjlab.utils.os import update_assets
 from mjlab.utils.spec_config import CollisionCfg
 
 ##
@@ -24,16 +23,8 @@ G1_XML: Path = (
 assert G1_XML.exists()
 
 
-def get_assets(meshdir: str) -> dict[str, bytes]:
-  assets: dict[str, bytes] = {}
-  update_assets(assets, G1_XML.parent / "assets", meshdir)
-  return assets
-
-
 def get_spec() -> mujoco.MjSpec:
-  spec = mujoco.MjSpec.from_file(str(G1_XML))
-  spec.assets = get_assets(spec.meshdir)
-  return spec
+  return mujoco.MjSpec.from_file(str(G1_XML))
 
 
 ##

--- a/src/mjlab/asset_zoo/robots/unitree_go1/go1_constants.py
+++ b/src/mjlab/asset_zoo/robots/unitree_go1/go1_constants.py
@@ -8,7 +8,6 @@ from mjlab import MJLAB_SRC_PATH
 from mjlab.actuator import BuiltinPositionActuatorCfg
 from mjlab.entity import EntityArticulationInfoCfg, EntityCfg
 from mjlab.utils.actuator import ElectricActuator, reflected_inertia
-from mjlab.utils.os import update_assets
 from mjlab.utils.spec_config import CollisionCfg
 
 ##
@@ -21,16 +20,8 @@ GO1_XML: Path = (
 assert GO1_XML.exists()
 
 
-def get_assets(meshdir: str) -> dict[str, bytes]:
-  assets: dict[str, bytes] = {}
-  update_assets(assets, GO1_XML.parent / "assets", meshdir)
-  return assets
-
-
 def get_spec() -> mujoco.MjSpec:
-  spec = mujoco.MjSpec.from_file(str(GO1_XML))
-  spec.assets = get_assets(spec.meshdir)
-  return spec
+  return mujoco.MjSpec.from_file(str(GO1_XML))
 
 
 ##

--- a/src/mjlab/utils/os.py
+++ b/src/mjlab/utils/os.py
@@ -1,37 +1,8 @@
 import re
 from pathlib import Path
-from typing import Any, Dict
+from typing import Dict
 
 import yaml
-
-
-def update_assets(
-  assets: Dict[str, Any],
-  path: str | Path,
-  meshdir: str | None = None,
-  glob: str = "*",
-  recursive: bool = False,
-):
-  """Update assets dictionary with files from a directory.
-
-  This function reads files from a directory and adds them to an assets dictionary,
-  with keys formatted to include the meshdir prefix when specified.
-
-  Args:
-    assets: Dictionary to update with file contents. Keys are asset paths, values are
-      file contents as bytes.
-    path: Path to directory containing asset files.
-    meshdir: Optional mesh directory prefix, typically `spec.meshdir`. If provided,
-      will be prepended to asset keys (e.g., "mesh.obj" becomes "custom_dir/mesh.obj").
-    glob: Glob pattern for file matching. Defaults to "*" (all files).
-    recursive: If True, recursively search subdirectories.
-  """
-  for f in Path(path).glob(glob):
-    if f.is_file():
-      asset_key = f"{meshdir}/{f.name}" if meshdir else f.name
-      assets[asset_key] = f.read_bytes()
-    elif f.is_dir() and recursive:
-      update_assets(assets, f, meshdir, glob, recursive)
 
 
 def dump_yaml(filename: Path, data: Dict, sort_keys: bool = False) -> None:


### PR DESCRIPTION
When `spec.assets` is empty, `MjSpec.Compile()` calls `mj_compile` with `vfs=nullptr`. MuJoCo's compiler then resolves mesh files directly from the OS filesystem via `mju_openResource`, which falls back to disk reads when no VFS is provided. The `get_assets`/`update_assets` pattern was reading those same files from disk into a Python dict, only for them to be round-tripped back into a VFS at compile time. Removes the redundant `get_assets` functions from all three robot constant files, the now-unused `update_assets` utility, and updates the entity docs accordingly.