### PR TITLE
docs: add InstinctMJ to mjlab projects

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -36,6 +36,8 @@ Added
   once per physics substep inside the decimation loop. The per substep
   values are averaged within each environment step, so episode averages
   remain comparable to regular per step metrics.
+- Added ``project-instinct/InstinctMJ`` to the research page's list of
+  projects built on mjlab.
 - Added a Checkpoints tab to the Viser play viewer for hot-swapping
   checkpoints without restarting. Works with local directories and W&B
   runs (:issue:`751`). Contribution by @omarrayyann.

--- a/docs/source/research.rst
+++ b/docs/source/research.rst
@@ -69,3 +69,5 @@ Projects built on mjlab. To add yours, open a pull request or post in
      - PAL Robotics robots and tasks.
    * - `Msornerrrr/in-hand-rotation-mjlab <https://github.com/Msornerrrr/in-hand-rotation-mjlab>`_
      - Sim to real RL for in hand cube rotation with the LEAP Hand.
+   * - `project-instinct/InstinctMJ <https://github.com/project-instinct/InstinctMJ>`_
+     - mjlab version of Project-Instinct, a whole-body control toolchain to study Instinct-Level intelligence.


### PR DESCRIPTION
## Summary
- add `project-instinct/InstinctMJ` to the research page's Projects list
- add the required changelog entry for the docs update

## Notes
- description uses the Project-Instinct mjlab positioning: a whole-body control toolchain to study Instinct-Level intelligence
- docs-only change