### PR TITLE
Add dr.pair_friction for geom-pair friction randomization

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -102,6 +102,7 @@ autodoc_mock_imports = [
   "tensordict",
   "trimesh",
   "toml",
+  "mjviser",
   "mujoco_warp",
   "gymnasium",
   "rsl_rl",

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,6 +8,8 @@ Upcoming version (not yet released)
 Added
 ^^^^^
 
+- Added :func:`~mjlab.envs.mdp.dr.pair_friction` for randomizing geom-pair
+  friction overrides (``pair_friction`` in ``mjModel``).
 - Added ``STAIRS_TERRAINS_CFG`` terrain preset for progressive stair
   curriculum training and ``@terrain_preset`` decorator for composing
   terrain configurations from reusable presets.

--- a/docs/source/randomization.rst
+++ b/docs/source/randomization.rst
@@ -231,6 +231,24 @@ and ``dr.body_ipos`` are the same function).
      - Material RGBA color (tints textures)
      -
 
+.. rubric:: Contact pair fields
+
+.. list-table::
+   :header-rows: 1
+   :widths: 28 18 34 20
+
+   * - Function
+     - MuJoCo field
+     - Description
+     - Notes
+   * - ``dr.pair_friction``
+     - ``pair_friction``
+     - Per-pair friction override ``[tangent1, tangent2, spin, roll1, roll2]``
+     - Default axis: 0 (tangent1, requires ``condim >= 3``). Overrides
+       per-geom friction for explicitly defined
+       `<contact><pair> <https://mujoco.readthedocs.io/en/stable/XMLreference.html#contact-pair>`_
+       elements
+
 .. rubric:: Tendon fields
 
 .. list-table::
@@ -647,8 +665,8 @@ choices. Write a custom event term instead (see
      - ``geom_margin``, ``geom_gap``, ``pair_margin``, ``pair_gap``
      - Interact with solver parameters above.
    * - Pair overrides
-     - ``pair_friction``, ``eq_data``
-     - Per-pair friction and constraint anchor overrides.
+     - ``eq_data``
+     - Constraint anchor overrides.
    * - Spring reference
      - ``qpos_spring``
      - Coupled with ``qpos0``; randomizing independently is

--- a/src/mjlab/entity/entity.py
+++ b/src/mjlab/entity/entity.py
@@ -36,6 +36,7 @@ class EntityIndexing:
   cameras: tuple[mujoco.MjsCamera, ...]
   lights: tuple[mujoco.MjsLight, ...]
   materials: tuple[mujoco.MjsMaterial, ...]
+  pairs: tuple[mujoco.MjsPair, ...]
   actuators: tuple[mujoco.MjsActuator, ...] | None
 
   # Indices.
@@ -46,6 +47,7 @@ class EntityIndexing:
   cam_ids: torch.Tensor
   light_ids: torch.Tensor
   mat_ids: torch.Tensor
+  pair_ids: torch.Tensor
   ctrl_ids: torch.Tensor
   joint_ids: torch.Tensor
   mocap_id: int | None
@@ -427,6 +429,10 @@ class Entity:
     return tuple(m.name.split("/")[-1] for m in self.spec.materials)
 
   @property
+  def pair_names(self) -> tuple[str, ...]:
+    return tuple(p.name.split("/")[-1] for p in self.spec.pairs)
+
+  @property
   def actuator_names(self) -> tuple[str, ...]:
     return tuple(a.name.split("/")[-1] for a in self.spec.actuators)
 
@@ -463,6 +469,10 @@ class Entity:
   @property
   def num_materials(self) -> int:
     return len(self.material_names)
+
+  @property
+  def num_pairs(self) -> int:
+    return len(self.pair_names)
 
   @property
   def num_actuators(self) -> int:
@@ -572,6 +582,16 @@ class Entity:
     if material_subset is None:
       material_subset = self.material_names
     return resolve_matching_names(name_keys, material_subset, preserve_order)
+
+  def find_pairs(
+    self,
+    name_keys: str | Sequence[str],
+    pair_subset: Sequence[str] | None = None,
+    preserve_order: bool = False,
+  ) -> tuple[list[int], list[str]]:
+    if pair_subset is None:
+      pair_subset = self.pair_names
+    return resolve_matching_names(name_keys, pair_subset, preserve_order)
 
   def find_actuators(
     self,
@@ -1139,6 +1159,7 @@ class Entity:
     cameras = tuple(self.spec.cameras)
     lights = tuple(self.spec.lights)
     materials = tuple(self.spec.materials)
+    pairs = tuple(self.spec.pairs)
 
     body_ids = torch.tensor([b.id for b in bodies], dtype=torch.int, device=device)
     geom_ids = torch.tensor([g.id for g in geoms], dtype=torch.int, device=device)
@@ -1147,6 +1168,7 @@ class Entity:
     cam_ids = torch.tensor([c.id for c in cameras], dtype=torch.int, device=device)
     light_ids = torch.tensor([lt.id for lt in lights], dtype=torch.int, device=device)
     mat_ids = torch.tensor([m.id for m in materials], dtype=torch.int, device=device)
+    pair_ids = torch.tensor([p.id for p in pairs], dtype=torch.int, device=device)
     joint_ids = torch.tensor([j.id for j in joints], dtype=torch.int, device=device)
 
     if self.is_actuated:
@@ -1190,6 +1212,7 @@ class Entity:
       cameras=cameras,
       lights=lights,
       materials=materials,
+      pairs=pairs,
       actuators=actuators,
       body_ids=body_ids,
       geom_ids=geom_ids,
@@ -1198,6 +1221,7 @@ class Entity:
       cam_ids=cam_ids,
       light_ids=light_ids,
       mat_ids=mat_ids,
+      pair_ids=pair_ids,
       ctrl_ids=ctrl_ids,
       joint_ids=joint_ids,
       mocap_id=mocap_id,

--- a/src/mjlab/envs/mdp/dr/__init__.py
+++ b/src/mjlab/envs/mdp/dr/__init__.py
@@ -73,6 +73,10 @@ from .light import light_pos as light_pos
 # isort: split
 from .material import mat_rgba as mat_rgba
 
+# Pair.
+# isort: split
+from .pair import pair_friction as pair_friction
+
 # Actuator.
 # isort: split
 from .actuator import effort_limits as effort_limits

--- a/src/mjlab/envs/mdp/dr/_core.py
+++ b/src/mjlab/envs/mdp/dr/_core.py
@@ -39,6 +39,7 @@ _ENTITY_NAMES_ATTR: dict[str, str] = {
   "camera": "camera_names",
   "light": "light_names",
   "material": "material_names",
+  "pair": "pair_names",
 }
 
 # Private engine.
@@ -214,6 +215,8 @@ def _get_entity_indices(
       return indexing.light_ids[asset_cfg.light_ids]
     case "material":
       return indexing.mat_ids[asset_cfg.material_ids]
+    case "pair":
+      return indexing.pair_ids[asset_cfg.pair_ids]
     case _:
       raise ValueError(f"Unknown entity type: {entity_type}")
 

--- a/src/mjlab/envs/mdp/dr/pair.py
+++ b/src/mjlab/envs/mdp/dr/pair.py
@@ -1,0 +1,61 @@
+"""Domain randomization functions for geom pair fields."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from mjlab.managers.event_manager import requires_model_fields
+from mjlab.managers.scene_entity_config import SceneEntityCfg
+
+from ._core import _DEFAULT_ASSET_CFG, Ranges, _randomize_model_field
+from ._types import Distribution, Operation
+
+if TYPE_CHECKING:
+  import torch
+
+  from mjlab.envs import ManagerBasedRlEnv
+
+
+@requires_model_fields("pair_friction")
+def pair_friction(
+  env: ManagerBasedRlEnv,
+  env_ids: torch.Tensor | None,
+  ranges: Ranges,
+  asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
+  distribution: Distribution | str = "uniform",
+  operation: Operation | str = "abs",
+  axes: list[int] | None = None,
+  shared_random: bool = False,
+) -> None:
+  """Randomize geom-pair friction overrides.
+
+  Pair friction has 5 components: ``[tangent1, tangent2, spin, roll1, roll2]``.
+  Default axis is 0 (tangent1 only). Axis 0 requires ``condim >= 3``
+  (the default); axes 1 and 2 require ``condim >= 4``; axes 3 and 4
+  require ``condim = 6``.
+
+  Args:
+    env: The environment instance.
+    env_ids: Environment indices to randomize. ``None`` means all.
+    ranges: Value range(s) for sampling.
+    asset_cfg: Entity and pair selection.
+    distribution: Sampling distribution.
+    operation: How to combine sampled values with the base.
+    axes: Which friction components to randomize. Defaults to ``[0]`` (tangent1).
+    shared_random: If ``True``, all selected pairs receive the same sampled value per
+      environment.
+  """
+  _randomize_model_field(
+    env,
+    env_ids,
+    "pair_friction",
+    entity_type="pair",
+    ranges=ranges,
+    distribution=distribution,
+    operation=operation,
+    asset_cfg=asset_cfg,
+    axes=axes,
+    shared_random=shared_random,
+    default_axes=[0],
+    valid_axes=[0, 1, 2, 3, 4],
+  )

--- a/src/mjlab/managers/scene_entity_config.py
+++ b/src/mjlab/managers/scene_entity_config.py
@@ -47,6 +47,7 @@ _FIELD_CONFIGS = [
     "num_materials",
     "material",
   ),
+  _FieldConfig("pair_names", "pair_ids", "find_pairs", "num_pairs", "pair"),
 ]
 
 
@@ -115,6 +116,12 @@ class SceneEntityCfg:
 
   material_ids: list[int] | slice = field(default_factory=lambda: slice(None))
   """IDs of materials to include. Can be a list or slice."""
+
+  pair_names: str | tuple[str, ...] | None = None
+  """Names of contact pairs to include. Can be a single string or tuple."""
+
+  pair_ids: list[int] | slice = field(default_factory=lambda: slice(None))
+  """IDs of contact pairs to include. Can be a list or slice."""
 
   preserve_order: bool = False
   """If True, maintains the order of components as specified."""

--- a/tests/test_domain_randomization.py
+++ b/tests/test_domain_randomization.py
@@ -1640,3 +1640,221 @@ def test_mat_rgba_invalid_name(mat_env):
       ranges=(0.2, 0.8),
       asset_cfg=cfg,
     )
+
+
+# pair_friction tests.
+
+PAIR_XML = """
+<mujoco>
+  <worldbody>
+    <body name="base" pos="0 0 1">
+      <freejoint name="free_joint"/>
+      <geom name="base_geom" type="box" size="0.1 0.1 0.1" mass="1.0"/>
+      <body name="foot" pos="0 0 -0.15">
+        <geom name="foot_geom" type="box" size="0.05 0.05 0.02" mass="0.1"/>
+      </body>
+    </body>
+    <geom name="floor" type="plane" size="2 2 0.1"/>
+  </worldbody>
+  <contact>
+    <pair name="base_floor" geom1="base_geom" geom2="floor"
+          friction="0.5 0.5 0.005 0.0001 0.0001"/>
+    <pair name="foot_floor" geom1="foot_geom" geom2="floor"
+          friction="0.3 0.3 0.003 0.0002 0.0002"/>
+  </contact>
+</mujoco>
+"""
+
+
+@pytest.fixture(scope="module")
+def pair_env(device):
+  entity_cfg = EntityCfg(spec_fn=lambda: mujoco.MjSpec.from_string(PAIR_XML))
+  scene_cfg = SceneCfg(num_envs=NUM_ENVS, entities={"robot": entity_cfg})
+  scene = Scene(scene_cfg, device)
+  model = scene.compile()
+  sim = Simulation(num_envs=NUM_ENVS, cfg=SimulationCfg(), model=model, device=device)
+  scene.initialize(model, sim.model, sim.data)
+  sim.expand_model_fields(("pair_friction",))
+  return Env(scene, sim, device)
+
+
+def test_pair_friction_abs(pair_env):
+  """Values set directly within range, diverse across envs."""
+  torch.manual_seed(42)
+  env = pair_env
+  robot = env.scene["robot"]
+
+  dr.pair_friction(env, env_ids=None, ranges=(0.4, 1.5), operation="abs")
+
+  friction = env.sim.model.pair_friction[:, robot.indexing.pair_ids, 0]
+  assert torch.all((friction >= 0.4) & (friction <= 1.5))
+  assert len(torch.unique(friction)) >= 2
+
+
+def test_pair_friction_scale(pair_env):
+  """Values = default * sample; no accumulation after 3 calls."""
+  env = pair_env
+  robot = env.scene["robot"]
+  pair_idx = robot.indexing.pair_ids[0]
+  default_val = env.sim.get_default_field("pair_friction")[pair_idx, 0].item()
+
+  for _ in range(3):
+    dr.pair_friction(
+      env,
+      env_ids=None,
+      ranges=(2.0, 2.0),
+      operation="scale",
+      asset_cfg=SceneEntityCfg("robot", pair_ids=[0]),
+      axes=[0],
+    )
+
+  result = env.sim.model.pair_friction[:, pair_idx, 0]
+  assert torch.allclose(result, torch.full_like(result, default_val * 2.0), atol=1e-5)
+
+
+def test_pair_friction_add(pair_env):
+  """Values = default + sample; no accumulation after 3 calls."""
+  env = pair_env
+  robot = env.scene["robot"]
+  pair_idx = robot.indexing.pair_ids[0]
+  default_val = env.sim.get_default_field("pair_friction")[pair_idx, 0].item()
+
+  for _ in range(3):
+    dr.pair_friction(
+      env,
+      env_ids=None,
+      ranges=(0.1, 0.1),
+      operation="add",
+      asset_cfg=SceneEntityCfg("robot", pair_ids=[0]),
+      axes=[0],
+    )
+
+  result = env.sim.model.pair_friction[:, pair_idx, 0]
+  assert torch.allclose(result, torch.full_like(result, default_val + 0.1), atol=1e-5)
+
+
+def test_pair_friction_axes_selectivity(pair_env):
+  """Only the targeted axis changes; others stay at their original values."""
+  torch.manual_seed(7)
+  env = pair_env
+  robot = env.scene["robot"]
+
+  before = env.sim.model.pair_friction.clone()
+
+  dr.pair_friction(env, env_ids=None, ranges=(0.8, 1.2), operation="abs", axes=[0])
+
+  after = env.sim.model.pair_friction
+  pair_ids = robot.indexing.pair_ids
+  # Axis 0 changed.
+  assert not torch.allclose(after[:, pair_ids, 0], before[:, pair_ids, 0])
+  # Axes 1-4 unchanged.
+  for ax in range(1, 5):
+    assert torch.allclose(after[:, pair_ids, ax], before[:, pair_ids, ax])
+
+
+def test_pair_friction_partial_env_ids(pair_env):
+  """Randomizing a subset of envs leaves the others unchanged."""
+  torch.manual_seed(99)
+  env = pair_env
+  robot = env.scene["robot"]
+
+  before = env.sim.model.pair_friction.clone()
+  randomized_ids = torch.tensor([0, 1], device=env.device)
+
+  dr.pair_friction(
+    env, env_ids=randomized_ids, ranges=(2.0, 3.0), operation="abs", axes=[0]
+  )
+
+  after = env.sim.model.pair_friction
+  pair_ids = robot.indexing.pair_ids
+  unchanged_ids = torch.tensor([2, 3], device=env.device)
+  assert torch.allclose(
+    after[unchanged_ids[:, None], pair_ids[None, :], :],
+    before[unchanged_ids[:, None], pair_ids[None, :], :],
+  )
+
+
+def test_pair_friction_shared_random(pair_env):
+  """All pairs in the same env get the same value; envs differ."""
+  torch.manual_seed(5)
+  env = pair_env
+  robot = env.scene["robot"]
+
+  dr.pair_friction(
+    env, env_ids=None, ranges=(0.5, 2.0), operation="abs", axes=[0], shared_random=True
+  )
+
+  pair_ids = robot.indexing.pair_ids
+  friction = env.sim.model.pair_friction[:, pair_ids, 0]
+  # Within each env, all pairs have the same value.
+  for e in range(env.num_envs):
+    row = friction[e]
+    assert torch.allclose(row, row[0].expand_as(row), atol=1e-6)
+  # Across envs, values differ.
+  assert not torch.allclose(friction[0], friction[1])
+
+
+def test_pair_friction_by_name(pair_env):
+  """Targeting pair by name only modifies that pair."""
+  torch.manual_seed(11)
+  env = pair_env
+  robot = env.scene["robot"]
+
+  foot_cfg = SceneEntityCfg("robot", pair_names=("foot_floor",))
+  foot_cfg.resolve(env.scene)
+  base_cfg = SceneEntityCfg("robot", pair_names=("base_floor",))
+  base_cfg.resolve(env.scene)
+  foot_pair_id = robot.indexing.pair_ids[foot_cfg.pair_ids]
+  base_pair_id = robot.indexing.pair_ids[base_cfg.pair_ids]
+
+  before = env.sim.model.pair_friction.clone()
+  dr.pair_friction(
+    env, env_ids=None, ranges=(1.5, 2.5), operation="abs", asset_cfg=foot_cfg
+  )
+
+  after = env.sim.model.pair_friction
+  # foot_floor changed.
+  assert not torch.allclose(after[:, foot_pair_id, 0], before[:, foot_pair_id, 0])
+  # base_floor unchanged.
+  assert torch.allclose(after[:, base_pair_id, :], before[:, base_pair_id, :])
+
+
+def test_pair_friction_string_ranges(pair_env):
+  """Dict with pair name patterns randomizes the matched pairs correctly."""
+  torch.manual_seed(13)
+  env = pair_env
+  robot = env.scene["robot"]
+
+  dr.pair_friction(
+    env,
+    env_ids=None,
+    ranges={"base_floor": (1.0, 1.0), "foot_floor": (0.5, 0.5)},
+    operation="abs",
+    axes=[0],
+  )
+
+  base_cfg = SceneEntityCfg("robot", pair_names=("base_floor",))
+  base_cfg.resolve(env.scene)
+  foot_cfg = SceneEntityCfg("robot", pair_names=("foot_floor",))
+  foot_cfg.resolve(env.scene)
+  base_id = robot.indexing.pair_ids[base_cfg.pair_ids]
+  foot_id = robot.indexing.pair_ids[foot_cfg.pair_ids]
+  assert torch.allclose(
+    env.sim.model.pair_friction[:, base_id, 0],
+    torch.ones(env.num_envs, device=env.device),
+    atol=1e-5,
+  )
+  assert torch.allclose(
+    env.sim.model.pair_friction[:, foot_id, 0],
+    torch.full((env.num_envs,), 0.5, device=env.device),
+    atol=1e-5,
+  )
+
+
+def test_pair_friction_invalid_name(pair_env):
+  """ValueError for unknown pair name."""
+  env = pair_env
+
+  with pytest.raises(ValueError, match="nonexistent_pair"):
+    cfg = SceneEntityCfg("robot", pair_names=("nonexistent_pair",))
+    cfg.resolve(env.scene)


### PR DESCRIPTION
MuJoCo's `<contact><pair>` elements define explicit per-pair friction overrides that take precedence over per-geom defaults during contact resolution. This adds `dr.pair_friction` to randomize those overrides independently.

`pair_friction` has 5 components: `[tangent1, tangent2, spin, roll1, roll2]`. The default axis is 0 (tangent1 only). Axes 1–4 only apply to contacts with `condim >= 4` or `condim = 6`.

To wire it in, the PR adds pair support throughout the entity layer: `EntityIndexing` gains `pairs` and `pair_ids`, `Entity` gains `pair_names`/`num_pairs`/`find_pairs()`, and `SceneEntityCfg` gains `pair_names`/`pair_ids` fields. The DR core engine gets a `"pair"` entity type entry. Everything follows the same patterns as existing terms like `geom_friction` and `mat_rgba`.

Also fixes a pre-existing docs build issue: `mjviser` was not in `autodoc_mock_imports`, causing Sphinx to import it and trip over a `trimesh.Trimesh | None` annotation at module level.

Usage:
```python
dr.pair_friction(env, env_ids=None, ranges=(0.5, 1.5))
dr.pair_friction(env, env_ids=None, ranges=(0.8, 1.2),
                 asset_cfg=SceneEntityCfg("robot", pair_names=("foot_floor",)))
```