### PR TITLE
Add relative joint position control

### DIFF
--- a/docs/source/actions.rst
+++ b/docs/source/actions.rst
@@ -76,6 +76,10 @@ Action types
        Encoder bias from ``dr.encoder_bias`` is subtracted automatically
        so that randomized offsets propagate correctly to the control
        command.
+   * - ``RelativeJointPositionAction``
+     - Sets joint position targets relative to the current joint positions.
+       The target is ``current_pos + action * scale``, so a policy output of
+       zero holds the robot in place regardless of its current configuration.
    * - ``JointVelocityAction``
      - Sets joint velocity targets. ``use_default_offset=True`` uses the
        default joint velocities (typically zero).

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,6 +8,10 @@ Upcoming version (not yet released)
 Added
 ^^^^^
 
+- Added :class:`~mjlab.envs.mdp.actions.RelativeJointPositionAction` for
+  joint position control relative to the current configuration. The target is
+  ``current_pos + action * scale``, so a zero action holds the current
+  configuration rather than commanding the default pose.
 - Added :func:`~mjlab.envs.mdp.dr.pair_friction` for randomizing geom-pair
   friction overrides (``pair_friction`` in ``mjModel``).
 - Added ``STAIRS_TERRAINS_CFG`` terrain preset for progressive stair

--- a/src/mjlab/envs/mdp/actions/__init__.py
+++ b/src/mjlab/envs/mdp/actions/__init__.py
@@ -8,6 +8,12 @@ from mjlab.envs.mdp.actions.actions import JointVelocityAction as JointVelocityA
 from mjlab.envs.mdp.actions.actions import (
   JointVelocityActionCfg as JointVelocityActionCfg,
 )
+from mjlab.envs.mdp.actions.actions import (
+  RelativeJointPositionAction as RelativeJointPositionAction,
+)
+from mjlab.envs.mdp.actions.actions import (
+  RelativeJointPositionActionCfg as RelativeJointPositionActionCfg,
+)
 from mjlab.envs.mdp.actions.actions import SiteEffortAction as SiteEffortAction
 from mjlab.envs.mdp.actions.actions import SiteEffortActionCfg as SiteEffortActionCfg
 from mjlab.envs.mdp.actions.actions import TendonEffortAction as TendonEffortAction

--- a/src/mjlab/envs/mdp/actions/actions.py
+++ b/src/mjlab/envs/mdp/actions/actions.py
@@ -224,6 +224,39 @@ class JointPositionAction(BaseAction):
     self._entity.set_joint_position_target(target, joint_ids=self._target_ids)
 
 
+@dataclass(kw_only=True)
+class RelativeJointPositionActionCfg(BaseActionCfg):
+  """Configuration for joint position control relative to current positions.
+
+  target = current_joint_pos + action * scale
+
+  The ``offset`` field inherited from ``BaseActionCfg`` is not supported and
+  must remain at its default of ``0.0``. The ``clip`` field is supported and
+  clamps the delta (``action * scale``) before it is added to the current
+  position.
+  """
+
+  def __post_init__(self):
+    self.transmission_type = TransmissionType.JOINT
+    if self.offset != 0.0:
+      raise ValueError(
+        "RelativeJointPositionActionCfg does not support 'offset'. "
+        "The target is current_pos + action * scale; a fixed offset has no meaning."
+      )
+
+  def build(self, env: ManagerBasedRlEnv) -> RelativeJointPositionAction:
+    return RelativeJointPositionAction(self, env)
+
+
+class RelativeJointPositionAction(BaseAction):
+  """Control joints via position targets relative to current positions."""
+
+  def apply_actions(self) -> None:
+    current_pos = self._entity.data.joint_pos[:, self._target_ids]
+    target = current_pos + self._processed_actions
+    self._entity.set_joint_position_target(target, joint_ids=self._target_ids)
+
+
 class JointVelocityAction(BaseAction):
   """Control joints via velocity targets."""
 

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -14,6 +14,7 @@ from mjlab.entity import Entity, EntityArticulationInfoCfg, EntityCfg
 from mjlab.envs import ManagerBasedRlEnv
 from mjlab.envs.mdp.actions import (
   JointPositionActionCfg,
+  RelativeJointPositionActionCfg,
   SiteEffortActionCfg,
   TendonEffortActionCfg,
   TendonLengthActionCfg,
@@ -51,6 +52,17 @@ def fixed_base_entity(fixtures_dir, device):
     TransmissionType.JOINT,
     device,
     from_file=True,
+  )
+
+
+@pytest.fixture(scope="module")
+def floating_base_entity(device):
+  return make_entity(
+    load_fixture_xml("floating_base_articulated"),
+    ("joint.*",),
+    TransmissionType.JOINT,
+    device,
+    from_file=False,
   )
 
 
@@ -231,3 +243,76 @@ def test_base_action_clip(fixed_base_entity, device):
   assert torch.allclose(
     action._processed_actions[:, 1], torch.tensor(2.0, device=device)
   )
+
+
+def test_relative_joint_position_zero_action(floating_base_entity, device):
+  """With zero action, targets equal current_pos."""
+  entity = floating_base_entity
+  env = make_env(entity, "robot", device)
+
+  cfg = RelativeJointPositionActionCfg(
+    entity_name="robot", actuator_names=("joint.*",), scale=1.0
+  )
+  action = cfg.build(env)
+
+  current_pos = entity.data.joint_pos[:, action.target_ids].clone()
+
+  action.process_actions(torch.zeros(4, action.action_dim, device=device))
+  action.apply_actions()
+
+  assert torch.allclose(entity.data.joint_pos_target[:, action.target_ids], current_pos)
+
+
+def test_relative_joint_position_nonzero_action(floating_base_entity, device):
+  """With nonzero action, targets shift by action * scale from current."""
+  entity = floating_base_entity
+  env = make_env(entity, "robot", device)
+
+  scale = 0.1
+  cfg = RelativeJointPositionActionCfg(
+    entity_name="robot", actuator_names=("joint.*",), scale=scale
+  )
+  action = cfg.build(env)
+
+  current_pos = entity.data.joint_pos[:, action.target_ids].clone()
+
+  raw = torch.ones(4, action.action_dim, device=device)
+  action.process_actions(raw)
+  action.apply_actions()
+
+  expected = current_pos + raw * scale
+  assert torch.allclose(entity.data.joint_pos_target[:, action.target_ids], expected)
+
+
+def test_relative_joint_position_ignores_encoder_bias(floating_base_entity, device):
+  """Encoder bias must not affect the target: target = current_pos + delta."""
+  entity = floating_base_entity
+  env = make_env(entity, "robot", device)
+
+  cfg = RelativeJointPositionActionCfg(
+    entity_name="robot", actuator_names=("joint.*",), scale=1.0
+  )
+  action = cfg.build(env)
+
+  entity.data.encoder_bias[:, action.target_ids] = 0.05
+
+  current_pos = entity.data.joint_pos[:, action.target_ids].clone()
+  delta = 0.1
+  raw = torch.full((4, action.action_dim), delta, device=device)
+  action.process_actions(raw)
+  action.apply_actions()
+
+  assert torch.allclose(
+    entity.data.joint_pos_target[:, action.target_ids], current_pos + delta
+  )
+
+  # Reset bias so this shared fixture doesn't affect other tests.
+  entity.data.encoder_bias[:, action.target_ids] = 0.0
+
+
+def test_relative_joint_position_offset_raises(floating_base_entity, device):
+  """Setting offset on RelativeJointPositionActionCfg raises ValueError."""
+  with pytest.raises(ValueError, match="offset"):
+    RelativeJointPositionActionCfg(
+      entity_name="robot", actuator_names=("joint.*",), offset=0.5
+    )


### PR DESCRIPTION
Adds `RelativeJointPositionAction` and `RelativeJointPositionActionCfg` for joint position control relative to the current configuration. The target is `current_pos + action * scale`, so a zero action holds the robot in place regardless of its current configuration, unlike `JointPositionAction` which always targets relative to the default pose.

Setting `offset` raises a `ValueError` at config construction time, since a fixed bias added to every per-step delta has no meaningful interpretation.