### PR TITLE
Add reduce field to MetricsTermCfg

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,6 +8,9 @@ Upcoming version (not yet released)
 Added
 ^^^^^
 
+- Added ``reduce`` field to ``MetricsTermCfg``. Setting ``reduce="last"``
+  reports the value from the final step of the episode rather than the
+  episode mean, which is useful for binary success metrics.
 - Added :class:`~mjlab.envs.mdp.actions.RelativeJointPositionAction` for
   joint position control relative to the current configuration. The target is
   ``current_pos + action * scale``, so a zero action holds the current

--- a/docs/source/metrics.rst
+++ b/docs/source/metrics.rst
@@ -51,12 +51,19 @@ environment. On every call to ``compute()``:
 2. Each term function is called with the current environment state.
 3. The returned per-environment values are added to the running sums.
 
-When an environment resets, the manager divides each term's accumulated sum
-by the step count for that environment, averages the result across all
-resetting environments, and returns the scalar under the key
-``Episode_Metrics/<term_name>``. The sums and counters are then zeroed for
-the reset environments. Division is per-environment, so environments that
-terminated early are not diluted by longer-running ones.
+When an environment resets, the manager reduces each term's accumulated
+values to a scalar, averages the result across all resetting environments,
+and returns it under the key ``Episode_Metrics/<term_name>``. The sums and
+counters are then zeroed for the reset environments.
+
+The reduction is controlled by the ``reduce`` field on ``MetricsTermCfg``:
+
+- ``"mean"`` (default): divides the accumulated sum by the step count for
+  each environment. Division is per-environment, so environments that
+  terminated early are not diluted by longer-running ones.
+- ``"last"``: reports the value from the final step of the episode. This is
+  useful for binary success metrics (such as whether the robot is standing)
+  that should not be averaged over time.
 
 These scalars flow through ``env.extras["log"]`` into the training runner,
 which writes them to the configured logger. In a typical training run they

--- a/src/mjlab/managers/metrics_manager.py
+++ b/src/mjlab/managers/metrics_manager.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING, Literal, Sequence
 
 import torch
 from prettytable import PrettyTable
@@ -24,9 +24,14 @@ class MetricsTermCfg(ManagerTermBaseCfg):
     decimation loop and report the per-step mean. Only the integrated state
     (qpos, qvel, act) is current mid-loop; all derived quantities (xpos, xquat,
     site_xpos, actuator_force, contacts, ...) are stale.
+    reduce: How to aggregate per-step values into an episode metric.
+    ``"mean"`` (default) reports ``sum / step_count``. ``"last"`` reports
+    the value from the final step of the episode, which is useful for binary
+    success metrics that should not be averaged over timesteps.
   """
 
   per_substep: bool = False
+  reduce: Literal["mean", "last"] = "mean"
 
 
 class MetricsManager(ManagerBase):
@@ -99,9 +104,13 @@ class MetricsManager(ManagerBase):
     counts = self._step_count[env_ids].float()
     # Avoid division by zero for envs that haven't stepped.
     safe_counts = torch.clamp(counts, min=1.0)
-    for key in self._episode_sums:
-      episode_avg = torch.mean(self._episode_sums[key][env_ids] / safe_counts)
-      extras["Episode_Metrics/" + key] = episode_avg
+    for idx, key in enumerate(self._episode_sums):
+      if self._term_cfgs[idx].reduce == "last":
+        extras["Episode_Metrics/" + key] = torch.mean(self._step_values[env_ids, idx])
+      else:
+        extras["Episode_Metrics/" + key] = torch.mean(
+          self._episode_sums[key][env_ids] / safe_counts
+        )
       self._episode_sums[key][env_ids] = 0.0
     self._step_count[env_ids] = 0
     for buf in self._substep_accum:

--- a/tests/test_metrics_manager.py
+++ b/tests/test_metrics_manager.py
@@ -176,6 +176,51 @@ def test_substep_reset_zeroes_accumulators(mock_env):
   assert manager._substep_accum[0][1].item() == pytest.approx(3.0)
 
 
+def test_reduce_last_reports_final_step_value(mock_env):
+  """reduce='last' reports the last step's value, not the episode average."""
+  step = [0]
+
+  def rising_metric(env):
+    step[0] += 1
+    return torch.full((env.num_envs,), float(step[0]), device=env.device)
+
+  cfg = {"term": MetricsTermCfg(func=rising_metric, params={}, reduce="last")}
+  manager = MetricsManager(cfg, mock_env)
+
+  for _ in range(4):
+    manager.compute()
+
+  info = manager.reset(env_ids=torch.tensor([0]))
+
+  # Values were 1, 2, 3, 4. Mean would be 2.5; last should be 4.
+  assert info["Episode_Metrics/term"].item() == pytest.approx(4.0)
+
+
+def test_reduce_mean_and_last_coexist(mock_env):
+  """Mixed reduce modes in the same manager report correctly."""
+  step = [0]
+
+  def rising_metric(env):
+    step[0] += 1
+    return torch.full((env.num_envs,), float(step[0]), device=env.device)
+
+  cfg = {
+    "mean_term": MetricsTermCfg(func=rising_metric, params={}, reduce="mean"),
+    "last_term": MetricsTermCfg(func=rising_metric, params={}, reduce="last"),
+  }
+  manager = MetricsManager(cfg, mock_env)
+
+  for _ in range(3):
+    manager.compute()
+
+  info = manager.reset(env_ids=torch.tensor([0]))
+
+  # mean_term sees steps 1, 3, 5 (odd calls); episode avg = 3.0.
+  # last_term sees steps 2, 4, 6 (even calls); last value = 6.0.
+  assert info["Episode_Metrics/mean_term"].item() == pytest.approx(3.0)
+  assert info["Episode_Metrics/last_term"].item() == pytest.approx(6.0)
+
+
 def test_no_substep_terms_no_overhead(mock_env):
   """When no per_substep terms exist, compute_substep is a no-op."""
   cfg = {


### PR DESCRIPTION
Adds a `reduce` field to `MetricsTermCfg` that controls how per-step values are aggregated into an episode metric. The default `"mean"` preserves existing behavior. Setting `reduce="last"` reports the value from the final step of the episode, which is useful for binary success metrics that should not be averaged over timesteps.

The implementation reuses the existing `_step_values` buffer, which already tracks the last computed value per term per environment, so no new state is required.