### PR TITLE
Add isotropic parameter to dr.pair_friction.

### DIFF
--- a/docs/source/randomization.rst
+++ b/docs/source/randomization.rst
@@ -244,10 +244,11 @@ and ``dr.body_ipos`` are the same function).
    * - ``dr.pair_friction``
      - ``pair_friction``
      - Per-pair friction override ``[tangent1, tangent2, spin, roll1, roll2]``
-     - Default axis: 0 (tangent1, requires ``condim >= 3``). Overrides
-       per-geom friction for explicitly defined
+     - Default axis: 0 (tangent1, requires ``condim >= 3``). Use
+       ``isotropic=True`` to mirror tangent2 = tangent1 (and roll2 = roll1).
+       Overrides per-geom friction for explicitly defined
        `<contact><pair> <https://mujoco.readthedocs.io/en/stable/XMLreference.html#contact-pair>`_
-       elements
+       elements. See :ref:`dr-pair-friction`.
 
 .. rubric:: Tendon fields
 
@@ -593,6 +594,125 @@ The formulas are type-dependent:
 
 Plane, heightfield, mesh, and SDF geoms are not supported because their bounds
 come from vertex data or are infinite, not derivable from ``geom_size``.
+
+
+.. _dr-pair-friction:
+
+``pair_friction`` and isotropic friction
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``pair_friction`` stores five friction coefficients per contact pair:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 10 20 20 50
+
+   * - Index
+     - Name
+     - Active when
+     - Meaning
+   * - 0
+     - tangent1
+     - ``condim >= 3``
+     - Sliding friction along the first tangent axis of the contact frame
+   * - 1
+     - tangent2
+     - ``condim >= 3``
+     - Sliding friction along the second tangent axis
+   * - 2
+     - spin
+     - ``condim >= 4``
+     - Torsional friction around the contact normal
+   * - 3
+     - roll1
+     - ``condim = 6``
+     - Rolling friction around the first tangent axis
+   * - 4
+     - roll2
+     - ``condim = 6``
+     - Rolling friction around the second tangent axis
+
+MuJoCo's standard geom friction is a 3-vector ``[tangential, torsional,
+rolling]`` that is automatically expanded to the 5-vector by replicating the
+tangential coefficient into tangent1 and tangent2, and the rolling coefficient
+into roll1 and roll2. For pair overrides the five values are stored
+independently, so the symmetry must be maintained explicitly. Pass
+``isotropic=True`` to enforce this: after sampling, tangent2 is overwritten
+with tangent1, and roll2 is overwritten with roll1 whenever axes 3 or 4 are
+targeted.
+
+**Recommendations by condim.**
+
+**condim = 3.** Both tangent axes are active. Sample tangent1 and set tangent2 equal to it with ``isotropic=True``. Pass
+``shared_random=True`` so that all pairs selected by ``asset_cfg`` receive the
+same sampled value within each environment (environments still get independent
+values from one another):
+
+.. code-block:: python
+
+   dr.pair_friction(
+       env,
+       env_ids=None,
+       ranges=(0.4, 1.0),
+       operation="abs",
+       asset_cfg=SceneEntityCfg("robot", pair_names=("foot1_floor", "foot2_floor")),
+       axes=[0],           # sample tangent1
+       shared_random=True, # all pairs selected by asset_cfg share one value per env
+       isotropic=True,     # tangent2 = tangent1
+   )
+
+**condim = 4.** Spin (axis 2) is additionally active. Randomize sliding
+friction as above. If spin should also be randomized, do so in a separate
+call with its own range:
+
+.. code-block:: python
+
+   dr.pair_friction(
+       env,
+       env_ids=None,
+       ranges=(0.4, 1.0),
+       operation="abs",
+       asset_cfg=SceneEntityCfg("robot", pair_names=("foot1_floor", "foot2_floor")),
+       axes=[0],
+       shared_random=True,
+       isotropic=True,
+   )
+   dr.pair_friction(
+       env,
+       env_ids=None,
+       ranges=(0.003, 0.01),
+       operation="abs",
+       asset_cfg=SceneEntityCfg("robot", pair_names=("foot1_floor", "foot2_floor")),
+       axes=[2],
+       shared_random=True,
+   )
+
+**condim = 6.** All five axes are active. Randomize sliding friction as above.
+To also randomize rolling friction symmetrically, target axis 3 with
+``isotropic=True`` so that roll2 is set equal to roll1:
+
+.. code-block:: python
+
+   dr.pair_friction(
+       env,
+       env_ids=None,
+       ranges=(0.4, 1.0),
+       operation="abs",
+       asset_cfg=SceneEntityCfg("robot", pair_names=("foot1_floor", "foot2_floor")),
+       axes=[0],
+       shared_random=True,
+       isotropic=True,
+   )
+   dr.pair_friction(
+       env,
+       env_ids=None,
+       ranges=(0.0001, 0.001),
+       operation="abs",
+       asset_cfg=SceneEntityCfg("robot", pair_names=("foot1_floor", "foot2_floor")),
+       axes=[3],
+       shared_random=True,
+       isotropic=True,  # roll2 = roll1
+   )
 
 
 Fields without ``dr`` functions

--- a/src/mjlab/envs/mdp/dr/pair.py
+++ b/src/mjlab/envs/mdp/dr/pair.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import torch
+
 from mjlab.managers.event_manager import requires_model_fields
 from mjlab.managers.scene_entity_config import SceneEntityCfg
 
@@ -11,8 +13,6 @@ from ._core import _DEFAULT_ASSET_CFG, Ranges, _randomize_model_field
 from ._types import Distribution, Operation
 
 if TYPE_CHECKING:
-  import torch
-
   from mjlab.envs import ManagerBasedRlEnv
 
 
@@ -26,6 +26,7 @@ def pair_friction(
   operation: Operation | str = "abs",
   axes: list[int] | None = None,
   shared_random: bool = False,
+  isotropic: bool = False,
 ) -> None:
   """Randomize geom-pair friction overrides.
 
@@ -33,6 +34,12 @@ def pair_friction(
   Default axis is 0 (tangent1 only). Axis 0 requires ``condim >= 3``
   (the default); axes 1 and 2 require ``condim >= 4``; axes 3 and 4
   require ``condim = 6``.
+
+  When ``isotropic=True``, tangent2 is set equal to tangent1 after sampling
+  (axis 1 is overwritten with axis 0). If axes 3 or 4 are targeted, roll2 is
+  also set equal to roll1 (axis 4 is overwritten with axis 3). This matches
+  MuJoCo's standard geom friction convention where both tangent directions and
+  both roll directions share one coefficient.
 
   Args:
     env: The environment instance.
@@ -44,6 +51,9 @@ def pair_friction(
     axes: Which friction components to randomize. Defaults to ``[0]`` (tangent1).
     shared_random: If ``True``, all selected pairs receive the same sampled value per
       environment.
+    isotropic: If ``True``, mirror tangent2 = tangent1 after sampling (and
+      roll2 = roll1 if roll axes are targeted). Use this to maintain isotropic
+      friction, matching MuJoCo's geom friction convention.
   """
   _randomize_model_field(
     env,
@@ -59,3 +69,23 @@ def pair_friction(
     default_axes=[0],
     valid_axes=[0, 1, 2, 3, 4],
   )
+
+  if isotropic:
+    _env_ids = (
+      torch.arange(env.num_envs, device=env.device, dtype=torch.int)
+      if env_ids is None
+      else env_ids.to(env.device, dtype=torch.int)
+    )
+    asset = env.scene[asset_cfg.name]
+    pair_indices = asset.indexing.pair_ids[asset_cfg.pair_ids]
+    env_grid, pair_grid = torch.meshgrid(_env_ids, pair_indices, indexing="ij")
+    pf = env.sim.model.pair_friction
+    pf[env_grid, pair_grid, 1] = pf[env_grid, pair_grid, 0]
+    if axes is not None:
+      effective_axes = axes
+    elif isinstance(ranges, dict) and ranges and isinstance(next(iter(ranges)), int):
+      effective_axes = list(ranges.keys())
+    else:
+      effective_axes = [0]
+    if 3 in effective_axes or 4 in effective_axes:
+      pf[env_grid, pair_grid, 4] = pf[env_grid, pair_grid, 3]

--- a/tests/test_domain_randomization.py
+++ b/tests/test_domain_randomization.py
@@ -1752,6 +1752,28 @@ def test_pair_friction_axes_selectivity(pair_env):
     assert torch.allclose(after[:, pair_ids, ax], before[:, pair_ids, ax])
 
 
+def test_pair_friction_multi_axis(pair_env):
+  """axes=[0, 1] randomizes both tangent components; axes 2-4 stay unchanged."""
+  torch.manual_seed(17)
+  env = pair_env
+  robot = env.scene["robot"]
+
+  before = env.sim.model.pair_friction.clone()
+
+  dr.pair_friction(env, env_ids=None, ranges=(0.4, 1.0), operation="abs", axes=[0, 1])
+
+  after = env.sim.model.pair_friction
+  pair_ids = robot.indexing.pair_ids
+  # Both tangent axes changed.
+  assert not torch.allclose(after[:, pair_ids, 0], before[:, pair_ids, 0])
+  assert not torch.allclose(after[:, pair_ids, 1], before[:, pair_ids, 1])
+  # Axes 2-4 unchanged.
+  for ax in range(2, 5):
+    assert torch.allclose(after[:, pair_ids, ax], before[:, pair_ids, ax])
+  # Axis 0 and axis 1 are sampled independently (not forced equal).
+  assert not torch.allclose(after[:, pair_ids, 0], after[:, pair_ids, 1])
+
+
 def test_pair_friction_partial_env_ids(pair_env):
   """Randomizing a subset of envs leaves the others unchanged."""
   torch.manual_seed(99)
@@ -1849,6 +1871,105 @@ def test_pair_friction_string_ranges(pair_env):
     torch.full((env.num_envs,), 0.5, device=env.device),
     atol=1e-5,
   )
+
+
+def test_pair_friction_isotropic_tangent(pair_env):
+  """isotropic=True mirrors tangent2 = tangent1; spin and roll axes unchanged."""
+  torch.manual_seed(21)
+  env = pair_env
+  robot = env.scene["robot"]
+  pair_ids = robot.indexing.pair_ids
+
+  before = env.sim.model.pair_friction.clone()
+  dr.pair_friction(
+    env, env_ids=None, ranges=(0.4, 1.0), operation="abs", axes=[0], isotropic=True
+  )
+
+  after = env.sim.model.pair_friction
+  # Axis 0 was randomized into range.
+  assert torch.all((after[:, pair_ids, 0] >= 0.4) & (after[:, pair_ids, 0] <= 1.0))
+  # Axis 1 equals axis 0 exactly.
+  assert torch.allclose(after[:, pair_ids, 1], after[:, pair_ids, 0])
+  # Axes 2, 3, 4 untouched.
+  for ax in (2, 3, 4):
+    assert torch.allclose(after[:, pair_ids, ax], before[:, pair_ids, ax])
+
+
+def test_pair_friction_isotropic_shared(pair_env):
+  """isotropic=True + shared_random=True: all pairs same value, tangent2 == tangent1."""
+  torch.manual_seed(33)
+  env = pair_env
+  robot = env.scene["robot"]
+  pair_ids = robot.indexing.pair_ids
+
+  dr.pair_friction(
+    env,
+    env_ids=None,
+    ranges=(0.4, 1.0),
+    operation="abs",
+    axes=[0],
+    shared_random=True,
+    isotropic=True,
+  )
+
+  friction = env.sim.model.pair_friction[:, pair_ids, :]
+  # All pairs in each env share the same tangent1 value.
+  for e in range(env.num_envs):
+    assert torch.allclose(
+      friction[e, :, 0], friction[e, 0, 0].expand(len(pair_ids)), atol=1e-6
+    )
+  # Across envs, values differ.
+  assert not torch.allclose(friction[0, 0, 0], friction[1, 0, 0])
+  # tangent2 == tangent1 everywhere.
+  assert torch.allclose(friction[:, :, 1], friction[:, :, 0])
+
+
+def test_pair_friction_isotropic_roll(pair_env):
+  """isotropic=True with roll axes mirrors roll2 = roll1; tangent axes unchanged."""
+  torch.manual_seed(41)
+  env = pair_env
+  robot = env.scene["robot"]
+  pair_ids = robot.indexing.pair_ids
+
+  before = env.sim.model.pair_friction.clone()
+  dr.pair_friction(
+    env, env_ids=None, ranges=(0.001, 0.01), operation="abs", axes=[3], isotropic=True
+  )
+
+  after = env.sim.model.pair_friction
+  # Axis 3 was randomized.
+  assert not torch.allclose(after[:, pair_ids, 3], before[:, pair_ids, 3])
+  # Axis 4 equals axis 3 exactly.
+  assert torch.allclose(after[:, pair_ids, 4], after[:, pair_ids, 3])
+  # Tangent and spin axes untouched.
+  for ax in (0, 1, 2):
+    assert torch.allclose(after[:, pair_ids, ax], before[:, pair_ids, ax])
+
+
+def test_pair_friction_isotropic_roll_dict_ranges(pair_env):
+  """isotropic=True with dict-int ranges containing roll axis triggers roll2 = roll1."""
+  torch.manual_seed(53)
+  env = pair_env
+  robot = env.scene["robot"]
+  pair_ids = robot.indexing.pair_ids
+
+  before = env.sim.model.pair_friction.clone()
+  dr.pair_friction(
+    env,
+    env_ids=None,
+    ranges={3: (0.001, 0.01)},
+    operation="abs",
+    isotropic=True,
+  )
+
+  after = env.sim.model.pair_friction
+  # Axis 3 was randomized.
+  assert not torch.allclose(after[:, pair_ids, 3], before[:, pair_ids, 3])
+  # Axis 4 equals axis 3 exactly (dict-int ranges must trigger the roll copy).
+  assert torch.allclose(after[:, pair_ids, 4], after[:, pair_ids, 3])
+  # Tangent and spin axes untouched.
+  for ax in (0, 1, 2):
+    assert torch.allclose(after[:, pair_ids, ax], before[:, pair_ids, ax])
 
 
 def test_pair_friction_invalid_name(pair_env):


### PR DESCRIPTION
pair_friction stores 5 friction components per pair: [tangent1, tangent2, spin, roll1, roll2]. The two tangent axes and two roll axes are symmetric in MuJoCo's geom friction convention, but pair overrides store them independently. Without explicit mirroring, randomizing axis 0 alone leaves tangent2 stale.

The new isotropic=True parameter copies tangent2 = tangent1 after sampling, and roll2 = roll1 when roll axes are targeted.