### PR TITLE
Add termination_curriculum for staged termination param scheduling

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,6 +8,11 @@ Upcoming version (not yet released)
 Added
 ^^^^^
 
+- Added :func:`~mjlab.envs.mdp.curriculums.termination_curriculum` for
+  scheduling changes to termination term parameters during training,
+  matching the existing ``reward_curriculum`` pattern. Both now share a
+  single internal engine with init-time validation of stage ordering,
+  field existence, and param keys.
 - Added ``reduce`` field to ``MetricsTermCfg``. Setting ``reduce="last"``
   reports the value from the final step of the episode rather than the
   episode mean, which is useful for binary success metrics.

--- a/docs/source/curriculum.rst
+++ b/docs/source/curriculum.rst
@@ -52,6 +52,10 @@ Built-in curriculum functions
      - Adjusts a reward term's weight and/or params according to
        training step thresholds. Replaces the older ``reward_weight``
        function and also supports modifying reward function parameters.
+   * - ``termination_curriculum``
+     - Adjusts a termination term's params according to training step
+       thresholds. Useful for gradually tightening termination
+       conditions (e.g. energy limits) as training progresses.
 
 
 Reward curriculum
@@ -114,6 +118,40 @@ A single stage can update both weight and params at once:
 .. code-block:: python
 
     {"step": 24000, "weight": -1.0, "params": {"max_vel": 1.0}}
+
+
+Termination curriculum
+----------------------
+
+``termination_curriculum`` schedules changes to a termination term's
+parameters as training progresses. This is useful for gradually
+tightening termination conditions once the policy has learned basic
+behaviors.
+
+**Tightening an energy limit**
+
+Start with a permissive energy threshold and reduce it over training:
+
+.. code-block:: python
+
+    from mjlab.managers.curriculum_manager import CurriculumTermCfg
+
+    curriculum = {
+        "energy_threshold": CurriculumTermCfg(
+            func=mdp.termination_curriculum,
+            params={
+                "termination_name": "energy",
+                "stages": [
+                    {"step": 12000, "params": {"threshold": 1000.0}},
+                    {"step": 24000, "params": {"threshold": 700.0}},
+                    {"step": 36000, "params": {"threshold": 400.0}},
+                ],
+            },
+        ),
+    }
+
+The ``time_out`` field on ``TerminationTermCfg`` can also be toggled
+via stages if needed, though this is uncommon in practice.
 
 
 Terrain curriculum

--- a/src/mjlab/envs/mdp/curriculums.py
+++ b/src/mjlab/envs/mdp/curriculums.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, TypedDict
 
 import torch
 
 if TYPE_CHECKING:
   from mjlab.envs import ManagerBasedRlEnv
+  from mjlab.managers.curriculum_manager import CurriculumTermCfg
 
-__all__ = ["RewardCurriculumStage", "reward_curriculum"]
+
+# Stage schemas.
 
 
 class _RewardCurriculumStageOptional(TypedDict, total=False):
@@ -19,12 +22,92 @@ class RewardCurriculumStage(_RewardCurriculumStageOptional):
   step: int
 
 
-def reward_curriculum(
-  env: ManagerBasedRlEnv,
-  env_ids: torch.Tensor,
-  reward_name: str,
-  stages: list[RewardCurriculumStage],
+class _TerminationCurriculumStageOptional(TypedDict, total=False):
+  params: dict[str, Any]
+  time_out: bool
+
+
+class TerminationCurriculumStage(_TerminationCurriculumStageOptional):
+  step: int
+
+
+# Shared engine.  Stage dicts are passed directly from the public TypedDict
+# schemas.  Any key that isn't "step" or "params" is treated as a top-level
+# field on the target term config (e.g. "weight" on RewardTermCfg).
+
+_RESERVED_KEYS = {"step", "params"}
+
+
+def _validate_stages(
+  term_cfg: Any,
+  term_name: str,
+  stages: Sequence[Any],
+) -> None:
+  """Validate stage ordering, field existence, and param keys."""
+  for i in range(1, len(stages)):
+    if stages[i]["step"] < stages[i - 1]["step"]:
+      raise ValueError(
+        f"Curriculum stages must be in nondecreasing step order,"
+        f" but stage {i} has step"
+        f" {stages[i]['step']} < {stages[i - 1]['step']}."
+      )
+  for stage in stages:
+    for key in stage:
+      if key not in _RESERVED_KEYS and not hasattr(term_cfg, key):
+        raise AttributeError(
+          f"Field '{key}' does not exist on the resolved term config for '{term_name}'."
+        )
+  for stage in stages:
+    unknown = stage.get("params", {}).keys() - term_cfg.params.keys()
+    if unknown:
+      raise KeyError(
+        f"Stage at step {stage['step']} sets unknown param(s)"
+        f" {unknown} on term '{term_name}'. Check for typos."
+      )
+
+
+def _apply_stages(
+  term_cfg: Any,
+  step_counter: int,
+  stages: Sequence[Any],
 ) -> dict[str, torch.Tensor]:
+  """Apply staged updates and return a logging snapshot."""
+  for stage in stages:
+    if step_counter >= stage["step"]:
+      for key, value in stage.items():
+        if key not in _RESERVED_KEYS:
+          setattr(term_cfg, key, value)
+      if "params" in stage:
+        term_cfg.params.update(stage["params"])
+  # Only log values that stages actually reference.
+  logged_fields: set[str] = set()
+  logged_params: set[str] = set()
+  for stage in stages:
+    for key in stage:
+      if key not in _RESERVED_KEYS:
+        logged_fields.add(key)
+    for key in stage.get("params", {}):
+      logged_params.add(key)
+  result: dict[str, torch.Tensor] = {}
+  for key in logged_fields:
+    value = getattr(term_cfg, key)
+    if isinstance(value, (int, float, bool)):
+      result[key] = torch.tensor(value)
+    elif isinstance(value, torch.Tensor):
+      result[key] = value
+  for key in logged_params:
+    v = term_cfg.params[key]
+    if isinstance(v, (int, float, bool)):
+      result[key] = torch.tensor(v)
+    elif isinstance(v, torch.Tensor):
+      result[key] = v
+  return result
+
+
+# Public wrappers.
+
+
+class reward_curriculum:
   """Update a reward term's weight and/or params based on training steps.
 
   Each stage specifies a ``step`` threshold and optionally a ``weight``
@@ -46,27 +129,59 @@ def reward_curriculum(
       },
     )
   """
-  del env_ids  # Unused.
-  reward_term_cfg = env.reward_manager.get_term_cfg(reward_name)
-  for stage in stages:
-    if env.common_step_counter >= stage["step"]:
-      if "weight" in stage:
-        reward_term_cfg.weight = stage["weight"]
-      if "params" in stage:
-        unknown = stage["params"].keys() - reward_term_cfg.params.keys()
-        if unknown:
-          raise KeyError(
-            f"reward_curriculum: stage at step {stage['step']} sets"
-            f" unknown param(s) {unknown} on reward term"
-            f" '{reward_name}'. Check for typos."
-          )
-        reward_term_cfg.params.update(stage["params"])
-  result: dict[str, torch.Tensor] = {
-    "weight": torch.tensor(reward_term_cfg.weight),
-  }
-  for k, v in reward_term_cfg.params.items():
-    if isinstance(v, (int, float)):
-      result[k] = torch.tensor(v)
-    elif isinstance(v, torch.Tensor):
-      result[k] = v
-  return result
+
+  def __init__(self, cfg: CurriculumTermCfg, env: ManagerBasedRlEnv):
+    reward_name: str = cfg.params["reward_name"]
+    stages: list[RewardCurriculumStage] = cfg.params["stages"]
+    self._term_cfg = env.reward_manager.get_term_cfg(reward_name)
+    self._stages = stages
+    _validate_stages(self._term_cfg, reward_name, self._stages)
+
+  def __call__(
+    self,
+    env: ManagerBasedRlEnv,
+    env_ids: torch.Tensor,
+    reward_name: str,
+    stages: list[RewardCurriculumStage],
+  ) -> dict[str, torch.Tensor]:
+    del env_ids, reward_name, stages
+    return _apply_stages(self._term_cfg, env.common_step_counter, self._stages)
+
+
+class termination_curriculum:
+  """Update a termination term's params based on training steps.
+
+  Each stage specifies a ``step`` threshold and a ``params`` dict.  When
+  ``env.common_step_counter`` reaches a stage's ``step``, the params are
+  applied.  Later stages take precedence.
+
+  Example::
+
+    CurriculumTermCfg(
+      func=mdp.termination_curriculum,
+      params={
+        "termination_name": "energy",
+        "stages": [
+          {"step": 12000, "params": {"threshold": 1000.0}},
+          {"step": 24000, "params": {"threshold": 700.0}},
+        ],
+      },
+    )
+  """
+
+  def __init__(self, cfg: CurriculumTermCfg, env: ManagerBasedRlEnv):
+    termination_name: str = cfg.params["termination_name"]
+    stages: list[TerminationCurriculumStage] = cfg.params["stages"]
+    self._term_cfg = env.termination_manager.get_term_cfg(termination_name)
+    self._stages = stages
+    _validate_stages(self._term_cfg, termination_name, self._stages)
+
+  def __call__(
+    self,
+    env: ManagerBasedRlEnv,
+    env_ids: torch.Tensor,
+    termination_name: str,
+    stages: list[TerminationCurriculumStage],
+  ) -> dict[str, torch.Tensor]:
+    del env_ids, termination_name, stages
+    return _apply_stages(self._term_cfg, env.common_step_counter, self._stages)

--- a/tests/test_envs_curriculums.py
+++ b/tests/test_envs_curriculums.py
@@ -1,171 +1,275 @@
-"""Tests for reward_curriculum."""
+"""Tests for reward_curriculum and termination_curriculum."""
 
 from unittest.mock import Mock
 
 import pytest
 import torch
 
-from mjlab.envs import mdp as envs_mdp
+from mjlab.envs.mdp.curriculums import reward_curriculum, termination_curriculum
+from mjlab.managers.curriculum_manager import CurriculumTermCfg
 from mjlab.managers.reward_manager import RewardTermCfg
+from mjlab.managers.termination_manager import TerminationTermCfg
 
 
-@pytest.fixture
-def mock_env():
+def _reward_func(env):
+  return torch.ones(env.num_envs)
+
+
+def _termination_func(env):
+  return torch.zeros(env.num_envs, dtype=torch.bool)
+
+
+def _make_reward_cfg(
+  weight: float = 1.0,
+  params: dict | None = None,
+) -> RewardTermCfg:
+  return RewardTermCfg(
+    func=_reward_func,
+    weight=weight,
+    params=params if params is not None else {"std": 0.5, "scale": 1.0},
+  )
+
+
+def _make_termination_cfg(
+  params: dict | None = None,
+) -> TerminationTermCfg:
+  return TerminationTermCfg(
+    func=_termination_func,
+    params=params if params is not None else {"threshold": float("inf")},
+  )
+
+
+def _build_reward(env, reward_name, stages):
+  params = {"reward_name": reward_name, "stages": stages}
+  cfg = CurriculumTermCfg(func=reward_curriculum, params=params)
+  instance = reward_curriculum(cfg, env)
+  return instance(env, env_ids=torch.tensor([0, 1]), **params)
+
+
+def _build_termination(env, termination_name, stages):
+  params = {"termination_name": termination_name, "stages": stages}
+  cfg = CurriculumTermCfg(func=termination_curriculum, params=params)
+  instance = termination_curriculum(cfg, env)
+  return instance(env, env_ids=torch.tensor([0, 1]), **params)
+
+
+def _make_reward_env(step_counter, reward_cfg):
   env = Mock()
-  env.num_envs = 2
-  env.device = "cpu"
+  env.common_step_counter = step_counter
+  env.reward_manager.get_term_cfg.return_value = reward_cfg
   return env
 
 
-@pytest.fixture
-def reward_term_cfg():
-  return RewardTermCfg(
-    func=lambda env: torch.ones(env.num_envs),
-    weight=1.0,
-    params={"std": 0.5, "scale": 1.0},
-  )
-
-
-def _setup_env(env, step_counter, reward_term_cfg):
+def _make_termination_env(step_counter, term_cfg):
+  env = Mock()
   env.common_step_counter = step_counter
-  env.reward_manager.get_term_cfg.return_value = reward_term_cfg
+  env.termination_manager.get_term_cfg.return_value = term_cfg
+  return env
 
 
-def _call(env, **kwargs):
-  return envs_mdp.reward_curriculum(env, env_ids=torch.tensor([0, 1]), **kwargs)
+# Reward: weight
 
 
-# Weight-only stages.
+def test_reward_weight_unchanged_before_threshold():
+  rc = _make_reward_cfg()
+  env = _make_reward_env(0, rc)
+  _build_reward(env, "r", [{"step": 100, "weight": 2.0}])
+  assert rc.weight == pytest.approx(1.0)
 
 
-def test_weight_unchanged_before_threshold(mock_env, reward_term_cfg):
-  _setup_env(mock_env, step_counter=0, reward_term_cfg=reward_term_cfg)
-  _call(
-    mock_env,
-    reward_name="r",
-    stages=[{"step": 100, "weight": 2.0}],
-  )
-  assert reward_term_cfg.weight == pytest.approx(1.0)
+def test_reward_weight_applied_at_threshold():
+  rc = _make_reward_cfg()
+  env = _make_reward_env(100, rc)
+  _build_reward(env, "r", [{"step": 100, "weight": 2.0}])
+  assert rc.weight == pytest.approx(2.0)
 
 
-def test_weight_applied_at_threshold(mock_env, reward_term_cfg):
-  """step: 100 applies when counter == 100 (>=, not >)."""
-  _setup_env(mock_env, step_counter=100, reward_term_cfg=reward_term_cfg)
-  _call(
-    mock_env,
-    reward_name="r",
-    stages=[{"step": 100, "weight": 2.0}],
-  )
-  assert reward_term_cfg.weight == pytest.approx(2.0)
-
-
-def test_weight_later_stage_wins(mock_env, reward_term_cfg):
-  _setup_env(mock_env, step_counter=500, reward_term_cfg=reward_term_cfg)
-  _call(
-    mock_env,
-    reward_name="r",
-    stages=[
+def test_reward_weight_later_stage_wins():
+  rc = _make_reward_cfg()
+  env = _make_reward_env(500, rc)
+  _build_reward(
+    env,
+    "r",
+    [
       {"step": 0, "weight": 0.5},
       {"step": 100, "weight": 1.5},
       {"step": 400, "weight": 3.0},
     ],
   )
-  assert reward_term_cfg.weight == pytest.approx(3.0)
+  assert rc.weight == pytest.approx(3.0)
 
 
-def test_weight_partial_application(mock_env, reward_term_cfg):
-  _setup_env(mock_env, step_counter=150, reward_term_cfg=reward_term_cfg)
-  _call(
-    mock_env,
-    reward_name="r",
-    stages=[
+def test_reward_weight_partial_application():
+  rc = _make_reward_cfg()
+  env = _make_reward_env(150, rc)
+  _build_reward(
+    env,
+    "r",
+    [
       {"step": 100, "weight": 2.0},
       {"step": 200, "weight": 4.0},
     ],
   )
-  assert reward_term_cfg.weight == pytest.approx(2.0)
+  assert rc.weight == pytest.approx(2.0)
 
 
-# Params-only stages.
+def test_step_zero_applies_immediately():
+  rc = _make_reward_cfg()
+  env = _make_reward_env(0, rc)
+  _build_reward(env, "r", [{"step": 0, "weight": 9.0}])
+  assert rc.weight == pytest.approx(9.0)
 
 
-def test_params_updated(mock_env, reward_term_cfg):
-  _setup_env(mock_env, step_counter=200, reward_term_cfg=reward_term_cfg)
-  _call(
-    mock_env,
-    reward_name="r",
-    stages=[{"step": 100, "params": {"std": 0.2}}],
+# Reward: params
+
+
+def test_reward_params_updated():
+  rc = _make_reward_cfg()
+  env = _make_reward_env(200, rc)
+  _build_reward(env, "r", [{"step": 100, "params": {"std": 0.2}}])
+  assert rc.params["std"] == 0.2
+
+
+def test_reward_params_unchanged_before_threshold():
+  rc = _make_reward_cfg()
+  env = _make_reward_env(0, rc)
+  _build_reward(env, "r", [{"step": 100, "params": {"std": 0.2}}])
+  assert rc.params["std"] == 0.5
+
+
+def test_reward_multiple_params_updated():
+  rc = _make_reward_cfg()
+  env = _make_reward_env(200, rc)
+  _build_reward(env, "r", [{"step": 100, "params": {"std": 0.2, "scale": 2.0}}])
+  assert rc.params["std"] == 0.2
+  assert rc.params["scale"] == 2.0
+
+
+# Reward: combined weight + params
+
+
+def test_reward_weight_and_params_in_same_stage():
+  rc = _make_reward_cfg()
+  env = _make_reward_env(200, rc)
+  _build_reward(env, "r", [{"step": 100, "weight": 5.0, "params": {"std": 0.1}}])
+  assert rc.weight == pytest.approx(5.0)
+  assert rc.params["std"] == 0.1
+
+
+# Termination: params
+
+
+def test_termination_params_updated():
+  tc = _make_termination_cfg()
+  env = _make_termination_env(200, tc)
+  _build_termination(env, "energy", [{"step": 100, "params": {"threshold": 500.0}}])
+  assert tc.params["threshold"] == 500.0
+
+
+def test_termination_params_unchanged_before_threshold():
+  tc = _make_termination_cfg()
+  env = _make_termination_env(0, tc)
+  _build_termination(env, "energy", [{"step": 100, "params": {"threshold": 500.0}}])
+  assert tc.params["threshold"] == float("inf")
+
+
+def test_termination_later_stage_wins():
+  tc = _make_termination_cfg()
+  env = _make_termination_env(500, tc)
+  _build_termination(
+    env,
+    "energy",
+    [
+      {"step": 0, "params": {"threshold": 1000.0}},
+      {"step": 100, "params": {"threshold": 700.0}},
+      {"step": 400, "params": {"threshold": 400.0}},
+    ],
   )
-  assert reward_term_cfg.params["std"] == 0.2
+  assert tc.params["threshold"] == 400.0
 
 
-def test_params_unchanged_before_threshold(mock_env, reward_term_cfg):
-  _setup_env(mock_env, step_counter=0, reward_term_cfg=reward_term_cfg)
-  _call(
-    mock_env,
-    reward_name="r",
-    stages=[{"step": 100, "params": {"std": 0.2}}],
-  )
-  assert reward_term_cfg.params["std"] == 0.5
+# Validation: shared engine
 
 
-def test_multiple_params_updated(mock_env, reward_term_cfg):
-  _setup_env(mock_env, step_counter=200, reward_term_cfg=reward_term_cfg)
-  _call(
-    mock_env,
-    reward_name="r",
-    stages=[{"step": 100, "params": {"std": 0.2, "scale": 2.0}}],
-  )
-  assert reward_term_cfg.params["std"] == 0.2
-  assert reward_term_cfg.params["scale"] == 2.0
-
-
-# Combined weight + params stages.
-
-
-def test_weight_and_params_in_same_stage(mock_env, reward_term_cfg):
-  _setup_env(mock_env, step_counter=200, reward_term_cfg=reward_term_cfg)
-  _call(
-    mock_env,
-    reward_name="r",
-    stages=[{"step": 100, "weight": 5.0, "params": {"std": 0.1}}],
-  )
-  assert reward_term_cfg.weight == pytest.approx(5.0)
-  assert reward_term_cfg.params["std"] == 0.1
-
-
-# Return value.
-
-
-def test_return_includes_weight_and_scalar_params(mock_env, reward_term_cfg):
-  _setup_env(mock_env, step_counter=200, reward_term_cfg=reward_term_cfg)
-  result = _call(
-    mock_env,
-    reward_name="r",
-    stages=[{"step": 100, "params": {"std": 0.2}}],
-  )
-  assert "weight" in result
-  assert result["weight"].item() == pytest.approx(1.0)
-  assert result["std"].item() == pytest.approx(0.2)
-
-
-def test_unknown_param_raises(mock_env, reward_term_cfg):
-  """Typos in param names are caught instead of silently ignored."""
-  _setup_env(mock_env, step_counter=200, reward_term_cfg=reward_term_cfg)
+def test_unknown_reward_param_raises():
+  rc = _make_reward_cfg()
+  env = _make_reward_env(0, rc)
+  params = {"reward_name": "r", "stages": [{"step": 0, "params": {"stdd": 0.2}}]}
+  cfg = CurriculumTermCfg(func=reward_curriculum, params=params)
   with pytest.raises(KeyError, match="unknown param"):
-    _call(
-      mock_env,
-      reward_name="r",
-      stages=[{"step": 100, "params": {"stdd": 0.2}}],
-    )
+    reward_curriculum(cfg, env)
 
 
-def test_step_zero_applies_immediately(mock_env, reward_term_cfg):
-  """A step: 0 stage applies on the very first call (counter == 0)."""
-  _setup_env(mock_env, step_counter=0, reward_term_cfg=reward_term_cfg)
-  _call(
-    mock_env,
-    reward_name="r",
-    stages=[{"step": 0, "weight": 9.0}],
+def test_unknown_termination_param_raises():
+  tc = _make_termination_cfg()
+  env = _make_termination_env(0, tc)
+  params = {
+    "termination_name": "energy",
+    "stages": [{"step": 0, "params": {"thresholddd": 1.0}}],
+  }
+  cfg = CurriculumTermCfg(func=termination_curriculum, params=params)
+  with pytest.raises(KeyError, match="unknown param"):
+    termination_curriculum(cfg, env)
+
+
+def test_unsorted_stages_raise():
+  rc = _make_reward_cfg()
+  env = _make_reward_env(0, rc)
+  params = {
+    "reward_name": "r",
+    "stages": [
+      {"step": 200, "weight": 1.0},
+      {"step": 100, "weight": 2.0},
+    ],
+  }
+  cfg = CurriculumTermCfg(func=reward_curriculum, params=params)
+  with pytest.raises(ValueError, match="nondecreasing"):
+    reward_curriculum(cfg, env)
+
+
+def test_duplicate_steps_allowed():
+  rc = _make_reward_cfg()
+  env = _make_reward_env(200, rc)
+  _build_reward(
+    env,
+    "r",
+    [
+      {"step": 100, "weight": 2.0},
+      {"step": 100, "params": {"std": 0.1}},
+    ],
   )
-  assert reward_term_cfg.weight == pytest.approx(9.0)
+  assert rc.weight == pytest.approx(2.0)
+  assert rc.params["std"] == 0.1
+
+
+# Logging keys
+
+
+def test_reward_logs_only_staged_keys():
+  rc = _make_reward_cfg()
+  env = _make_reward_env(200, rc)
+  result = _build_reward(
+    env, "r", [{"step": 100, "weight": 5.0, "params": {"std": 0.2}}]
+  )
+  assert result["weight"].item() == pytest.approx(5.0)
+  assert result["std"].item() == pytest.approx(0.2)
+  assert "scale" not in result  # Not in any stage.
+
+
+def test_reward_omits_weight_when_not_staged():
+  rc = _make_reward_cfg()
+  env = _make_reward_env(200, rc)
+  result = _build_reward(env, "r", [{"step": 100, "params": {"std": 0.2}}])
+  assert "weight" not in result
+  assert "std" in result
+
+
+def test_termination_log_keys():
+  tc = _make_termination_cfg()
+  env = _make_termination_env(200, tc)
+  result = _build_termination(
+    env, "energy", [{"step": 100, "params": {"threshold": 500.0}}]
+  )
+  assert "threshold" in result
+  assert result["threshold"].item() == pytest.approx(500.0)
+  assert "weight" not in result  # No weight for termination.


### PR DESCRIPTION
mjlab provided reward_curriculum for scheduling reward weight and param changes during training but had no equivalent for termination terms.

This PR adds termination_curriculum and refactors reward_curriculum from a plain function to a class-based term so both share a private engine. The engine validates stage ordering, field existence, and param keys at init time, applies nondecreasing staged updates at each curriculum compute, and returns a logging snapshot.