### PR TITLE
Add RecorderManager for downstream data collection

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -71,6 +71,7 @@ Table of Contents
    source/randomization
    source/curriculum
    source/metrics
+   source/recorders
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/api/managers.rst
+++ b/docs/source/api/managers.rst
@@ -35,6 +35,10 @@ mjlab.managers
   - :class:`MetricsManager`
   - :class:`NullMetricsManager`
   - :class:`MetricsTermCfg`
+  - :class:`RecorderManager`
+  - :class:`NullRecorderManager`
+  - :class:`RecorderTerm`
+  - :class:`RecorderTermCfg`
 
 Base
 ----
@@ -182,3 +186,23 @@ Metrics Manager
 .. autoclass:: MetricsTermCfg
   :members:
   :exclude-members: __init__
+
+Recorder Manager
+----------------
+
+.. autoclass:: RecorderManager
+  :members:
+  :show-inheritance:
+
+.. autoclass:: NullRecorderManager
+  :members:
+  :show-inheritance:
+
+.. autoclass:: RecorderTerm
+  :members:
+  :show-inheritance:
+
+.. autoclass:: RecorderTermCfg
+  :members:
+  :exclude-members: __init__
+  :undoc-members:

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,6 +8,12 @@ Upcoming version (not yet released)
 Added
 ^^^^^
 
+- Added :class:`~mjlab.managers.RecorderManager` for logging observations,
+  actions, or arbitrary environment data during rollouts. Implement a
+  :class:`~mjlab.managers.RecorderTerm` subclass and register it in the
+  ``recorders`` dict on ``ManagerBasedRlEnvCfg``. The manager provides
+  ``record_pre_reset``, ``record_post_reset``, and ``record_post_step``
+  lifecycle hooks with no opinion on how data is stored.
 - Added :func:`~mjlab.envs.mdp.curriculums.termination_curriculum` for
   scheduling changes to termination term parameters during training,
   matching the existing ``reward_curriculum`` pattern. Both now share a

--- a/docs/source/recorders.rst
+++ b/docs/source/recorders.rst
@@ -1,0 +1,122 @@
+.. _recorders:
+
+Recorders
+=========
+
+The recorder manager provides lifecycle hooks for logging data during
+rollouts. Unlike rewards, recorders have no effect on the optimization
+loop. They exist purely to let you capture observations, actions, or any
+other environment state without modifying mjlab internals.
+
+Each recorder term is a class that you implement. mjlab calls its methods
+at the right moments and leaves all I/O decisions to you.
+
+If the ``recorders`` dictionary on ``ManagerBasedRlEnvCfg`` is empty, the
+environment substitutes a lightweight no-op manager with zero overhead.
+
+
+Lifecycle hooks
+---------------
+
+The manager exposes three hooks per term:
+
+``record_pre_reset(env_ids)``
+    Called inside ``env.step()`` before terminated environments are reset.
+    ``obs_buf`` holds the observation from the end of the *previous* step
+    (the input the agent used to choose the terminal action, not the
+    post-action terminal state). ``action_manager.action`` holds the
+    terminal action and is still valid here; it will be zeroed for these
+    environments by ``_reset_idx`` immediately after. ``reward_buf`` holds
+    the terminal reward. This is the right place to record the terminal
+    transition ``(obs_t, action_t, reward_t, done=True)``.
+
+``record_post_reset(env_ids)``
+    Called after a reset completes and fresh observations are available.
+    Fires at the end of ``env.reset()`` (all environments) and within
+    ``env.step()`` after each batch of terminated environments is reset.
+    ``obs_buf[env_ids]`` holds the initial observation of the new episode;
+    ``action_manager.action[env_ids]`` is zero. Use this to initialize
+    per-episode state or record the first observation.
+
+``record_post_step()``
+    Called at the end of every ``env.step()`` with fresh observations.
+    For environments that reset during this step, ``action_manager.action``
+    has been zeroed and ``obs_buf`` holds the initial state of the new
+    episode rather than the post-action terminal observation. Use
+    ``record_pre_reset`` for those environments' terminal transitions and
+    ``self._env.reset_buf`` to identify which environments reset.
+
+``close()``
+    Called when the environment closes. Release file handles and flush
+    buffers here.
+
+
+Writing a recorder term
+------------------------
+
+Subclass :class:`~mjlab.managers.RecorderTerm` and override whichever
+hooks you need. The environment is available as ``self._env``, giving
+access to ``self._env.obs_buf``, ``self._env.action_manager.action``, and
+all other managers.
+
+.. code-block:: python
+
+    import csv
+    from mjlab.managers import RecorderTerm, RecorderTermCfg
+
+    class CsvRecorder(RecorderTerm):
+        def __init__(self, cfg, env):
+            super().__init__(cfg, env)
+            self._file = open(cfg.params["path"], "w", newline="")
+            self._writer = csv.writer(self._file)
+
+        def record_pre_reset(self, env_ids):
+            # Terminal transition: action is still intact here.
+            # It will be zeroed by _reset_idx immediately after this returns.
+            obs = self._env.obs_buf["actor"][env_ids].cpu().numpy()
+            act = self._env.action_manager.action[env_ids].cpu().numpy()
+            for o, a in zip(obs, act):
+                self._writer.writerow(o.tolist() + a.tolist())
+
+        def record_post_step(self):
+            # Skip envs that just reset: their terminal pair was written
+            # in record_pre_reset and their action is now zeroed.
+            mask = ~self._env.reset_buf
+            obs = self._env.obs_buf["actor"][mask].cpu().numpy()
+            act = self._env.action_manager.action[mask].cpu().numpy()
+            for o, a in zip(obs, act):
+                self._writer.writerow(o.tolist() + a.tolist())
+
+        def close(self):
+            self._file.close()
+
+The term receives the full ``cfg`` object so it can read any values you
+put in ``cfg.params``.
+
+
+Registration
+------------
+
+Add the term to the ``recorders`` dictionary on your environment config:
+
+.. code-block:: python
+
+    from dataclasses import dataclass, field
+    from mjlab.managers import RecorderTermCfg
+
+    @dataclass
+    class MyEnvCfg(SomeTaskEnvCfg):
+        recorders: dict = field(default_factory=lambda: {
+            "csv": RecorderTermCfg(
+                func=CsvRecorder,
+                params={"path": "rollout.csv"},
+            )
+        })
+
+Multiple terms can be registered under different keys and run together.
+
+.. note::
+
+    ``func`` must be a :class:`~mjlab.managers.RecorderTerm` subclass.
+    Function-based terms are not supported because recorder terms are
+    stateful.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,6 +152,8 @@ ignore = ["B011"]
 
 [tool.pyright]
 pythonVersion = "3.10"
+venvPath = "."
+venv = ".venv"
 ignore = ["./typings", "./src/mjlab/utils/lab_api", "./docs"]
 stubPath = "typings"
 

--- a/src/mjlab/envs/manager_based_rl_env.py
+++ b/src/mjlab/envs/manager_based_rl_env.py
@@ -28,6 +28,11 @@ from mjlab.managers.metrics_manager import (
   NullMetricsManager,
 )
 from mjlab.managers.observation_manager import ObservationGroupCfg, ObservationManager
+from mjlab.managers.recorder_manager import (
+  NullRecorderManager,
+  RecorderManager,
+  RecorderTermCfg,
+)
 from mjlab.managers.reward_manager import RewardManager, RewardTermCfg
 from mjlab.managers.termination_manager import TerminationManager, TerminationTermCfg
 from mjlab.scene import Scene
@@ -121,6 +126,10 @@ class ManagerBasedRlEnvCfg:
 
   metrics: dict[str, MetricsTermCfg] = field(default_factory=dict)
   """Custom metric terms for logging per-step values as episode averages."""
+
+  recorders: dict[str, RecorderTermCfg] = field(default_factory=dict)
+  """Recorder terms for logging observations, actions, or other data during rollouts.
+  If empty, a no-op manager is used with zero overhead."""
 
   is_finite_horizon: bool = False
   """Whether the task has a finite or infinite horizon. Defaults to False (infinite).
@@ -310,6 +319,11 @@ class ManagerBasedRlEnv:
     else:
       self.metrics_manager = NullMetricsManager()
     print_info(f"[INFO] {self.metrics_manager}")
+    if len(self.cfg.recorders) > 0:
+      self.recorder_manager = RecorderManager(self.cfg.recorders, self)
+    else:
+      self.recorder_manager = NullRecorderManager()
+    print_info(f"[INFO] {self.recorder_manager}")
 
     # Configure spaces for the environment.
     self._configure_gym_env_spaces()
@@ -336,6 +350,7 @@ class ManagerBasedRlEnv:
     self.command_manager.compute(dt=0.0)
     self.sim.sense()
     self.obs_buf = self.observation_manager.compute(update_history=True)
+    self.recorder_manager.record_post_reset(env_ids)
     return self.obs_buf, self.extras
 
   def step(self, action: torch.Tensor) -> types.VecEnvStepReturn:
@@ -394,6 +409,7 @@ class ManagerBasedRlEnv:
     # Reset envs that terminated/timed-out and log the episode info.
     reset_env_ids = self.reset_buf.nonzero(as_tuple=False).squeeze(-1)
     if len(reset_env_ids) > 0:
+      self.recorder_manager.record_pre_reset(reset_env_ids)
       self._reset_idx(reset_env_ids)
       self.scene.write_data_to_sim()
 
@@ -412,6 +428,9 @@ class ManagerBasedRlEnv:
 
     self.sim.sense()
     self.obs_buf = self.observation_manager.compute(update_history=True)
+    if len(reset_env_ids) > 0:
+      self.recorder_manager.record_post_reset(reset_env_ids)
+    self.recorder_manager.record_post_step()
 
     return (
       self.obs_buf,
@@ -441,6 +460,7 @@ class ManagerBasedRlEnv:
   def close(self) -> None:
     if self._offline_renderer is not None:
       self._offline_renderer.close()
+    self.recorder_manager.close()
 
   @staticmethod
   def seed(seed: int = -1) -> int:

--- a/src/mjlab/managers/__init__.py
+++ b/src/mjlab/managers/__init__.py
@@ -26,6 +26,10 @@ from mjlab.managers.observation_manager import (
 )
 from mjlab.managers.observation_manager import ObservationManager as ObservationManager
 from mjlab.managers.observation_manager import ObservationTermCfg as ObservationTermCfg
+from mjlab.managers.recorder_manager import NullRecorderManager as NullRecorderManager
+from mjlab.managers.recorder_manager import RecorderManager as RecorderManager
+from mjlab.managers.recorder_manager import RecorderTerm as RecorderTerm
+from mjlab.managers.recorder_manager import RecorderTermCfg as RecorderTermCfg
 from mjlab.managers.reward_manager import RewardManager as RewardManager
 from mjlab.managers.reward_manager import RewardTermCfg as RewardTermCfg
 from mjlab.managers.scene_entity_config import SceneEntityCfg as SceneEntityCfg

--- a/src/mjlab/managers/recorder_manager.py
+++ b/src/mjlab/managers/recorder_manager.py
@@ -1,0 +1,240 @@
+"""Recorder manager for logging environment data during rollouts."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import torch
+from prettytable import PrettyTable
+
+from mjlab.managers.manager_base import ManagerBase, ManagerTermBase, ManagerTermBaseCfg
+
+if TYPE_CHECKING:
+  from mjlab.envs.manager_based_rl_env import ManagerBasedRlEnv
+
+
+@dataclass
+class RecorderTermCfg(ManagerTermBaseCfg):
+  """Configuration for a recorder term.
+
+  ``func`` must be a :class:`RecorderTerm` subclass. Function-based terms are
+  not supported because recorder terms are stateful (file handles, buffers,
+  etc.).
+  """
+
+
+class RecorderTerm(ManagerTermBase):
+  """Base class for recorder terms.
+
+  Override only the lifecycle methods you need. Each method is a no-op by
+  default so subclasses are not required to implement all of them.
+
+  The environment is available as ``self._env``, giving access to
+  ``self._env.obs_buf``, ``self._env.action_manager.action``, and all
+  other environment state.
+
+  Example::
+
+    class CsvRecorder(RecorderTerm):
+        def __init__(self, cfg, env):
+            super().__init__(cfg, env)
+            self._file = open(cfg.params["path"], "w", newline="")
+            self._writer = csv.writer(self._file)
+
+        def record_pre_reset(self, env_ids):
+            # Terminal transition: action is still intact here.
+            # It will be zeroed by _reset_idx immediately after this returns.
+            obs = self._env.obs_buf["actor"][env_ids].cpu().numpy()
+            act = self._env.action_manager.action[env_ids].cpu().numpy()
+            for o, a in zip(obs, act):
+                self._writer.writerow(o.tolist() + a.tolist())
+
+        def record_post_step(self):
+            # Skip envs that just reset: their terminal pair was written
+            # in record_pre_reset and their action is now zeroed.
+            mask = ~self._env.reset_buf
+            obs = self._env.obs_buf["actor"][mask].cpu().numpy()
+            act = self._env.action_manager.action[mask].cpu().numpy()
+            for o, a in zip(obs, act):
+                self._writer.writerow(o.tolist() + a.tolist())
+
+        def close(self):
+            self._file.close()
+  """
+
+  def __init__(self, cfg: RecorderTermCfg, env: ManagerBasedRlEnv):
+    super().__init__(env)  # ManagerTermBase only accepts env
+    self.cfg = cfg
+
+  def record_pre_reset(self, env_ids: torch.Tensor) -> None:
+    """Called in ``env.step()`` before terminated environments are reset.
+
+    **What is available:**
+
+    - ``obs_buf`` contains the observation from the *end of the previous
+      step* (the input the agent used to choose the terminal action). It
+      does **not** contain the post-action terminal observation (the state
+      reached after applying the action), which is never computed for
+      resetting environments.
+    - ``action_manager.action`` contains the action applied during this
+      step. This is the correct terminal action. It will be zeroed for
+      these environments by ``_reset_idx`` immediately after this hook
+      returns, so capture it here if you need it later.
+    - ``reward_buf`` contains the reward for this terminal step.
+    - ``reset_terminated`` and ``reset_time_outs`` reflect why each
+      environment is resetting.
+
+    This is the right hook to record the terminal transition
+    ``(obs_t, action_t, reward_t, done=True)`` for each resetting
+    environment.
+
+    Args:
+      env_ids: Indices of environments that are about to be reset.
+    """
+    del env_ids  # Unused in base implementation.
+
+  def record_post_reset(self, env_ids: torch.Tensor) -> None:
+    """Called after a reset completes with fresh observations computed.
+
+    Fires at the end of ``env.reset()`` (covering all environments on
+    the initial call) and within ``env.step()`` for each batch of
+    environments that terminates, after state has been overwritten and
+    new observations computed.
+
+    At this point ``obs_buf[env_ids]`` holds the initial observation of
+    the new episode and ``action_manager.action[env_ids]`` is zero (no
+    action has been taken in the new episode yet).
+
+    Use this hook to initialize per-episode state or record the first
+    observation of a new episode.
+
+    Args:
+      env_ids: Indices of environments that were reset.
+    """
+    del env_ids  # Unused in base implementation.
+
+  def record_post_step(self) -> None:
+    """Called at the end of every ``env.step()`` with fresh observations.
+
+    At this point ``obs_buf`` holds the new observation for every
+    environment and ``action_manager.action`` holds the action that was
+    applied during this step. **Exception:** for environments that reset
+    during this step, ``action_manager.action`` has been zeroed by
+    ``_reset_idx`` and ``obs_buf`` holds the initial observation of the
+    new episode rather than the post-action terminal observation. Use
+    ``record_pre_reset`` to capture the terminal ``(obs, action)`` pair
+    for those environments. Resetting environments are identified by
+    ``self._env.reset_buf``.
+    """
+
+  def close(self) -> None:
+    """Called when the environment closes.
+
+    Release file handles, flush write buffers, or finalize output here.
+    """
+
+  def __call__(self):
+    raise NotImplementedError(
+      "RecorderTerm is not invoked via __call__. "
+      "Override the lifecycle methods instead."
+    )
+
+
+class RecorderManager(ManagerBase):
+  """Orchestrates recorder terms during environment rollouts.
+
+  Holds a collection of :class:`RecorderTerm` instances and calls their
+  lifecycle methods at the appropriate points in the environment loop. The
+  manager has no opinion on how data is stored; each term handles its own
+  I/O entirely.
+
+  Register terms by adding them to the ``recorders`` dict on
+  :class:`~mjlab.envs.ManagerBasedRlEnvCfg`. If the dict is empty, the
+  environment substitutes a :class:`NullRecorderManager` with zero overhead.
+  """
+
+  def __init__(self, cfg: dict[str, RecorderTermCfg], env: ManagerBasedRlEnv):
+    self._term_names: list[str] = []
+    self._terms: list[RecorderTerm] = []
+    self.cfg = deepcopy(cfg)
+    super().__init__(env)  # calls _prepare_terms()
+
+  def __str__(self) -> str:
+    msg = f"<RecorderManager> contains {len(self._term_names)} active terms.\n"
+    table = PrettyTable()
+    table.title = "Active Recorder Terms"
+    table.field_names = ["Index", "Name"]
+    for idx, name in enumerate(self._term_names):
+      table.add_row([idx, name])
+    return msg + table.get_string()
+
+  @property
+  def active_terms(self) -> list[str]:
+    return self._term_names
+
+  def record_pre_reset(self, env_ids: torch.Tensor) -> None:
+    """Forward to each term's :meth:`RecorderTerm.record_pre_reset`."""
+    for term in self._terms:
+      term.record_pre_reset(env_ids)
+
+  def record_post_reset(self, env_ids: torch.Tensor) -> None:
+    """Forward to each term's :meth:`RecorderTerm.record_post_reset`."""
+    for term in self._terms:
+      term.record_post_reset(env_ids)
+
+  def record_post_step(self) -> None:
+    """Forward to each term's :meth:`RecorderTerm.record_post_step`."""
+    for term in self._terms:
+      term.record_post_step()
+
+  def close(self) -> None:
+    """Forward to each term's :meth:`RecorderTerm.close`."""
+    for term in self._terms:
+      term.close()
+
+  def _prepare_terms(self):
+    for name, cfg in self.cfg.items():
+      if cfg is None:
+        continue
+      self._resolve_common_term_cfg(name, cfg)
+      # _resolve_common_term_cfg instantiates class-based terms in-place.
+      if not isinstance(cfg.func, RecorderTerm):
+        raise TypeError(
+          f"Recorder term '{name}': func must be a RecorderTerm subclass,"
+          f" got {type(cfg.func).__name__}. Function-based terms are not"
+          " supported."
+        )
+      self._term_names.append(name)
+      self._terms.append(cfg.func)
+
+
+class NullRecorderManager:
+  """No-op fallback used when no recorder terms are configured.
+
+  All methods are no-ops. This class is not a :class:`ManagerBase` subclass
+  so it carries zero overhead.
+  """
+
+  def __init__(self):
+    self.active_terms: list[str] = []
+    self.cfg = None
+
+  def __str__(self) -> str:
+    return "<NullRecorderManager> (inactive)"
+
+  def __repr__(self) -> str:
+    return "NullRecorderManager()"
+
+  def record_pre_reset(self, env_ids: torch.Tensor) -> None:
+    del env_ids
+
+  def record_post_reset(self, env_ids: torch.Tensor) -> None:
+    del env_ids
+
+  def record_post_step(self) -> None:
+    pass
+
+  def close(self) -> None:
+    pass

--- a/tests/test_recorder_manager.py
+++ b/tests/test_recorder_manager.py
@@ -1,0 +1,463 @@
+"""Tests for the recorder manager."""
+
+from unittest.mock import Mock
+
+import mujoco
+import pytest
+import torch
+from conftest import get_test_device
+
+from mjlab.actuator import BuiltinPositionActuatorCfg
+from mjlab.entity import EntityArticulationInfoCfg, EntityCfg
+from mjlab.envs import ManagerBasedRlEnv, ManagerBasedRlEnvCfg, mdp
+from mjlab.managers.observation_manager import ObservationGroupCfg, ObservationTermCfg
+from mjlab.managers.recorder_manager import (
+  NullRecorderManager,
+  RecorderManager,
+  RecorderTerm,
+  RecorderTermCfg,
+)
+from mjlab.managers.termination_manager import TerminationTermCfg
+from mjlab.scene import SceneCfg
+from mjlab.sim import MujocoCfg, SimulationCfg
+from mjlab.terrains import TerrainEntityCfg
+
+
+class _CountingRecorder(RecorderTerm):
+  """Records calls to each lifecycle method for inspection."""
+
+  def __init__(self, cfg, env):
+    super().__init__(cfg, env)
+    self.pre_reset_calls: list[torch.Tensor] = []
+    self.post_reset_calls: list[torch.Tensor] = []
+    self.post_step_count = 0
+    self.closed = False
+
+  def record_pre_reset(self, env_ids: torch.Tensor) -> None:
+    self.pre_reset_calls.append(env_ids.clone())
+
+  def record_post_reset(self, env_ids: torch.Tensor) -> None:
+    self.post_reset_calls.append(env_ids.clone())
+
+  def record_post_step(self) -> None:
+    self.post_step_count += 1
+
+  def close(self) -> None:
+    self.closed = True
+
+
+@pytest.fixture
+def mock_env() -> Mock:
+  env = Mock()
+  env.num_envs = 4
+  env.device = "cpu"
+  return env
+
+
+@pytest.fixture
+def manager_and_term(mock_env: Mock) -> tuple[RecorderManager, _CountingRecorder]:
+  cfg = {"recorder": RecorderTermCfg(func=_CountingRecorder, params={})}
+  manager = RecorderManager(cfg, mock_env)
+  term = manager._terms[0]
+  assert isinstance(term, _CountingRecorder)
+  return manager, term
+
+
+# Lifecycle semantics.
+
+
+def test_terminal_action_available_at_record_pre_reset(mock_env: Mock) -> None:
+  """record_pre_reset fires before _reset_idx, so action_manager.action is intact.
+
+  In step(), the sequence is:
+    record_pre_reset(reset_env_ids)   <- action still set
+    _reset_idx(reset_env_ids)         <- zeroes action_manager.action
+    ...
+    record_post_step()                <- action is now 0 for reset envs
+
+  A recorder that wants the terminal action MUST capture it at record_pre_reset.
+  """
+  seen: dict[str, torch.Tensor] = {}
+
+  class ActionCapture(RecorderTerm):
+    def record_pre_reset(self, env_ids: torch.Tensor) -> None:
+      seen["pre_reset_action"] = self._env.action_manager.action[env_ids].clone()
+
+    def record_post_step(self) -> None:
+      seen["post_step_action"] = self._env.action_manager.action.clone()
+
+  mock_env.action_manager = Mock()
+  mock_env.action_manager.action = torch.tensor(
+    [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [7.0, 8.0]]
+  )
+
+  cfg = {"r": RecorderTermCfg(func=ActionCapture, params={})}
+  manager = RecorderManager(cfg, mock_env)
+
+  reset_env_ids = torch.tensor([0, 2])
+
+  # Simulate step(): record_pre_reset fires before _reset_idx zeros actions.
+  manager.record_pre_reset(reset_env_ids)
+  assert torch.equal(
+    seen["pre_reset_action"],
+    torch.tensor([[1.0, 2.0], [5.0, 6.0]]),
+  ), "Terminal action must be intact at record_pre_reset"
+
+  # Simulate _reset_idx: zeros action for reset envs.
+  mock_env.action_manager.action[reset_env_ids] = 0.0
+
+  manager.record_post_step()
+  assert torch.all(seen["post_step_action"][reset_env_ids] == 0.0), (
+    "Action is zeroed for reset envs at record_post_step; use record_pre_reset"
+    " to capture terminal actions"
+  )
+  # Non-reset envs retain their action.
+  non_reset = torch.tensor([1, 3])
+  assert torch.equal(
+    seen["post_step_action"][non_reset],
+    torch.tensor([[3.0, 4.0], [7.0, 8.0]]),
+  )
+
+
+def test_record_pre_reset_obs_buf_is_previous_step(mock_env: Mock) -> None:
+  """obs_buf at record_pre_reset is the previous step's observation, not the
+  post-action terminal state. It is the input obs the agent used to pick the
+  terminal action.
+  """
+  seen: dict[str, torch.Tensor] = {}
+
+  # Use a plain tensor for obs_buf to avoid dict-subscript complexity in the
+  # type checker. The point of this test is lifecycle timing, not data structure.
+  class ObsCapture(RecorderTerm):
+    def record_pre_reset(self, env_ids: torch.Tensor) -> None:
+      obs: torch.Tensor = self._env.obs_buf  # type: ignore[assignment]
+      seen["pre_reset_obs"] = obs[env_ids].clone()
+
+    def record_post_step(self) -> None:
+      obs: torch.Tensor = self._env.obs_buf  # type: ignore[assignment]
+      seen["post_step_obs"] = obs.clone()
+
+  prev_obs = torch.arange(8, dtype=torch.float).reshape(4, 2)
+  mock_env.obs_buf = prev_obs.clone()
+
+  cfg = {"r": RecorderTermCfg(func=ObsCapture, params={})}
+  manager = RecorderManager(cfg, mock_env)
+
+  reset_env_ids = torch.tensor([1])
+  manager.record_pre_reset(reset_env_ids)
+  # obs_buf at pre_reset is unchanged from the previous step.
+  assert torch.equal(seen["pre_reset_obs"], prev_obs[reset_env_ids])
+
+  # Simulate _reset_idx + obs recompute: reset env gets new initial obs.
+  mock_env.obs_buf[reset_env_ids] = torch.zeros(1, 2)
+  manager.record_post_step()
+  assert torch.all(seen["post_step_obs"][reset_env_ids] == 0.0), (
+    "After reset, obs_buf for the reset env holds the new-episode initial obs"
+  )
+
+
+def test_record_post_reset_fires_after_obs_are_fresh(mock_env: Mock) -> None:
+  """record_post_reset is called after obs are computed, so obs_buf already
+  holds the new-episode initial observation for the reset environments.
+  """
+  seen: dict[str, torch.Tensor] = {}
+
+  class ResetObsCapture(RecorderTerm):
+    def record_post_reset(self, env_ids: torch.Tensor) -> None:
+      obs: torch.Tensor = self._env.obs_buf  # type: ignore[assignment]
+      seen["obs"] = obs[env_ids].clone()
+
+  reset_obs = torch.ones(4, 2) * 99.0
+  mock_env.obs_buf = reset_obs
+
+  cfg = {"r": RecorderTermCfg(func=ResetObsCapture, params={})}
+  manager = RecorderManager(cfg, mock_env)
+
+  env_ids = torch.tensor([0, 3])
+  manager.record_post_reset(env_ids)
+  assert torch.equal(seen["obs"], reset_obs[env_ids])
+
+
+def test_record_pre_reset_before_record_post_step_in_step(mock_env: Mock) -> None:
+  """record_pre_reset fires before record_post_step within a single step."""
+  call_log: list[str] = []
+
+  class OrderRecorder(RecorderTerm):
+    def record_pre_reset(self, env_ids: torch.Tensor) -> None:
+      call_log.append("pre_reset")
+
+    def record_post_step(self) -> None:
+      call_log.append("post_step")
+
+  cfg = {"r": RecorderTermCfg(func=OrderRecorder, params={})}
+  manager = RecorderManager(cfg, mock_env)
+
+  manager.record_pre_reset(torch.tensor([0]))
+  manager.record_post_step()
+
+  assert call_log == ["pre_reset", "post_step"]
+
+
+# Manager dispatch.
+
+
+def test_record_post_step_called_each_step(
+  manager_and_term: tuple[RecorderManager, _CountingRecorder],
+) -> None:
+  manager, term = manager_and_term
+  for _ in range(5):
+    manager.record_post_step()
+  assert term.post_step_count == 5
+
+
+def test_record_pre_reset_passes_env_ids(
+  manager_and_term: tuple[RecorderManager, _CountingRecorder],
+) -> None:
+  manager, term = manager_and_term
+  env_ids = torch.tensor([0, 2])
+  manager.record_pre_reset(env_ids)
+  assert len(term.pre_reset_calls) == 1
+  assert torch.equal(term.pre_reset_calls[0], env_ids)
+
+
+def test_record_post_reset_passes_env_ids(
+  manager_and_term: tuple[RecorderManager, _CountingRecorder],
+) -> None:
+  manager, term = manager_and_term
+  env_ids = torch.tensor([1, 3])
+  manager.record_post_reset(env_ids)
+  assert len(term.post_reset_calls) == 1
+  assert torch.equal(term.post_reset_calls[0], env_ids)
+
+
+def test_close_propagates_to_all_terms(mock_env: Mock) -> None:
+  cfg = {
+    "a": RecorderTermCfg(func=_CountingRecorder, params={}),
+    "b": RecorderTermCfg(func=_CountingRecorder, params={}),
+  }
+  manager = RecorderManager(cfg, mock_env)
+  term_a, term_b = manager._terms
+  assert isinstance(term_a, _CountingRecorder)
+  assert isinstance(term_b, _CountingRecorder)
+
+  manager.close()
+  assert term_a.closed
+  assert term_b.closed
+
+
+def test_terms_called_in_registration_order(mock_env: Mock) -> None:
+  call_log: list[str] = []
+
+  class NamedRecorder(RecorderTerm):
+    def __init__(self, cfg, env):
+      super().__init__(cfg, env)
+      self._name: str = cfg.params["name"]
+
+    def record_post_step(self) -> None:
+      call_log.append(self._name)
+
+  cfg = {
+    "first": RecorderTermCfg(func=NamedRecorder, params={"name": "first"}),
+    "second": RecorderTermCfg(func=NamedRecorder, params={"name": "second"}),
+    "third": RecorderTermCfg(func=NamedRecorder, params={"name": "third"}),
+  }
+  manager = RecorderManager(cfg, mock_env)
+  manager.record_post_step()
+  assert call_log == ["first", "second", "third"]
+
+
+def test_multiple_terms_have_independent_state(mock_env: Mock) -> None:
+  cfg = {
+    "a": RecorderTermCfg(func=_CountingRecorder, params={}),
+    "b": RecorderTermCfg(func=_CountingRecorder, params={}),
+  }
+  manager = RecorderManager(cfg, mock_env)
+  term_a, term_b = manager._terms
+  assert isinstance(term_a, _CountingRecorder)
+  assert isinstance(term_b, _CountingRecorder)
+
+  manager.record_post_step()
+  manager.record_post_step()
+  manager.record_pre_reset(torch.tensor([0]))
+
+  assert term_a.post_step_count == 2
+  assert term_b.post_step_count == 2
+  assert len(term_a.pre_reset_calls) == 1
+  assert len(term_b.pre_reset_calls) == 1
+
+
+def test_active_terms_matches_registration_order(mock_env: Mock) -> None:
+  cfg = {
+    "first": RecorderTermCfg(func=_CountingRecorder, params={}),
+    "second": RecorderTermCfg(func=_CountingRecorder, params={}),
+  }
+  manager = RecorderManager(cfg, mock_env)
+  assert manager.active_terms == ["first", "second"]
+
+
+def test_none_terms_skipped(mock_env: Mock) -> None:
+  cfg: dict[str, RecorderTermCfg | None] = {
+    "valid": RecorderTermCfg(func=_CountingRecorder, params={}),
+    "skipped": None,
+  }
+  manager = RecorderManager(cfg, mock_env)  # type: ignore[arg-type]
+  assert manager.active_terms == ["valid"]
+  assert len(manager._terms) == 1
+
+
+def test_function_based_term_raises(mock_env: Mock) -> None:
+  cfg = {"bad": RecorderTermCfg(func=lambda env: None, params={})}
+  with pytest.raises(TypeError, match="RecorderTerm subclass"):
+    RecorderManager(cfg, mock_env)
+
+
+def test_cfg_params_accessible_on_term(mock_env: Mock) -> None:
+  cfg = {"t": RecorderTermCfg(func=_CountingRecorder, params={"path": "/tmp/out.csv"})}
+  manager = RecorderManager(cfg, mock_env)
+  term = manager._terms[0]
+  assert isinstance(term, _CountingRecorder)
+  assert term.cfg.params["path"] == "/tmp/out.csv"
+
+
+def test_deepcopy_protects_original_cfg(mock_env: Mock) -> None:
+  """Creating a manager must not mutate the caller's cfg dict.
+
+  _resolve_common_term_cfg replaces cfg.func with the instantiated object
+  in-place on the internal copy. Without deepcopy the caller's cfg would
+  be silently corrupted, breaking any second use.
+  """
+  original_cfg = {"t": RecorderTermCfg(func=_CountingRecorder, params={})}
+  RecorderManager(original_cfg, mock_env)
+  assert original_cfg["t"].func is _CountingRecorder
+
+
+def test_null_recorder_manager_no_ops() -> None:
+  manager = NullRecorderManager()
+  env_ids = torch.tensor([0, 1])
+  manager.record_pre_reset(env_ids)
+  manager.record_post_reset(env_ids)
+  manager.record_post_step()
+  manager.close()
+  assert manager.active_terms == []
+
+
+def test_base_term_all_hooks_are_no_ops(mock_env: Mock) -> None:
+  """Base RecorderTerm hooks do nothing; __call__ raises NotImplementedError."""
+
+  class MinimalRecorder(RecorderTerm):
+    pass
+
+  term = MinimalRecorder(
+    cfg=RecorderTermCfg(func=MinimalRecorder, params={}), env=mock_env
+  )
+  env_ids = torch.tensor([0])
+  term.record_pre_reset(env_ids)
+  term.record_post_reset(env_ids)
+  term.record_post_step()
+  term.close()
+
+  with pytest.raises(NotImplementedError):
+    term()
+
+
+# Integration: real ManagerBasedRlEnv.
+
+
+_SLIDING_MASS_XML = """
+<mujoco>
+  <option timestep="0.002"/>
+  <worldbody>
+    <body name="mass" pos="0 0 0">
+      <joint name="slide" type="slide" axis="1 0 0" range="-1 1" limited="true"/>
+      <geom name="mass_geom" type="sphere" size="0.1" mass="1.0"/>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+
+def _make_env_cfg(recorders: dict | None = None) -> ManagerBasedRlEnvCfg:
+  """One-step episode (time_out fires after a single step)."""
+  timestep = 0.002
+  return ManagerBasedRlEnvCfg(
+    scene=SceneCfg(
+      terrain=TerrainEntityCfg(terrain_type="plane"),
+      num_envs=2,
+      extent=1.0,
+      entities={
+        "robot": EntityCfg(
+          spec_fn=lambda: mujoco.MjSpec.from_string(_SLIDING_MASS_XML),
+          articulation=EntityArticulationInfoCfg(
+            actuators=(
+              BuiltinPositionActuatorCfg(
+                target_names_expr=(".*",), stiffness=100.0, damping=10.0
+              ),
+            )
+          ),
+        )
+      },
+    ),
+    observations={
+      "actor": ObservationGroupCfg(
+        terms={"obs": ObservationTermCfg(func=mdp.joint_pos_rel)}
+      )
+    },
+    actions={
+      "joint_pos": mdp.JointPositionActionCfg(
+        entity_name="robot", actuator_names=(".*",), scale=1.0
+      )
+    },
+    terminations={"time_out": TerminationTermCfg(func=mdp.time_out, time_out=True)},
+    events={},
+    sim=SimulationCfg(mujoco=MujocoCfg(timestep=timestep, iterations=1)),
+    decimation=1,
+    episode_length_s=timestep,  # terminates every env after exactly one step
+    recorders=recorders or {},
+  )
+
+
+@pytest.fixture(scope="module")
+def device() -> str:
+  return get_test_device()
+
+
+def test_integration_terminal_action_available_at_record_pre_reset(device: str) -> None:
+  """In a real env.step(), record_pre_reset fires before _reset_idx zeroes
+  action_manager.action for reset envs. This verifies the hook ordering
+  described in the docstring is enforced by the actual step() implementation.
+  """
+  seen: dict[str, torch.Tensor] = {}
+
+  class HookOrderRecorder(RecorderTerm):
+    def record_pre_reset(self, env_ids: torch.Tensor) -> None:
+      # Action must still be non-zero; _reset_idx has not run yet.
+      seen["pre_reset_action"] = self._env.action_manager.action[env_ids].clone()
+
+    def record_post_step(self) -> None:
+      seen["post_step_action"] = self._env.action_manager.action.clone()
+      seen["reset_buf"] = self._env.reset_buf.clone()
+
+  cfg = _make_env_cfg(
+    recorders={"r": RecorderTermCfg(func=HookOrderRecorder, params={})}
+  )
+  env = ManagerBasedRlEnv(cfg=cfg, device=device)
+  env.reset()
+
+  action = torch.ones(2, 1, device=device) * 0.5
+  env.step(action)
+
+  # With episode_length_s = one timestep, both envs time out on the first step.
+  assert seen["reset_buf"].all(), "Both envs should have reset after one step"
+
+  # Terminal action must have been captured intact at record_pre_reset.
+  assert seen["pre_reset_action"].shape == (2, 1)
+  assert torch.allclose(seen["pre_reset_action"], action), (
+    "record_pre_reset must see the applied action before _reset_idx zeroes it"
+  )
+
+  # By record_post_step the action is zeroed for all reset envs.
+  assert torch.all(seen["post_step_action"] == 0.0), (
+    "action_manager.action is zeroed for reset envs by the time record_post_step runs"
+  )
+
+  env.close()


### PR DESCRIPTION
PR #872 wanted to add CSV obs/action logging by modifying `ManagerBasedRlEnv.step()` directly. That's the wrong place for it: it hardcodes I/O policy into the core env and doesn't generalize. This PR adds a `RecorderManager` that gives users a clean hooks API to implement any logging they want without touching mjlab internals.

The design follows the existing manager pattern. Users subclass `RecorderTerm` and register it in the `recorders` dict on their env config:

```python
class CsvRecorder(RecorderTerm):
    def __init__(self, cfg, env):
        super().__init__(cfg, env)
        self._file = open(cfg.params["path"], "w", newline="")
        self._writer = csv.writer(self._file)

    def record_pre_reset(self, env_ids):
        obs = self._env.obs_buf["actor"][env_ids].cpu().numpy()
        act = self._env.action_manager.action[env_ids].cpu().numpy()
        for o, a in zip(obs, act):
            self._writer.writerow(o.tolist() + a.tolist())

    def record_post_step(self):
        mask = ~self._env.reset_buf
        obs = self._env.obs_buf["actor"][mask].cpu().numpy()
        act = self._env.action_manager.action[mask].cpu().numpy()
        for o, a in zip(obs, act):
            self._writer.writerow(o.tolist() + a.tolist())

    def close(self):
        self._file.close()

@dataclass
class MyEnvCfg(SomeTaskEnvCfg):
    recorders: dict = field(default_factory=lambda: {
        "csv": RecorderTermCfg(func=CsvRecorder, params={"path": "rollout.csv"})
    })
```

Three lifecycle hooks fire at the right moments in `step()` and `reset()`:

- `record_pre_reset(env_ids)`: called before `_reset_idx`, so `action_manager.action` is still intact. This is the only place to capture the terminal `(obs_t, action_t, reward_t)` tuple; the action is zeroed immediately after.
- `record_post_reset(env_ids)`: called after obs are computed for reset envs, with fresh initial observations.
- `record_post_step()`: called at the end of every step. Reset envs have action=0 and obs from the new episode; use `~self._env.reset_buf` to skip them.

If `recorders` is empty (the default), a `NullRecorderManager` is used with zero overhead. Existing configs need no changes.

Includes docs, changelog entry, and 18 tests covering both isolated dispatch and a real env integration test that verifies terminal action availability at `record_pre_reset`.