### PR TITLE
Filter wandb checkpoints server-side

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -112,6 +112,9 @@ Changed
 - Removed ``EntityData.generalized_force``. The property was bugged (indexed
   free joint DOFs instead of articulated DOFs) and the name was ambiguous.
   Use ``qfrc_actuator`` or ``qfrc_external`` instead (:issue:`776`).
+- ``fetch_wandb_checkpoint`` now filters checkpoints server-side via the
+  ``pattern`` parameter, avoiding unnecessary pagination and tolerance to
+  corrupted metadata (:issue:`898`).
 
 Fixed
 ^^^^^

--- a/src/mjlab/utils/os.py
+++ b/src/mjlab/utils/os.py
@@ -78,7 +78,9 @@ def get_wandb_checkpoint_path(
   api = wandb.Api()
   wandb_run = api.run(str(run_path))
   files = [
-    file.name for file in wandb_run.files() if re.match(r"^model_\d+\.pt$", file.name)
+    file.name
+    for file in wandb_run.files(pattern="model_%.pt")
+    if re.match(r"^model_\d+\.pt$", file.name)
   ]
   if checkpoint_name is None:
     checkpoint_file = max(files, key=lambda x: int(x.split("_")[1].split(".")[0]))


### PR DESCRIPTION
`fetch_wandb_checkpoint` called `wandb_run.files()` without a filter, pulling all file metadata before discarding non-matches locally. This caused unnecessary pagination for runs with many stored files and was sensitive to `null` paginator returns from corrupted metadata (e.g. partial uploads or interrupted runs).

This adds the `pattern` parameter to filter at the server level (`model_%.pt` in wandb's MySQL LIKE syntax), keeping the existing regex as a secondary guard since the LIKE pattern is less strict than `model_\d+\.pt`.

Fixes #898