### PR TITLE
Add auto_reset config flag

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,6 +8,13 @@ Upcoming version (not yet released)
 Added
 ^^^^^
 
+- Added ``ManagerBasedRlEnvCfg.auto_reset`` flag. When ``True`` (default),
+  ``step()`` continues to reset done environments in place and returns the
+  post-reset observation. When ``False``, ``step()`` skips the reset block
+  and returns the terminal observation directly; the caller must call
+  ``reset(env_ids=...)`` for done environments before the next ``step()``
+  or a ``RuntimeError`` is raised. Enables access to the true terminal
+  state for algorithms that need it (:issue:`900`).
 - Added ``ActuatorCfg.viscous_damping`` for passive velocity proportional
   damping (``f = -b·v``), distinct from the PD derivative gain ``damping``
   used by position and velocity actuators. Maps to ``<joint damping>`` for

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -14,7 +14,9 @@ Added
   and returns the terminal observation directly; the caller must call
   ``reset(env_ids=...)`` for done environments before the next ``step()``
   or a ``RuntimeError`` is raised. Enables access to the true terminal
-  state for algorithms that need it (:issue:`900`).
+  state for algorithms that need it. Note that mjlab's bundled ``train.py``
+  uses rsl_rl's ``OnPolicyRunner``, which does not drive manual resets, so
+  ``auto_reset=False`` is intended for custom training loops (:issue:`900`).
 - Added ``ActuatorCfg.viscous_damping`` for passive velocity proportional
   damping (``f = -b·v``), distinct from the PD derivative gain ``damping``
   used by position and velocity actuators. Maps to ``<joint damping>`` for

--- a/src/mjlab/envs/manager_based_rl_env.py
+++ b/src/mjlab/envs/manager_based_rl_env.py
@@ -148,6 +148,10 @@ class ManagerBasedRlEnvCfg:
   observations. When False, ``step()`` returns the true terminal observation and the
   caller must explicitly call ``reset(env_ids=...)`` for done environments before the
   next ``step()``.
+
+  Note: mjlab's bundled ``train.py`` goes through rsl_rl's ``OnPolicyRunner``, which
+  does not drive manual resets. ``auto_reset=False`` is intended for users running
+  their own training loop (or a wrapper that handles the reset between steps).
   """
 
   scale_rewards_by_dt: bool = True

--- a/src/mjlab/envs/manager_based_rl_env.py
+++ b/src/mjlab/envs/manager_based_rl_env.py
@@ -141,6 +141,15 @@ class ManagerBasedRlEnvCfg:
     limit.
   """
 
+  auto_reset: bool = True
+  """Whether to automatically reset environments that terminate or time out.
+
+  When True (default), ``step()`` resets done environments and returns post-reset
+  observations. When False, ``step()`` returns the true terminal observation and the
+  caller must explicitly call ``reset(env_ids=...)`` for done environments before the
+  next ``step()``.
+  """
+
   scale_rewards_by_dt: bool = True
   """Whether to multiply rewards by the environment step duration (dt).
 
@@ -175,6 +184,9 @@ class ManagerBasedRlEnv:
     self._sim_step_counter = 0
     self.extras = {}
     self.obs_buf = {}
+    self._manual_reset_pending = torch.zeros(
+      self.cfg.scene.num_envs, dtype=torch.bool, device=device
+    )
 
     # Initialize scene and simulation.
     self.scene = Scene(self.cfg.scene, device=device)
@@ -356,32 +368,43 @@ class ManagerBasedRlEnv:
   def step(self, action: torch.Tensor) -> types.VecEnvStepReturn:
     """Run one environment step: apply actions, simulate, compute RL signals.
 
-    **Forward-call placement.** MuJoCo's ``mj_step`` runs forward kinematics
-    *before* integration, so after stepping, derived quantities (``xpos``,
-    ``xquat``, ``site_xpos``, ``cvel``, ``sensordata``) lag ``qpos``/``qvel``
-    by one physics substep. Rather than calling ``sim.forward()`` twice (once
-    after the decimation loop and once after the reset block), this method
-    calls it **once**, right before observation computation. This single call
-    refreshes derived quantities for *all* envs: non-reset envs pick up
-    post-decimation kinematics, reset envs pick up post-reset kinematics.
+    When ``auto_reset=True`` (default), environments that terminate or time out are
+    reset in place and the returned observation is the post-reset state. When
+    ``auto_reset=False``, the reset is skipped and the returned observation is the
+    terminal state; the caller must call ``reset(env_ids=...)`` for done envs before
+    the next ``step()``.
 
-    The tradeoff is that termination and reward managers see derived
-    quantities that are stale by one physics substep (the last ``mj_step``
-    ran ``mj_forward`` from *pre*-integration ``qpos``). In practice, the
-    staleness is negligible for reward shaping and termination
-    checks. Critically, the staleness is *consistent*: every env,
-    every step, always sees the same lag, so the MDP is well-defined
-    and the value function can learn the correct mapping.
+    **Forward-call placement.** MuJoCo's ``mj_step`` runs forward kinematics *before*
+    integration, so after stepping, derived quantities (``xpos``, ``xquat``,
+    ``site_xpos``, ``cvel``, ``sensordata``) lag ``qpos``/``qvel`` by one physics
+    substep. Rather than calling ``sim.forward()`` twice (once after the decimation
+    loop and once after the reset block), this method calls it **once**, right
+    before observation computation. This single call refreshes derived quantities
+    for *all* envs: non-reset envs pick up post-decimation kinematics, reset envs
+    pick up post-reset kinematics.
+
+    The tradeoff is that termination and reward managers see derived quantities that
+    are stale by one physics substep (the last ``mj_step`` ran ``mj_forward`` from
+    *pre*-integration ``qpos``). In practice, the staleness is negligible for reward
+    shaping and termination checks. Critically, the staleness is *consistent*: every
+    env, every step, always sees the same lag, so the MDP is well-defined and the
+    value function can learn the correct mapping.
 
     .. note::
 
-      Event and command authors do not need to call ``sim.forward()``
-      themselves. This method handles it. The only constraint is: do not
-      read derived quantities (``root_link_pose_w``, ``body_link_vel_w``,
-      etc.) in the same function that writes state
-      (``write_root_state_to_sim``, ``write_joint_state_to_sim``, etc.).
-      See :ref:`faq` for details.
+      Event and command authors do not need to call ``sim.forward()`` themselves.
+      This method handles it. The only constraint is: do not read derived quantities
+      (``root_link_pose_w``, ``body_link_vel_w``, etc.) in the same function that
+      writes state (``write_root_state_to_sim``, ``write_joint_state_to_sim``,
+      etc.). See :ref:`faq` for details.
     """
+    if not self.cfg.auto_reset and torch.any(self._manual_reset_pending):
+      pending_ids = self._manual_reset_pending.nonzero(as_tuple=False).squeeze(-1)
+      raise RuntimeError(
+        f"Environments {pending_ids.cpu().tolist()} must be reset via "
+        "reset(env_ids=...) before calling step() again when auto_reset=False."
+      )
+
     self.action_manager.process_action(action.to(self.device))
 
     for _ in range(self.cfg.decimation):
@@ -408,7 +431,7 @@ class ManagerBasedRlEnv:
 
     # Reset envs that terminated/timed-out and log the episode info.
     reset_env_ids = self.reset_buf.nonzero(as_tuple=False).squeeze(-1)
-    if len(reset_env_ids) > 0:
+    if self.cfg.auto_reset and len(reset_env_ids) > 0:
       self.recorder_manager.record_pre_reset(reset_env_ids)
       self._reset_idx(reset_env_ids)
       self.scene.write_data_to_sim()
@@ -428,8 +451,12 @@ class ManagerBasedRlEnv:
 
     self.sim.sense()
     self.obs_buf = self.observation_manager.compute(update_history=True)
-    if len(reset_env_ids) > 0:
+
+    if self.cfg.auto_reset and len(reset_env_ids) > 0:
       self.recorder_manager.record_post_reset(reset_env_ids)
+    elif len(reset_env_ids) > 0:
+      self._manual_reset_pending[reset_env_ids] = True
+
     self.recorder_manager.record_post_step()
 
     return (
@@ -548,3 +575,4 @@ class ManagerBasedRlEnv:
     self.extras["log"].update(info)
     # reset the episode length buffer.
     self.episode_length_buf[env_ids] = 0
+    self._manual_reset_pending[env_ids] = False

--- a/tests/test_auto_reset.py
+++ b/tests/test_auto_reset.py
@@ -1,0 +1,125 @@
+"""Tests for the auto_reset config flag."""
+
+import pytest
+import torch
+from conftest import get_test_device
+
+from mjlab.envs import ManagerBasedRlEnv
+from mjlab.tasks.cartpole.cartpole_env_cfg import cartpole_balance_env_cfg
+
+
+@pytest.fixture(scope="module")
+def device():
+  return get_test_device()
+
+
+def _make_cfg(auto_reset: bool):
+  cfg = cartpole_balance_env_cfg()
+  cfg.episode_length_s = 0.5  # 10 steps at dt=0.05
+  cfg.scene.num_envs = 4
+  cfg.auto_reset = auto_reset
+  return cfg
+
+
+def _step_until_done_env(env):
+  """Step with zero actions until at least one env is done. Return step outputs."""
+  for _ in range(env.max_episode_length + 5):
+    action = torch.zeros((env.num_envs, 1), device=env.device)
+    result = env.step(action)
+    terminated, truncated = result[2], result[3]
+    if (terminated | truncated).any():
+      return result
+  pytest.fail("No env terminated within max_episode_length steps")
+
+
+def test_auto_reset_true_resets_done_envs(device):
+  """With auto_reset=True (default), done envs are reset during step."""
+  env = ManagerBasedRlEnv(cfg=_make_cfg(auto_reset=True), device=device)
+  env.reset()
+  _, _, terminated, truncated, _ = _step_until_done_env(env)
+  done = terminated | truncated
+  done_ids = done.nonzero(as_tuple=False).squeeze(-1)
+
+  # Episode counter was reset to 0 for done envs.
+  assert (env.episode_length_buf[done_ids] == 0).all()
+  env.close()
+
+
+def test_auto_reset_false_preserves_terminal_state(device):
+  """With auto_reset=False, done envs are NOT reset and obs is the terminal state."""
+  env = ManagerBasedRlEnv(cfg=_make_cfg(auto_reset=False), device=device)
+  env.reset()
+  obs, _, terminated, truncated, _ = _step_until_done_env(env)
+  done = terminated | truncated
+  done_ids = done.nonzero(as_tuple=False).squeeze(-1)
+
+  # Episode counter was NOT reset (still at max_episode_length).
+  assert (env.episode_length_buf[done_ids] == env.max_episode_length).all()
+
+  # The returned obs must reflect the current (post-decimation terminal) sim
+  # state. Since no reset ran and the sim wasn't touched after step(), a fresh
+  # observation_manager.compute() on the current sim state must match exactly.
+  # This catches regressions where step() might return stale or post-reset obs.
+  env.observation_manager._obs_buffer = None  # bypass cache
+  fresh_obs = env.observation_manager.compute()
+  for group in obs:
+    returned = obs[group]
+    current = fresh_obs[group]
+    assert isinstance(returned, torch.Tensor) and isinstance(current, torch.Tensor)
+    assert torch.equal(returned, current)
+  env.close()
+
+
+def test_auto_reset_false_explicit_reset_works(device):
+  """After auto_reset=False, calling reset(env_ids=...) resets those envs."""
+  env = ManagerBasedRlEnv(cfg=_make_cfg(auto_reset=False), device=device)
+  env.reset()
+  _, _, terminated, truncated, _ = _step_until_done_env(env)
+  done = terminated | truncated
+  done_ids = done.nonzero(as_tuple=False).squeeze(-1)
+
+  # Manually reset done envs.
+  env.reset(env_ids=done_ids)
+  assert (env.episode_length_buf[done_ids] == 0).all()
+
+  # Can continue stepping after manual reset.
+  action = torch.zeros((env.num_envs, 1), device=env.device)
+  obs, reward, _, _, _ = env.step(action)
+  assert obs is not None
+  assert reward is not None
+  env.close()
+
+
+def test_auto_reset_false_requires_manual_reset_before_next_step(device):
+  """Raw env should reject another step until done envs are explicitly reset."""
+  env = ManagerBasedRlEnv(cfg=_make_cfg(auto_reset=False), device=device)
+  env.reset()
+  _step_until_done_env(env)
+
+  action = torch.zeros((env.num_envs, 1), device=env.device)
+  with pytest.raises(RuntimeError, match="must be reset via reset"):
+    env.step(action)
+
+  env.close()
+
+
+def test_auto_reset_false_obs_differs_from_auto_reset_true(device):
+  """Terminal obs (auto_reset=False) differs from post-reset obs (auto_reset=True)."""
+  # Run with auto_reset=True, capture post-reset obs for done envs.
+  env_on = ManagerBasedRlEnv(cfg=_make_cfg(auto_reset=True), device=device)
+  env_on.reset(seed=42)
+  obs_on, _, _, _, _ = _step_until_done_env(env_on)
+  env_on.close()
+
+  # Run with auto_reset=False with the same seed, capture terminal obs.
+  env_off = ManagerBasedRlEnv(cfg=_make_cfg(auto_reset=False), device=device)
+  env_off.reset(seed=42)
+  obs_off, _, _, _, _ = _step_until_done_env(env_off)
+  env_off.close()
+
+  # The observations should differ: one is post-reset, the other is terminal.
+  for group in obs_on:
+    on_val = obs_on[group]
+    off_val = obs_off[group]
+    assert isinstance(on_val, torch.Tensor) and isinstance(off_val, torch.Tensor)
+    assert not torch.equal(on_val, off_val)

--- a/tests/test_auto_reset.py
+++ b/tests/test_auto_reset.py
@@ -103,6 +103,46 @@ def test_auto_reset_false_requires_manual_reset_before_next_step(device):
   env.close()
 
 
+def _slice_obs(obs: dict, ids: torch.Tensor) -> dict[str, torch.Tensor]:
+  """Return a new obs dict containing only the rows at ``ids`` (per group)."""
+  return {k: v[ids] for k, v in obs.items() if isinstance(v, torch.Tensor)}
+
+
+def test_auto_reset_false_user_loop_pattern(device):
+  """Example: run your own training loop against an auto_reset=False env.
+
+  The pattern is:
+    1. After step(), derive done_ids from terminated | truncated.
+    2. Slice obs[done_ids] to get the true terminal observation and use it for
+      bootstrap / target computation.
+    3. Call env.reset(env_ids=done_ids) to reset only the done envs.
+    4. Continue stepping with the full batch.
+  """
+  env = ManagerBasedRlEnv(cfg=_make_cfg(auto_reset=False), device=device)
+  obs, _ = env.reset(seed=0)
+  episode_count = torch.zeros(env.num_envs, dtype=torch.long, device=env.device)
+  last_terminal_obs: dict[str, torch.Tensor] | None = None
+
+  action = torch.zeros((env.num_envs, 1), device=env.device)
+  for _ in range((env.max_episode_length + 2) * 3):
+    obs, _, terminated, truncated, _ = env.step(action)
+    done = terminated | truncated
+    if not done.any():
+      continue
+
+    done_ids = done.nonzero(as_tuple=False).squeeze(-1)
+    last_terminal_obs = _slice_obs(obs, done_ids)  # feed this to your critic/replay
+
+    episode_count[done_ids] += 1
+    obs, _ = env.reset(env_ids=done_ids)
+    if (episode_count >= 2).all():
+      break
+
+  assert (episode_count >= 2).all()
+  assert last_terminal_obs is not None
+  env.close()
+
+
 def test_auto_reset_false_obs_differs_from_auto_reset_true(device):
   """Terminal obs (auto_reset=False) differs from post-reset obs (auto_reset=True)."""
   # Run with auto_reset=True, capture post-reset obs for done envs.


### PR DESCRIPTION
Adds `ManagerBasedRlEnvCfg.auto_reset` (default `True`). When `False`, `step()` skips the reset block for done environments and returns the true terminal observation; the caller must call `reset(env_ids=...)` before the next `step()` or the env raises. Algorithms that need the real terminal state (off-policy Q targets, correct PPO truncation bootstrap) get direct access to it.

Note that mjlab's default `train.py` path goes through rsl_rl's `OnPolicyRunner`, which doesn't drive manual resets, so `auto_reset=False` is intended for users running their own training loop or a wrapper that handles the reset between steps.

An earlier version of this branch also set `terminal_observation` in `extras` under `auto_reset=True`. Getting that right would have required broader changes across the manager layer, and I wanted to keep this PR self-contained. Users who need terminal-obs bootstrap can opt into `auto_reset=False` and own the reset in a thin wrapper.

Closes #900.