### PR TITLE
Extend information of the exported ONNX metadata

### DIFF
--- a/src/mjlab/rl/exporter_utils.py
+++ b/src/mjlab/rl/exporter_utils.py
@@ -72,12 +72,8 @@ def get_base_metadata(
     else:
       observation_term_clip.append(list(raw_clip))
 
-    observation_term_flatten_history_dim.append(
-      cfg.flatten_history_dim
-    )
-    observation_term_history_length.append(
-      cfg.history_length
-    )
+    observation_term_flatten_history_dim.append(cfg.flatten_history_dim)
+    observation_term_history_length.append(cfg.history_length)
 
   if (
     len(observation_term_flatten_history_dim) != len(observation_term_history_length)

--- a/src/mjlab/rl/exporter_utils.py
+++ b/src/mjlab/rl/exporter_utils.py
@@ -48,33 +48,35 @@ def get_base_metadata(
   ]
   joint_stiffness = env.sim.mj_model.actuator_gainprm[ctrl_ids_natural, 0]
   joint_damping = -env.sim.mj_model.actuator_biasprm[ctrl_ids_natural, 2]
-  observation_term_scale = list()
-  observation_term_flatten_history_dim = list()
-  observation_term_history_length = list()
-  observation_term_clip = list()
+  observation_term_scale: list = []
+  observation_term_flatten_history_dim: list = []
+  observation_term_history_length: list = []
+  observation_term_clip: list = []
   observation_names = env.observation_manager.active_terms["actor"]
 
   for active_term in observation_names:
-    if env.observation_manager.get_term_cfg("actor", active_term).scale is None:
+    cfg = env.observation_manager.get_term_cfg("actor", active_term)
+
+    if cfg.scale is None:
       observation_term_scale.append(1.0)
     else:
-      raw_scale = env.observation_manager.get_term_cfg("actor", active_term).scale
+      raw_scale = cfg.scale
       scale = (
         raw_scale.cpu().tolist() if isinstance(raw_scale, torch.Tensor) else raw_scale
       )
       observation_term_scale.append(scale)
 
-    raw_clip = env.observation_manager.get_term_cfg("actor", active_term).clip
+    raw_clip = cfg.clip
     if raw_clip is None:
       observation_term_clip.append([float("-inf"), float("inf")])
     else:
       observation_term_clip.append(list(raw_clip))
 
     observation_term_flatten_history_dim.append(
-      env.observation_manager.get_term_cfg("actor", active_term).flatten_history_dim
+      cfg.flatten_history_dim
     )
     observation_term_history_length.append(
-      env.observation_manager.get_term_cfg("actor", active_term).history_length
+      cfg.history_length
     )
 
   if (
@@ -97,7 +99,7 @@ def get_base_metadata(
     "observation_terms_scale": observation_term_scale,
     "observation_terms_flatten_history_dim": observation_term_flatten_history_dim,
     "observation_terms_history_length": observation_term_history_length,
-    "observation_term_clip": observation_term_clip,
+    "observation_terms_clip": observation_term_clip,
     "action_scale": joint_action._scale[0].cpu().tolist()
     if isinstance(joint_action._scale, torch.Tensor)
     else joint_action._scale,

--- a/src/mjlab/rl/exporter_utils.py
+++ b/src/mjlab/rl/exporter_utils.py
@@ -51,6 +51,7 @@ def get_base_metadata(
   observation_term_scale = list()
   observation_term_flatten_history_dim = list()
   observation_term_history_length = list()
+  observation_term_clip = list()
   observation_names = env.observation_manager.active_terms["actor"]
 
   for active_term in observation_names:
@@ -62,6 +63,13 @@ def get_base_metadata(
         raw_scale.cpu().tolist() if isinstance(raw_scale, torch.Tensor) else raw_scale
       )
       observation_term_scale.append(scale)
+
+    raw_clip = env.observation_manager.get_term_cfg("actor", active_term).clip
+    if raw_clip is None:
+      observation_term_clip.append([float("-inf"), float("inf")])
+    else:
+      observation_term_clip.append(list(raw_clip))
+
     observation_term_flatten_history_dim.append(
       env.observation_manager.get_term_cfg("actor", active_term).flatten_history_dim
     )
@@ -89,6 +97,7 @@ def get_base_metadata(
     "observation_terms_scale": observation_term_scale,
     "observation_terms_flatten_history_dim": observation_term_flatten_history_dim,
     "observation_terms_history_length": observation_term_history_length,
+    "observation_term_clip": observation_term_clip,
     "action_scale": joint_action._scale[0].cpu().tolist()
     if isinstance(joint_action._scale, torch.Tensor)
     else joint_action._scale,

--- a/src/mjlab/rl/exporter_utils.py
+++ b/src/mjlab/rl/exporter_utils.py
@@ -8,15 +8,27 @@ from mjlab.envs import ManagerBasedRlEnv
 from mjlab.envs.mdp.actions import JointPositionAction
 
 
-def list_to_csv_str(arr, *, decimals: int = 3, delimiter: str = ",") -> str:
-  """Convert list to CSV string with specified decimal precision."""
+def list_to_csv_str(
+  arr, *, decimals: int = 3, delimiter: str = ",", sub_delimiter: str = ";"
+) -> str:
+  """Convert list to CSV string with specified decimal precision.
+
+  Elements that are themselves sequences (e.g. a per-dimension scale or a
+  [min, max] clip range) are joined with `sub_delimiter` instead of being
+  `str()`-formatted, which would otherwise embed a second, ambiguous set of
+  commas inside the top-level comma-delimited string.
+  """
   fmt = f"{{:.{decimals}f}}"
-  return delimiter.join(
-    fmt.format(x)
-    if isinstance(x, (int, float))
-    else str(x)  # numbers → format, strings → as-is
-    for x in arr
-  )
+
+  def format_scalar(x) -> str:
+    return fmt.format(x) if isinstance(x, (int, float)) else str(x)
+
+  def format_entry(x) -> str:
+    if isinstance(x, (list, tuple)):
+      return sub_delimiter.join(format_scalar(v) for v in x)
+    return format_scalar(x)
+
+  return delimiter.join(format_entry(x) for x in arr)
 
 
 def get_base_metadata(
@@ -74,15 +86,6 @@ def get_base_metadata(
 
     observation_term_flatten_history_dim.append(cfg.flatten_history_dim)
     observation_term_history_length.append(cfg.history_length)
-
-  if (
-    len(observation_term_flatten_history_dim) != len(observation_term_history_length)
-    or len(observation_term_scale) != len(observation_term_history_length)
-    or len(observation_term_scale) != len(observation_names)
-  ):
-    raise ValueError(
-      "Length of observation term metadata lists must match number of active observation terms."
-    )
 
   return {
     "run_path": run_path,

--- a/src/mjlab/rl/exporter_utils.py
+++ b/src/mjlab/rl/exporter_utils.py
@@ -48,6 +48,36 @@ def get_base_metadata(
   ]
   joint_stiffness = env.sim.mj_model.actuator_gainprm[ctrl_ids_natural, 0]
   joint_damping = -env.sim.mj_model.actuator_biasprm[ctrl_ids_natural, 2]
+  observation_term_scale = list()
+  observation_term_flatten_history_dim = list()
+  observation_term_history_length = list()
+  observation_names = env.observation_manager.active_terms["actor"]
+
+  for active_term in observation_names:
+    if env.observation_manager.get_term_cfg("actor", active_term).scale is None:
+      observation_term_scale.append(1.0)
+    else:
+      raw_scale = env.observation_manager.get_term_cfg("actor", active_term).scale
+      scale = (
+        raw_scale.cpu().tolist() if isinstance(raw_scale, torch.Tensor) else raw_scale
+      )
+      observation_term_scale.append(scale)
+    observation_term_flatten_history_dim.append(
+      env.observation_manager.get_term_cfg("actor", active_term).flatten_history_dim
+    )
+    observation_term_history_length.append(
+      env.observation_manager.get_term_cfg("actor", active_term).history_length
+    )
+
+  if (
+    len(observation_term_flatten_history_dim) != len(observation_term_history_length)
+    or len(observation_term_scale) != len(observation_term_history_length)
+    or len(observation_term_scale) != len(observation_names)
+  ):
+    raise ValueError(
+      "Length of observation term metadata lists must match number of active observation terms."
+    )
+
   return {
     "run_path": run_path,
     "joint_names": list(robot.joint_names),
@@ -55,7 +85,10 @@ def get_base_metadata(
     "joint_damping": joint_damping.tolist(),
     "default_joint_pos": robot.data.default_joint_pos[0].cpu().tolist(),
     "command_names": list(env.command_manager.active_terms),
-    "observation_names": env.observation_manager.active_terms["actor"],
+    "observation_names": observation_names,
+    "observation_terms_scale": observation_term_scale,
+    "observation_terms_flatten_history_dim": observation_term_flatten_history_dim,
+    "observation_terms_history_length": observation_term_history_length,
     "action_scale": joint_action._scale[0].cpu().tolist()
     if isinstance(joint_action._scale, torch.Tensor)
     else joint_action._scale,

--- a/tests/test_rl_exporter.py
+++ b/tests/test_rl_exporter.py
@@ -145,7 +145,9 @@ def test_get_base_metadata_skips_non_actuated_joints(device):
       "actor": ObservationGroupCfg(
         terms={
           "joint_pos": ObservationTermCfg(
-            func=lambda env: env.scene["robot"].data.joint_pos
+            func=lambda env: env.scene["robot"].data.joint_pos,
+            history_length=5,
+            scale=2.0,
           ),
         },
       ),
@@ -179,5 +181,25 @@ def test_get_base_metadata_skips_non_actuated_joints(device):
   assert isinstance(damping_meta, list)
   assert len(stiffness_meta) == len(robot.spec.actuators)
   assert len(damping_meta) == len(robot.spec.actuators)
+
+  observation_names = metadata["observation_names"]
+  assert isinstance(observation_names, list)
+  assert "joint_pos" in observation_names
+
+  observation_terms_scale = metadata["observation_terms_scale"]
+  assert isinstance(observation_terms_scale, list)
+  assert len(observation_terms_scale) == len(observation_names)
+  assert observation_terms_scale[0] == 2.0
+
+  observation_history_length = metadata["observation_terms_history_length"]
+  assert isinstance(observation_history_length, list)
+  assert len(observation_history_length) == len(observation_names)
+  assert observation_history_length[0] == 5
+
+  observation_flatten_history_dim = metadata["observation_terms_flatten_history_dim"]
+  assert isinstance(observation_flatten_history_dim, list)
+  assert len(observation_flatten_history_dim) == len(observation_names)
+  # Default flatten_history_dim is 1.0 (True)
+  assert observation_flatten_history_dim[0] == 1.0
 
   env.close()

--- a/tests/test_rl_exporter.py
+++ b/tests/test_rl_exporter.py
@@ -6,6 +6,7 @@ import tempfile
 import mujoco
 import onnx
 import pytest
+import torch
 from conftest import get_test_device
 
 from mjlab.actuator import XmlActuatorCfg
@@ -207,5 +208,89 @@ def test_get_base_metadata_skips_non_actuated_joints(device):
   assert len(observation_terms_clip) == len(observation_names)
   # Default clip is [-inf, inf]
   assert observation_terms_clip[0] == [float("-inf"), float("inf")]
+
+  env.close()
+
+
+def test_get_base_metadata_multiple_terms_scale_clip(device):
+  """get_base_metadata preserves obs term ordering and handles scalar/vector tensor scale, tuple scale, and non-default clip."""
+  robot_cfg = EntityCfg(
+    spec_fn=lambda: mujoco.MjSpec.from_string(ROBOT_XML_UNDERACTUATED),
+    articulation=EntityArticulationInfoCfg(
+      actuators=(XmlActuatorCfg(target_names_expr=(".*",)),)
+    ),
+  )
+
+  env_cfg = ManagerBasedRlEnvCfg(
+    scene=SceneCfg(
+      terrain=TerrainEntityCfg(terrain_type="plane"),
+      num_envs=1,
+      extent=1.0,
+      entities={"robot": robot_cfg},
+    ),
+    observations={
+      "actor": ObservationGroupCfg(
+        terms={
+          "joint_pos": ObservationTermCfg(
+            func=lambda env: env.scene["robot"].data.joint_pos,
+            scale=torch.tensor(
+              2.0
+            ),  # tensor scale -> should be converted via .tolist()
+            history_length=1,
+          ),
+          "joint_vel": ObservationTermCfg(
+            func=lambda env: env.scene["robot"].data.joint_vel,
+            scale=(0.5, 1.5),  # tuple scale -> stored as-is
+            clip=(-1.0, 1.0),  # non-default clip
+            history_length=1,
+          ),
+          "joint_pos_scaled": ObservationTermCfg(
+            func=lambda env: env.scene["robot"].data.joint_pos,
+            scale=torch.tensor([1.0, 2.0]),  # per-element tensor -> list of floats
+            history_length=1,
+          ),
+        },
+      ),
+    },
+    actions={
+      "joint_pos": mdp.JointPositionActionCfg(
+        entity_name="robot", actuator_names=(".*",), scale=1.0
+      )
+    },
+    sim=SimulationCfg(mujoco=MujocoCfg(timestep=0.01, iterations=1)),
+    decimation=1,
+    episode_length_s=1.0,
+  )
+
+  env = ManagerBasedRlEnv(cfg=env_cfg, device=device)
+  metadata = get_base_metadata(env, run_path="dummy/run")
+
+  observation_names = metadata["observation_names"]
+  scales = metadata["observation_terms_scale"]
+  clips = metadata["observation_terms_clip"]
+  assert isinstance(observation_names, list)
+  assert isinstance(scales, list)
+  assert isinstance(clips, list)
+
+  # Terms appear in definition order.
+  assert observation_names == ["joint_pos", "joint_vel", "joint_pos_scaled"]
+
+  # Scalar tensor scale is unwrapped to a plain float.
+  assert scales[0] == 2.0
+
+  # Tuple scale is stored as list.
+  assert scales[1] == [0.5, 1.5]
+
+  # Per-element tensor scale is converted to a list of floats.
+  assert scales[2] == [1.0, 2.0]
+
+  # joint_pos has default clip.
+  assert clips[0] == [float("-inf"), float("inf")]
+
+  # joint_vel has explicit clip converted to list.
+  assert clips[1] == [-1.0, 1.0]
+
+  # joint_pos_scaled has default clip.
+  assert clips[2] == [float("-inf"), float("inf")]
 
   env.close()

--- a/tests/test_rl_exporter.py
+++ b/tests/test_rl_exporter.py
@@ -202,4 +202,10 @@ def test_get_base_metadata_skips_non_actuated_joints(device):
   # Default flatten_history_dim is 1.0 (True)
   assert observation_flatten_history_dim[0] == 1.0
 
+  observation_term_clip = metadata["observation_term_clip"]
+  assert isinstance(observation_term_clip, list)
+  assert len(observation_term_clip) == len(observation_names)
+  # Default clip is [-inf, inf]
+  assert observation_term_clip[0] == [float("-inf"), float("inf")]
+
   env.close()

--- a/tests/test_rl_exporter.py
+++ b/tests/test_rl_exporter.py
@@ -200,12 +200,12 @@ def test_get_base_metadata_skips_non_actuated_joints(device):
   assert isinstance(observation_flatten_history_dim, list)
   assert len(observation_flatten_history_dim) == len(observation_names)
   # Default flatten_history_dim is 1.0 (True)
-  assert observation_flatten_history_dim[0] == 1.0
+  assert observation_flatten_history_dim[0] is True
 
-  observation_term_clip = metadata["observation_term_clip"]
-  assert isinstance(observation_term_clip, list)
-  assert len(observation_term_clip) == len(observation_names)
+  observation_terms_clip = metadata["observation_terms_clip"]
+  assert isinstance(observation_terms_clip, list)
+  assert len(observation_terms_clip) == len(observation_names)
   # Default clip is [-inf, inf]
-  assert observation_term_clip[0] == [float("-inf"), float("inf")]
+  assert observation_terms_clip[0] == [float("-inf"), float("inf")]
 
   env.close()

--- a/tests/test_rl_exporter.py
+++ b/tests/test_rl_exporter.py
@@ -41,6 +41,15 @@ def test_list_to_csv_str():
   result = list_to_csv_str([1.0, 2.0, 3.0], decimals=1, delimiter=";")
   assert result == "1.0;2.0;3.0"
 
+  # Test nested sequence entries (e.g. per-term clip ranges or vector scales):
+  # each entry is joined with the sub-delimiter so the outer delimiter stays
+  # unambiguous and round-trips via a plain split.
+  result = list_to_csv_str([[1.0, 2.0], 3.0, [4.0, 5.0]], decimals=1)
+  assert result == "1.0;2.0,3.0,4.0;5.0"
+  entries = result.split(",")
+  assert entries == ["1.0;2.0", "3.0", "4.0;5.0"]
+  assert entries[0].split(";") == ["1.0", "2.0"]
+
 
 def test_attach_metadata_to_onnx():
   """Test that metadata can be attached to ONNX models."""
@@ -95,6 +104,47 @@ def test_attach_metadata_to_onnx():
     # Check stiffness values are in natural joint order.
     stiffness_values = [float(x) for x in metadata_props["joint_stiffness"].split(",")]
     assert stiffness_values == [20.0, 10.0]  # Natural order: joint_a (20), joint_b (10)
+
+
+def test_attach_metadata_to_onnx_nested_clip_and_scale():
+  """Per-term clip ranges and vector scales must round-trip through a plain
+  comma split without corrupting neighboring entries."""
+  with tempfile.TemporaryDirectory() as tmpdir:
+    onnx_path = os.path.join(tmpdir, "test_policy.onnx")
+
+    input_tensor = onnx.helper.make_tensor_value_info(
+      "input", onnx.TensorProto.FLOAT, [1, 2]
+    )
+    output_tensor = onnx.helper.make_tensor_value_info(
+      "output", onnx.TensorProto.FLOAT, [1, 2]
+    )
+    node = onnx.helper.make_node("Identity", ["input"], ["output"])
+    graph = onnx.helper.make_graph(
+      [node], "test_graph", [input_tensor], [output_tensor]
+    )
+    model = onnx.helper.make_model(graph)
+    onnx.save(model, onnx_path)
+
+    metadata = {
+      "observation_terms_clip": [
+        [float("-inf"), float("inf")],
+        [-1.0, 1.0],
+        [float("-inf"), float("inf")],
+      ],
+      "observation_terms_scale": [1.0, [0.5, 1.2, 0.3], 2.0],
+    }
+    attach_metadata_to_onnx(onnx_path, metadata)
+
+    loaded_model = onnx.load(onnx_path)
+    metadata_props = {prop.key: prop.value for prop in loaded_model.metadata_props}
+
+    clip_entries = metadata_props["observation_terms_clip"].split(",")
+    assert clip_entries == ["-inf;inf", "-1.000;1.000", "-inf;inf"]
+    assert [float(x) for x in clip_entries[1].split(";")] == [-1.0, 1.0]
+
+    scale_entries = metadata_props["observation_terms_scale"].split(",")
+    assert scale_entries == ["1.000", "0.500;1.200;0.300", "2.000"]
+    assert [float(x) for x in scale_entries[1].split(";")] == [0.5, 1.2, 0.3]
 
 
 # Robot with 2 joints but only 1 actuator (underactuated).


### PR DESCRIPTION
This PR extends the information exported via ONNX metadata

We are using this metadata in our deployment pipeline; we need this info to automatically load the appropriate parameters


```
mjlab/logs/rsl_rl/g1_velocity/2026-04-13_15-49-03_mjlab_1204_g1_lin_vel_obs_hist/2026-04-13_15-49-03_mjlab_1204_g1_lin_vel_obs_hist.onnx 
{'observation_term_clip': '[-inf, inf],[-inf, inf],[-inf, inf],[-inf, inf],[-inf, inf],[-inf, inf],[-inf, inf]', 'action_scale': '0.548,0.351,0.548,0.351,0.439,0.439,0.548,0.351,0.548,0.351,0.439,0.439,0.548,0.439,0.439,0.439,0.439,0.439,0.439,0.439,0.075,0.075,0.439,0.439,0.439,0.439,0.439,0.075,0.075', 'observation_terms_history_length': '5.000,5.000,5.000,5.000,5.000,5.000,5.000', 'observation_terms_scale': '1.000,1.000,1.000,1.000,1.000,1.000,1.000', 'observation_terms_flatten_history_dim': '1.000,1.000,1.000,1.000,1.000,1.000,1.000', 'command_names': 'twist', 'joint_damping': '2.558,6.309,2.558,6.309,1.814,1.814,2.558,6.309,2.558,6.309,1.814,1.814,2.558,1.814,1.814,0.907,0.907,0.907,0.907,0.907,1.068,1.068,0.907,0.907,0.907,0.907,0.907,1.068,1.068', 'observation_names': 'base_lin_vel,base_ang_vel,projected_gravity,joint_pos,joint_vel,actions,command', 'joint_stiffness': '40.179,99.098,40.179,99.098,28.501,28.501,40.179,99.098,40.179,99.098,28.501,28.501,40.179,28.501,28.501,14.251,14.251,14.251,14.251,14.251,16.778,16.778,14.251,14.251,14.251,14.251,14.251,16.778,16.778', 'default_joint_pos': '-0.312,0.000,0.000,0.669,-0.363,0.000,-0.312,0.000,0.000,0.669,-0.363,0.000,0.000,0.000,0.000,0.200,0.200,0.000,0.600,0.000,0.000,0.000,0.200,-0.200,0.000,0.600,0.000,0.000,0.000', 'joint_names': 'left_hip_pitch_joint,left_hip_roll_joint,left_hip_yaw_joint,left_knee_joint,left_ankle_pitch_joint,left_ankle_roll_joint,right_hip_pitch_joint,right_hip_roll_joint,right_hip_yaw_joint,right_knee_joint,right_ankle_pitch_joint,right_ankle_roll_joint,waist_yaw_joint,waist_roll_joint,waist_pitch_joint,left_shoulder_pitch_joint,left_shoulder_roll_joint,left_shoulder_yaw_joint,left_elbow_joint,left_wrist_roll_joint,left_wrist_pitch_joint,left_wrist_yaw_joint,right_shoulder_pitch_joint,right_shoulder_roll_joint,right_shoulder_yaw_joint,right_elbow_joint,right_wrist_roll_joint,right_wrist_pitch_joint,right_wrist_yaw_joint', 'run_path': 'local'}
```