### PR TITLE
Add top-level --help for train/play, rename list_envs to list-envs

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -83,6 +83,9 @@ Added
 Changed
 ^^^^^^^
 
+- Renamed the ``list_envs`` console script to ``list-envs`` for consistency
+  with the other hyphenated entry points (``viz-nan``, ``export-scene``).
+  Invoke via ``uv run list-envs``.
 - ``ActuatorCfg.armature`` and ``ActuatorCfg.frictionloss`` now default to
   ``None`` instead of ``0.0``. ``None`` preserves the value defined in the
   XML. Previously, builtin actuators would silently overwrite XML joint and
@@ -128,6 +131,9 @@ Changed
 Fixed
 ^^^^^
 
+- ``train`` and ``play`` now print a top-level usage message when invoked
+  with ``-h`` / ``--help`` and no task argument, pointing users at
+  ``list-envs`` and ``<TASK> --help`` (:issue:`905`).
 - Fixed ghost geom filtering in the Viser viewer. Ghost geoms were selected
   by collision flags, so collision-disabled robot geoms appeared as ghosts.
   The viewer now uses visual alpha to determine which geoms to render.

--- a/docs/source/training/cloud.rst
+++ b/docs/source/training/cloud.rst
@@ -145,8 +145,8 @@ To see all registered tasks:
 
 .. code-block:: bash
 
-   uv run list_envs
-   uv run list_envs --keyword Velocity  # filter by keyword
+   uv run list-envs
+   uv run list-envs --keyword Velocity  # filter by keyword
 
 
 Hyperparameter sweeps

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ dependencies = [
 train = "mjlab.scripts.train:main"
 play = "mjlab.scripts.play:main"
 demo = "mjlab.scripts.demo:main"
-list_envs = "mjlab.scripts.list_envs:main"
+list-envs = "mjlab.scripts.list_envs:main"
 viz-nan = "mjlab.scripts.nan_viz:main"
 export-scene = "mjlab.scripts.export_scene:main"
 

--- a/src/mjlab/scripts/_cli.py
+++ b/src/mjlab/scripts/_cli.py
@@ -1,0 +1,18 @@
+"""Shared helpers for CLI entrypoints."""
+
+import sys
+
+
+def maybe_print_top_level_help(prog: str) -> None:
+  """Print a top-level usage message and exit if argv is bare -h/--help.
+
+  The ``train`` and ``play`` entrypoints use a two-stage tyro parse with
+  ``add_help=False`` on the first stage, so ``prog --help`` otherwise
+  produces no output. This handles that case explicitly.
+  """
+  if len(sys.argv) >= 2 and sys.argv[1] in ("-h", "--help"):
+    print(f"usage: {prog} <TASK> [OPTIONS]")
+    print()
+    print(f"Run '{prog} <TASK> --help' for task-specific options.")
+    print("Run 'uv run list-envs' to list available tasks.")
+    sys.exit(0)

--- a/src/mjlab/scripts/play.py
+++ b/src/mjlab/scripts/play.py
@@ -13,6 +13,7 @@ import tyro
 
 from mjlab.envs import ManagerBasedRlEnv
 from mjlab.rl import MjlabOnPolicyRunner, RslRlVecEnvWrapper
+from mjlab.scripts._cli import maybe_print_top_level_help
 from mjlab.tasks.registry import list_tasks, load_env_cfg, load_rl_cfg, load_runner_cls
 from mjlab.tasks.tracking.mdp import MotionCommandCfg
 from mjlab.utils.os import get_wandb_checkpoint_path
@@ -295,6 +296,8 @@ def run_play(task_id: str, cfg: PlayConfig):
 
 
 def main():
+  maybe_print_top_level_help("play")
+
   # Parse first argument to choose the task.
   # Import tasks to populate the registry.
   import mjlab.tasks  # noqa: F401

--- a/src/mjlab/scripts/train.py
+++ b/src/mjlab/scripts/train.py
@@ -12,6 +12,7 @@ import tyro
 
 from mjlab.envs import ManagerBasedRlEnv, ManagerBasedRlEnvCfg
 from mjlab.rl import MjlabOnPolicyRunner, RslRlBaseRunnerCfg, RslRlVecEnvWrapper
+from mjlab.scripts._cli import maybe_print_top_level_help
 from mjlab.tasks.registry import list_tasks, load_env_cfg, load_rl_cfg, load_runner_cls
 from mjlab.tasks.tracking.mdp import MotionCommandCfg
 from mjlab.utils.gpu import select_gpus
@@ -227,6 +228,8 @@ def launch_training(task_id: str, args: TrainConfig | None = None):
 
 
 def main():
+  maybe_print_top_level_help("train")
+
   # Parse first argument to choose the task.
   # Import tasks to populate the registry.
   import mjlab.tasks  # noqa: F401


### PR DESCRIPTION
The `train` and `play` entrypoints use a two-stage tyro parse with `add_help=False` on the first stage so that task-scoped help works after a task is chosen. The side effect is that `uv run train --help` and `uv run play --help` previously printed nothing useful, leaving new users with no way to discover that a task argument is required or where to find one.

This adds a tiny shared helper in `src/mjlab/scripts/_cli.py` that intercepts bare `-h`/`--help` before the first-stage parse and prints a short usage message pointing at `list-envs` and `<TASK> --help`. The check is deliberately narrow (`sys.argv[1] in {-h, --help}`) so `train <TASK> --help` still falls through to the existing task-scoped help unchanged.

While here, renames the `list_envs` console script to `list-envs` for consistency with the other hyphenated entry points (`viz-nan`, `export-scene`). The underscore form was the odd one out. Docs and the new help message both reference the hyphenated name.

Fixes #905