### PR TITLE
Prepare v1.3.0 release

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -33,9 +33,9 @@ keywords:
   - reinforcement-learning
   - robotics
 license: Apache-2.0
-commit: 3919ff442c51b9a26b18be0ea3242235b812fac5
-version: 1.2.0
-date-released: '2026-03-06'
+commit: b256792d3286c687e19ab0fba897bda16d83abe3
+version: 1.3.0
+date-released: '2026-04-14'
 preferred-citation:
   type: article
   title: >-

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -2,8 +2,8 @@
 Changelog
 =========
 
-Upcoming version (not yet released)
------------------------------------
+Version 1.3.0 (April 14, 2026)
+------------------------------
 
 Added
 ^^^^^
@@ -41,7 +41,9 @@ Added
   ``current_pos + action * scale``, so a zero action holds the current
   configuration rather than commanding the default pose.
 - Added :func:`~mjlab.envs.mdp.dr.pair_friction` for randomizing geom-pair
-  friction overrides (``pair_friction`` in ``mjModel``).
+  friction overrides (``pair_friction`` in ``mjModel``), with an
+  ``isotropic=True`` option that mirrors the symmetric tangent and roll
+  axes so single-axis randomization does not leave the paired axis stale.
 - Added ``STAIRS_TERRAINS_CFG`` terrain preset for progressive stair
   curriculum training and ``@terrain_preset`` decorator for composing
   terrain configurations from reusable presets.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "mjlab"
-version = "1.2.0"
+version = "1.3.0"
 license = "Apache-2.0"
 license-files = ["LICENSE"]
 readme = { file = "README.md", content-type = "text/markdown" }
@@ -37,8 +37,8 @@ dependencies = [
   "torch>=2.7.0",
   "torchrunx>=0.3.4",
   "warp-lang>=1.12.0",
-  "mujoco-warp>=3.6.0",
-  "mujoco>=3.6.0",
+  "mujoco-warp>=3.7.0.1",
+  "mujoco>=3.7.0",
   "trimesh>=4.8.3",
   "viser>=1.0.26",
   "mjviser>=0.0.11",
@@ -98,9 +98,9 @@ conflicts = [
   [{extra = "cu128"}, {extra = "cpu"}],
 ]
 # The nightly index (py.mujoco.org) only has dev builds, and PEP 440 ranks
-# 3.6.0.devN < 3.6.0, so the >=3.6.0 floor in [project.dependencies] would
+# 3.7.0.devN < 3.7.0, so the >=3.7.0 floor in [project.dependencies] would
 # reject them. This override loosens the constraint for uv resolution only.
-override-dependencies = ["mujoco>=3.6.0.dev0"]
+override-dependencies = ["mujoco>=3.7.0.dev0"]
 required-environments = [
   "sys_platform == 'darwin' and platform_machine == 'arm64'",
   "sys_platform == 'linux' and platform_machine == 'x86_64'",
@@ -136,7 +136,7 @@ torch = [
   { index = "pytorch-cpu", extra = "cpu", marker = "sys_platform != 'darwin'" },
 ]
 mujoco = { index = "mujoco" }
-mujoco-warp = { git = "https://github.com/google-deepmind/mujoco_warp", rev = "36fc8bef0f12bf8ade95a106b03f00dd1a8a82e9" }
+mujoco-warp = { git = "https://github.com/google-deepmind/mujoco_warp", rev = "ea7f05b" }
 
 [tool.ruff]
 src = ["src"]  # Helpful for recognizing first-party imports.

--- a/uv.lock
+++ b/uv.lock
@@ -41,7 +41,7 @@ conflicts = [[
 ]]
 
 [manifest]
-overrides = [{ name = "mujoco", specifier = ">=3.6.0.dev0", index = "https://py.mujoco.org/" }]
+overrides = [{ name = "mujoco", specifier = ">=3.7.0.dev0", index = "https://py.mujoco.org/" }]
 
 [[package]]
 name = "absl-py"
@@ -1649,7 +1649,7 @@ wheels = [
 
 [[package]]
 name = "mjlab"
-version = "1.2.0"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "imageio-ffmpeg" },
@@ -1718,8 +1718,8 @@ requires-dist = [
     { name = "imageio-ffmpeg" },
     { name = "mediapy", specifier = ">=1.2.6" },
     { name = "mjviser", specifier = ">=0.0.11" },
-    { name = "mujoco", specifier = ">=3.6.0", index = "https://py.mujoco.org/" },
-    { name = "mujoco-warp", git = "https://github.com/google-deepmind/mujoco_warp?rev=36fc8bef0f12bf8ade95a106b03f00dd1a8a82e9" },
+    { name = "mujoco", specifier = ">=3.7.0", index = "https://py.mujoco.org/" },
+    { name = "mujoco-warp", git = "https://github.com/google-deepmind/mujoco_warp?rev=ea7f05b" },
     { name = "onnxscript", specifier = ">=0.5.4" },
     { name = "prettytable" },
     { name = "rsl-rl-lib", specifier = "==5.0.1" },
@@ -1964,8 +1964,8 @@ wheels = [
 
 [[package]]
 name = "mujoco-warp"
-version = "3.6.0"
-source = { git = "https://github.com/google-deepmind/mujoco_warp?rev=36fc8bef0f12bf8ade95a106b03f00dd1a8a82e9#36fc8bef0f12bf8ade95a106b03f00dd1a8a82e9" }
+version = "3.7.0.1"
+source = { git = "https://github.com/google-deepmind/mujoco_warp?rev=ea7f05b#ea7f05baa3e5ea375ed2eeb041fd90eb9b7d6932" }
 dependencies = [
     { name = "absl-py" },
     { name = "etils", extra = ["epath"] },


### PR DESCRIPTION
Bumps mjlab to 1.3.0, raises the mujoco-warp floor to 3.7.0.1 and the mujoco floor to 3.7.0, pins mujoco-warp to ea7f05b (v3.7.0.1 tag), renames the Upcoming section in the changelog to Version 1.3.0 (April 14, 2026), and updates CITATION.cff.

After merge I'll tag v1.3.0 on the merge commit to trigger the publish workflow.