### PR TITLE
Fix CITATION.cff commit hash for v1.3.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -33,7 +33,7 @@ keywords:
   - reinforcement-learning
   - robotics
 license: Apache-2.0
-commit: b256792d3286c687e19ab0fba897bda16d83abe3
+commit: e2f33c6fb49caa26ec11f7b2de3c0c9aba71e9fd
 version: 1.3.0
 date-released: '2026-04-14'
 preferred-citation:


### PR DESCRIPTION
PR #907 was squash-merged, so the SHA that CITATION.cff references (b256792d, the pre-squash release-prep commit) no longer exists on main. Update the hash to point at the squashed release commit e2f33c6f so the citation metadata resolves to a commit that actually exists before tagging v1.3.0.