### PR TITLE
Print traceback on task load exceptions

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -2,6 +2,18 @@
 Changelog
 =========
 
+Upcoming version (not yet released)
+-----------------------------------
+
+Changed
+^^^^^^^
+
+- Task package load failures during ``mjlab`` import now print the full
+  traceback (and the entry point's module path) to ``stderr`` instead of
+  just the exception message, making it easier to pinpoint the source of
+  import errors when running commands like ``list-envs`` (:issue:`910`).
+  Contribution by @saikishor.
+
 Version 1.3.0 (April 14, 2026)
 ------------------------------
 

--- a/src/mjlab/__init__.py
+++ b/src/mjlab/__init__.py
@@ -1,4 +1,5 @@
 import os
+import traceback
 from importlib.metadata import entry_points
 from pathlib import Path
 
@@ -42,8 +43,11 @@ def _import_registered_packages() -> None:
   for entry_point in mjlab_tasks:
     try:
       entry_point.load()
-    except Exception as e:
-      print(f"[WARN] Failed to load task package {entry_point.name}: {e}")
+    except Exception:
+      print(
+        f"[WARN] Failed to load task package '{entry_point.name}' ({entry_point.value}):"
+      )
+      traceback.print_exc()
 
 
 def _configure_mediapy() -> None:

--- a/src/mjlab/__init__.py
+++ b/src/mjlab/__init__.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import traceback
 from importlib.metadata import entry_points
 from pathlib import Path
@@ -45,9 +46,10 @@ def _import_registered_packages() -> None:
       entry_point.load()
     except Exception:
       print(
-        f"[WARN] Failed to load task package '{entry_point.name}' ({entry_point.value}):"
+        f"[WARN] Failed to load task package '{entry_point.name}' ({entry_point.value}):",
+        file=sys.stderr,
       )
-      traceback.print_exc()
+      traceback.print_exc(file=sys.stderr)
 
 
 def _configure_mediapy() -> None:


### PR DESCRIPTION
When I'm trying to migrate to the new release of the mjlab, I stumpled upon a case where there is an issue with asset_cfg, but it was hard to find among all the tasks we have. It would be nice to print the stacktrace, so it wouldbe easier to pinpoint the issue

**Right now:**
```

$ uv run list-envs
[WARN] Failed to load task package pal_mjlab: 'asset_cfg'
+-----------------------------------------------------------+
|              Available Environments in mjlab              |
+----+------------------------------------------------------+
| #  | Task ID                                              |
+----+------------------------------------------------------+
| 1  | Mjlab-Cartpole-Balance                               |
| 2  | Mjlab-Cartpole-Swingup                               |
| 3  | Mjlab-Lift-Cube-Yam                                  |

```

**With the proposed change:**
```

$ uv run list-envs
[WARN] Failed to load task package 'pal_mjlab' (pal_mjlab.tasks):
Traceback (most recent call last):
  File "/home/saikishor/reinforcement_learning/locomotion/pal_mjlab/.venv/lib/python3.13/site-packages/mjlab/__init__.py", line 45, in _import_registered_packages
    entry_point.load()
    ~~~~~~~~~~~~~~~~^^
  File "/home/saikishor/.local/share/uv/python/cpython-3.13.11-linux-x86_64-gnu/lib/python3.13/importlib/metadata/__init__.py", line 179, in load
    module = import_module(match.group('module'))
  File "/home/saikishor/.local/share/uv/python/cpython-3.13.11-linux-x86_64-gnu/lib/python3.13/importlib/__init__.py", line 88, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 1023, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/home/saikishor/reinforcement_learning/locomotion/pal_mjlab/src/pal_mjlab/tasks/__init__.py", line 5, in <module>
    import_packages(__name__, _BLACKLIST_PKGS)
    ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/saikishor/reinforcement_learning/locomotion/pal_mjlab/.venv/lib/python3.13/site-packages/mjlab/utils/lab_api/tasks/importer.py", line 40, in import_packages
    for _ in _walk_packages(
             ~~~~~~~~~~~~~~^
      package.__path__, package.__name__ + ".", blacklist_pkgs=blacklist_pkgs
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ):
    ^
  File "/home/saikishor/reinforcement_learning/locomotion/pal_mjlab/.venv/lib/python3.13/site-packages/mjlab/utils/lab_api/tasks/importer.py", line 89, in _walk_packages
    yield from _walk_packages(path, info.name + ".", onerror, blacklist_pkgs)
  File "/home/saikishor/reinforcement_learning/locomotion/pal_mjlab/.venv/lib/python3.13/site-packages/mjlab/utils/lab_api/tasks/importer.py", line 77, in _walk_packages
    __import__(info.name)
    ~~~~~~~~~~^^^^^^^^^^^
  File "/home/saikishor/reinforcement_learning/locomotion/pal_mjlab/src/pal_mjlab/tasks/velocity/talos/__init__.py", line 9, in <module>
    env_cfg=pal_talos_rough_env_cfg(),
            ~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/home/saikishor/reinforcement_learning/locomotion/pal_mjlab/src/pal_mjlab/tasks/velocity/talos/env_cfgs.py", line 136, in pal_talos_rough_env_cfg
    cfg.rewards[reward_name].params["asset_cfg"].site_names = site_names
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
KeyError: 'asset_cfg'
+-----------------------------------------------------------+
|              Available Environments in mjlab              |
+----+------------------------------------------------------+
| #  | Task ID                                              |
+----+------------------------------------------------------+
| 1  | Mjlab-Cartpole-Balance                               |
| 2  | Mjlab-Cartpole-Swingup                               |
| 3  | Mjlab-Lift-Cube-Yam                                  |
| 4  | Mjlab-Lift-Cube-Yam-Depth                            |

```