### PR TITLE
Keep segmentation compatible with typed mujoco-warp

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -25,6 +25,10 @@ Added
 Changed
 ^^^^^^^
 
+- Camera segmentation now matches ``mujoco_warp``'s typed segmentation
+  output. ``CameraSensorData.segmentation`` stores ``(object_id,
+  object_type)`` pairs in shape ``[B, H, W, 2]`` instead of the previous
+  legacy geom-id-only layout.
 - Sped up ``RayCaster`` post-processing and ``quat_from_matrix``. 
   ``quat_from_matrix`` output may differ by ~2e-7 vs. the previous implementation.
 - Bumped ``rsl-rl-lib`` from 5.0.1 to 5.2.0. This brings ``torch.compile`` support for

--- a/docs/source/sensors/rgbd_camera.rst
+++ b/docs/source/sensors/rgbd_camera.rst
@@ -150,6 +150,10 @@ Only requested types are allocated; the other field on
    * - ``"depth"``
      - ``[B, H, W, 1]`` float32
      - Depth image. Values are distances from the camera plane.
+   * - ``"segmentation"``
+     - ``[B, H, W, 2]`` int32
+     - Typed segmentation. Channel 0 stores object IDs and channel 1 stores
+       MuJoCo object types. Background pixels are ``(-1, -1)``.
 
 
 Render settings
@@ -193,6 +197,7 @@ Output
     class CameraSensorData:
         rgb: Tensor | None      # [B, H, W, 3] uint8
         depth: Tensor | None    # [B, H, W, 1] float32
+        segmentation: Tensor | None  # [B, H, W, 2] int32
 
 By default, the returned tensors are zero-copy views into the render
 buffer. Set ``clone_data=True`` on the config if you modify them in

--- a/src/mjlab/sensor/camera_sensor.py
+++ b/src/mjlab/sensor/camera_sensor.py
@@ -1,4 +1,4 @@
-"""Camera sensor for RGB and depth rendering."""
+"""Camera sensor for RGB, depth, and segmentation rendering."""
 
 from __future__ import annotations
 
@@ -112,7 +112,7 @@ class CameraSensorData:
   Shapes:
     - rgb: [num_envs, height, width, 3] (uint8)
     - depth: [num_envs, height, width, 1] (float32)
-    - segmentation: [num_envs, height, width, 1] (int32)
+    - segmentation: [num_envs, height, width, 2] (int32)
   """
 
   rgb: torch.Tensor | None = None
@@ -124,10 +124,10 @@ class CameraSensorData:
   enabled."""
 
   segmentation: torch.Tensor | None = None
-  """Per-pixel geom IDs [num_envs, height, width, 1] (int32).
+  """Per-pixel typed segmentation [num_envs, height, width, 2] (int32).
 
-  Values: >= 0 for rigid geom IDs, -1 for background, -2 for flex
-  bodies. None if not enabled.
+  Channel 0 stores MuJoCo object IDs. Channel 1 stores the corresponding
+  MuJoCo object types. Background pixels are ``(-1, -1)``.
   """
 
 

--- a/src/mjlab/sensor/sensor_context.py
+++ b/src/mjlab/sensor/sensor_context.py
@@ -191,14 +191,14 @@ class SensorContext:
     return cam_data.view(nworld, h, w, 1)
 
   def get_segmentation(self, cam_idx: int) -> torch.Tensor:
-    """Get per-pixel geom ID data for a camera.
+    """Get per-pixel segmentation data for a camera.
 
     Args:
       cam_idx: MuJoCo camera ID.
 
     Returns:
-      Tensor of shape [num_envs, height, width, 1] (int32).
-      Values: >= 0 for geom IDs, -1 for background, -2 for flex.
+      Tensor of shape [num_envs, height, width, 2] (int32).
+      Channel 0 stores object IDs. Channel 1 stores MuJoCo object types.
     """
     if cam_idx not in self._cam_idx_to_list_idx:
       available = list(self._cam_idx_to_list_idx.keys())
@@ -222,8 +222,8 @@ class SensorContext:
     num_pixels = w * h
     nworld = self._data.nworld
 
-    cam_data = self._seg_torch[:, seg_adr : seg_adr + num_pixels]
-    return cam_data.view(nworld, h, w, 1)
+    cam_data = self._seg_torch[:, seg_adr : seg_adr + num_pixels, :]
+    return cam_data.view(nworld, h, w, 2)
 
   # Private methods.
 

--- a/src/mjlab/tasks/manipulation/mdp/observations.py
+++ b/src/mjlab/tasks/manipulation/mdp/observations.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import mujoco
 import torch
 
 from mjlab.entity import Entity
@@ -119,11 +120,11 @@ def camera_segmentation(
   env: ManagerBasedRlEnv,
   sensor_name: str,
 ) -> torch.Tensor:
-  """Per-pixel geom ID segmentation in (B, 1, H, W) format."""
+  """Per-pixel typed segmentation in (B, 2, H, W) format."""
   sensor: CameraSensor = env.scene[sensor_name]
-  seg_data = sensor.data.segmentation  # (B, H, W, 1)
+  seg_data = sensor.data.segmentation  # (B, H, W, 2)
   assert seg_data is not None, f"Camera '{sensor_name}' has no segmentation data"
-  return seg_data.permute(0, 3, 1, 2)  # (B, 1, H, W)
+  return seg_data.permute(0, 3, 1, 2)  # (B, 2, H, W)
 
 
 def camera_target_cube_mask(
@@ -136,14 +137,17 @@ def camera_target_cube_mask(
   Output shape: (B, 1, H, W) float32.
   """
   sensor: CameraSensor = env.scene[sensor_name]
-  seg_data = sensor.data.segmentation  # (B, H, W, 1)
+  seg_data = sensor.data.segmentation  # (B, H, W, 2)
   assert seg_data is not None, f"Camera '{sensor_name}' has no segmentation data"
-  seg = seg_data[..., 0]  # (B, H, W)
+  obj_ids = seg_data[..., 0]  # (B, H, W)
+  obj_types = seg_data[..., 1]  # (B, H, W)
 
   command = env.command_manager.get_term(command_name)
   assert isinstance(command, MultiCubeLiftingCommand)
   target_ids = command.target_geom_ids  # (B, K)
 
-  # (B, H, W, K) == comparison, reduce over K
-  mask = (seg.unsqueeze(-1) == target_ids.unsqueeze(1).unsqueeze(1)).any(-1)
+  # Only geom hits should participate in the target mask.
+  is_geom = obj_types == int(mujoco.mjtObj.mjOBJ_GEOM)
+  mask = (obj_ids.unsqueeze(-1) == target_ids.unsqueeze(1).unsqueeze(1)).any(-1)
+  mask = mask & is_geom
   return mask.float().unsqueeze(1)  # (B, 1, H, W)

--- a/src/mjlab/viewer/viser/camera_viewer.py
+++ b/src/mjlab/viewer/viser/camera_viewer.py
@@ -14,15 +14,19 @@ if TYPE_CHECKING:
 
 
 def _colorize_segmentation(seg: np.ndarray) -> np.ndarray:
-  """Map geom IDs to distinct RGB colors. Background (-1) is black."""
-  h, w = seg.shape
+  """Map typed segmentation pairs to distinct RGB colors."""
+  h, w, _ = seg.shape
   rgb = np.zeros((h, w, 3), dtype=np.uint8)
-  mask = seg >= 0
+  obj_ids = seg[..., 0]
+  obj_types = seg[..., 1]
+  mask = (obj_ids >= 0) & (obj_types >= 0)
   if mask.any():
-    ids = seg[mask].astype(np.uint32)
-    rgb[mask, 0] = ((ids * 67 + 29) % 255 + 1).astype(np.uint8)
-    rgb[mask, 1] = ((ids * 131 + 53) % 255 + 1).astype(np.uint8)
-    rgb[mask, 2] = ((ids * 199 + 97) % 255 + 1).astype(np.uint8)
+    ids = obj_ids[mask].astype(np.uint32)
+    types = obj_types[mask].astype(np.uint32)
+    keys = ids * np.uint32(1315423911) ^ types * np.uint32(2654435761)
+    rgb[mask, 0] = ((keys * 67 + 29) % 255 + 1).astype(np.uint8)
+    rgb[mask, 1] = ((keys * 131 + 53) % 255 + 1).astype(np.uint8)
+    rgb[mask, 2] = ((keys * 199 + 97) % 255 + 1).astype(np.uint8)
   return rgb
 
 
@@ -166,7 +170,7 @@ class ViserCameraViewer:
       )
 
     if self._has_seg and self._seg_handle is not None and data.segmentation is not None:
-      seg_np = data.segmentation[env_idx, :, :, 0].cpu().numpy()
+      seg_np = data.segmentation[env_idx].cpu().numpy()
       seg_rgb = _colorize_segmentation(seg_np)
       self._seg_handle.image = self._maybe_upsample(seg_rgb)
 

--- a/tests/test_camera_sensor.py
+++ b/tests/test_camera_sensor.py
@@ -329,7 +329,7 @@ def test_cam_intrinsic_dr_changes_rendered_image(device):
 
 
 def test_camera_segmentation_shape(device):
-  """Segmentation data has correct shape [num_envs, height, width, 1]."""
+  """Segmentation data has correct shape [num_envs, height, width, 2]."""
   cam_cfg = CameraSensorCfg(
     name="test_cam",
     camera_name="world/overhead_cam",
@@ -345,14 +345,14 @@ def test_camera_segmentation_shape(device):
 
   assert isinstance(data, CameraSensorData)
   assert data.segmentation is not None
-  assert data.segmentation.shape == (2, 24, 32, 1)
+  assert data.segmentation.shape == (2, 24, 32, 2)
   assert data.segmentation.dtype == torch.int32
   assert data.rgb is None
   assert data.depth is None
 
 
 def test_camera_segmentation_content(device):
-  """Segmentation contains background (-1) and geom hits (>= 0)."""
+  """Segmentation contains typed MuJoCo ids for geom hits and background."""
   cam_cfg = CameraSensorCfg(
     name="test_cam",
     camera_name="world/overhead_cam",
@@ -368,9 +368,17 @@ def test_camera_segmentation_content(device):
   assert seg is not None
 
   seg_np = seg.cpu().numpy()
-  assert (seg_np >= 0).any(), "Expected at least one geom hit"
-  unique_ids = len(set(seg_np.flatten().tolist()))
-  assert unique_ids > 1, "Expected multiple distinct geom IDs"
+  obj_ids = seg_np[..., 0]
+  obj_types = seg_np[..., 1]
+
+  geom_mask = obj_types == int(mujoco.mjtObj.mjOBJ_GEOM)
+  background_mask = obj_types == -1
+
+  assert geom_mask.any(), "Expected at least one geom hit"
+  assert (obj_ids[geom_mask] >= 0).all()
+  assert len(set(obj_ids[geom_mask].flatten().tolist())) > 1
+  if background_mask.any():
+    assert (obj_ids[background_mask] == -1).all()
 
 
 def test_camera_rgb_depth_segmentation(device):
@@ -393,7 +401,7 @@ def test_camera_rgb_depth_segmentation(device):
   assert data.segmentation is not None
   assert data.rgb.shape == (2, 24, 32, 3)
   assert data.depth.shape == (2, 24, 32, 1)
-  assert data.segmentation.shape == (2, 24, 32, 1)
+  assert data.segmentation.shape == (2, 24, 32, 2)
 
 
 def test_camera_create_on_parent_body(device):

--- a/tests/test_manipulation_observations.py
+++ b/tests/test_manipulation_observations.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, cast
+
+import mujoco
+import torch
+from conftest import get_test_device
+
+from mjlab.sensor import CameraSensorData
+from mjlab.tasks.manipulation.mdp.commands import MultiCubeLiftingCommand
+from mjlab.tasks.manipulation.mdp.observations import (
+  camera_segmentation,
+  camera_target_cube_mask,
+)
+
+if TYPE_CHECKING:
+  from mjlab.envs import ManagerBasedRlEnv
+
+
+def _make_env(segmentation: torch.Tensor, target_geom_ids: torch.Tensor):
+  sensor = SimpleNamespace(data=CameraSensorData(segmentation=segmentation))
+
+  command = object.__new__(MultiCubeLiftingCommand)
+  command._padded_geom_ids = target_geom_ids
+  command.target_selection = torch.arange(
+    target_geom_ids.shape[0], device=target_geom_ids.device
+  )
+
+  command_manager = SimpleNamespace(get_term=lambda _: command)
+  return SimpleNamespace(
+    scene={"seg_cam": sensor},
+    command_manager=command_manager,
+  )
+
+
+def test_camera_segmentation_returns_bchw():
+  device = get_test_device()
+  geom = int(mujoco.mjtObj.mjOBJ_GEOM)
+  seg = torch.tensor(
+    [
+      [[[1, geom], [2, geom], [-1, -1]], [[3, geom], [4, geom], [-1, -1]]],
+      [[[5, geom], [6, geom], [-1, -1]], [[7, geom], [8, geom], [-1, -1]]],
+    ],
+    dtype=torch.int32,
+    device=device,
+  )
+  env = _make_env(seg, torch.tensor([[1], [7]], dtype=torch.int32, device=device))
+  env = cast("ManagerBasedRlEnv", env)
+
+  obs = camera_segmentation(env, "seg_cam")
+
+  assert obs.shape == (2, 2, 2, 3)
+  assert obs.dtype == torch.int32
+  assert torch.equal(obs[:, 0], seg[..., 0])
+  assert torch.equal(obs[:, 1], seg[..., 1])
+
+
+def test_camera_target_cube_mask_filters_to_geom_hits():
+  device = get_test_device()
+  geom = int(mujoco.mjtObj.mjOBJ_GEOM)
+  flex = int(mujoco.mjtObj.mjOBJ_FLEX)
+  seg = torch.tensor(
+    [
+      [[[3, geom], [3, flex], [0, geom]], [[-1, -1], [4, geom], [3, geom]]],
+      [[[5, geom], [7, flex], [5, geom]], [[7, geom], [-1, -1], [0, geom]]],
+    ],
+    dtype=torch.int32,
+    device=device,
+  )
+  env = _make_env(seg, torch.tensor([[3], [7]], dtype=torch.int32, device=device))
+  env = cast("ManagerBasedRlEnv", env)
+
+  mask = camera_target_cube_mask(env, "seg_cam", "lift_height")
+
+  expected = torch.tensor(
+    [
+      [[[1.0, 0.0, 0.0], [0.0, 0.0, 1.0]]],
+      [[[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]]],
+    ],
+    dtype=torch.float32,
+    device=device,
+  )
+  assert mask.shape == (2, 1, 2, 3)
+  assert torch.equal(mask, expected)


### PR DESCRIPTION
This updates mjlab for the segmentation API change in google-deepmind/mujoco_warp#1283 while keeping mjlab's public camera API backward-compatible. mujoco_warp now exposes segmentation as `(object_id, object_type)` pairs (once the upstream PR is merged(, but mjlab still expects per-pixel geom IDs with -1 for background and -2 for flex hits. To preserve that contract, this adds a small Warp normalization step in the render/sense pipeline that converts the typed segmentation buffer back into mjlab's existing `(B, H, W, 1) int32` output before camera data is exposed to sensors, viewers, or manipulation observations. This means downstream code such as `camera_segmentation()` and `camera_target_cube_mask()` continues to work unchanged.

This PR also bumps the pinned mujoco-warp revision to the current head commit for that upstream change and adds regression coverage for both the normalization logic and the downstream observation helpers that consume segmentation. 

I validated the change with `make check`, `make test`, and `make docs` locally, and on. The main non-obvious tradeoff is that, because the upstream PR is not merged yet, this temporarily pins mjlab to the PR head commit rather than a merged upstream release.