### PR TITLE
Fix ContactSensor air-time crash with num_slots>1, clarify shapes

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -5,6 +5,14 @@ Changelog
 Upcoming version (not yet released)
 -----------------------------------
 
+Added
+^^^^^
+
+- Added ``ContactSensor.primary_names`` property to expose the resolved
+  primary names in the order they appear along the per-contact axis of the
+  output tensors. This makes it possible to map a contact-data column back
+  to the primary it belongs to (:issue:`914`).
+
 Changed
 ^^^^^^^
 
@@ -13,10 +21,20 @@ Changed
   just the exception message, making it easier to pinpoint the source of
   import errors when running commands like ``list-envs`` (:issue:`910`).
   Contribution by @saikishor.
+- Clarified ``ContactSensor`` shape conventions: per-contact fields
+  (``found``, ``force``, ``torque``, ``dist``, ``pos``, ``normal``,
+  ``tangent``) have shape ``[B, P * num_slots, ...]`` while per-primary
+  air-time fields (``current_air_time``, ``last_air_time``,
+  ``current_contact_time``, ``last_contact_time``) have shape ``[B, P]``,
+  where ``P`` is the number of resolved primaries (:issue:`914`).
 
 Fixed
 ^^^^^
 
+- Fixed a runtime broadcast error in ``ContactSensor`` when combining
+  ``num_slots > 1`` with ``track_air_time=True`` and more than one primary.
+  Air-time tracking now reduces ``found`` across slots so that a primary is
+  considered in contact when any of its slots reports a match (:issue:`914`).
 - Updated the ``create_new_task.ipynb`` Colab tutorial to import
   ``XmlActuatorCfg`` instead of the removed ``XmlVelocityActuatorCfg``.
   Added a regression test (``tests/test_notebooks.py``) that parses each

--- a/docs/source/sensors/index.rst
+++ b/docs/source/sensors/index.rst
@@ -48,8 +48,8 @@ independent of any entity entirely. This is why sensors live in
     # Access at runtime.
     imu = env.scene["robot/imu_acc"].data        # [B, 3] acceleration
     feet = env.scene["feet_contact"].data         # ContactData
-    feet.found                                    # [B, N] contact count
-    feet.force                                    # [B, N, 3] contact force
+    feet.found                                    # [B, P] contact count per foot
+    feet.force                                    # [B, P, 3] contact force per foot
 
 mjlab provides four sensor types: ``BuiltinSensor`` for native MuJoCo
 measurements, ``ContactSensor`` for structured contact detection,
@@ -187,12 +187,52 @@ names within the entity.
         fields=("found",),
     )
 
+Output shape
+^^^^^^^^^^^^
+
+A pattern like ``r".*_foot$"`` resolves to ``P`` primary elements (e.g.
+four feet on a quadruped). Each primary becomes one column on the
+per-contact axis of the output tensors:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 25 40
+
+   * - Field group
+     - Shape
+     - Notes
+   * - Per-contact
+       (``found``, ``force``, ``torque``, ``dist``, ``pos``, ``normal``,
+       ``tangent``)
+     - ``[B, P * num_slots, ...]``
+     - Primary-major: indices
+       ``[i * num_slots : (i + 1) * num_slots]`` belong to primary ``i``.
+   * - Per-primary
+       (``current_air_time``, ``last_air_time``,
+       ``current_contact_time``, ``last_contact_time``)
+     - ``[B, P]``
+     - Air-time fields are accumulated per primary, reducing across
+       slots (any slot in contact counts as the primary in contact).
+
+With the default ``num_slots=1`` the two shape families coincide
+(``N == P``), which is why most code can treat both as ``[B, P, ...]``.
+
+Use :attr:`mjlab.sensor.contact_sensor.ContactSensor.primary_names` to
+recover the index-to-name mapping after pattern expansion:
+
+.. code-block:: python
+
+    sensor = env.scene["feet_contact"]
+    sensor.primary_names                # ["FR_foot", "FL_foot", "RR_foot", "RL_foot"]
+    sensor.data.current_air_time[:, 0]  # air time for FR_foot
+
 Reduction
 ^^^^^^^^^
 
-A single foot geom can have many simultaneous contacts with the ground.
-Policies typically need one representative contact per element, not the
-raw list. The ``reduce`` mode selects which contacts to keep.
+A single primary element can have many simultaneous contacts with the
+secondary (e.g. a flat foot resting on rough terrain has multiple
+contact points). The ``reduce`` mode collapses those raw contacts down
+to ``num_slots`` representative contacts:
 
 .. list-table::
    :header-rows: 1
@@ -201,21 +241,49 @@ raw list. The ``reduce`` mode selects which contacts to keep.
    * - Mode
      - Behavior
    * - ``"none"``
-     - Fast, non-deterministic selection
+     - Fast, non-deterministic selection of up to ``num_slots`` contacts.
    * - ``"mindist"``
-     - Closest contacts by penetration depth
+     - Keep the deepest ``num_slots`` contacts.
    * - ``"maxforce"``
-     - Strongest contacts by force magnitude
+     - Keep the strongest ``num_slots`` contacts by force magnitude.
    * - ``"netforce"``
-     - Sums all contacts into a single synthetic contact at the
-       force-weighted centroid with the net wrench
+     - Sum all contacts into a single net wrench at the force-weighted
+       centroid. Always emits one slot per primary regardless of
+       ``num_slots``.
 
-``num_slots`` controls how many contacts are retained per primary
-element after reduction. The default is 1, which gives one
-representative contact per primary match. The output shape is
-``[B, N * num_slots, ...]`` where ``N`` is the number of primary
-matches. With ``reduce="netforce"``, the output is always one contact
-per primary regardless of ``num_slots``.
+When to set ``num_slots > 1``
+"""""""""""""""""""""""""""""
+
+Almost all configurations leave ``num_slots`` at its default of ``1``,
+because pattern expansion already produces one column per element of
+interest (one per foot, one per finger, one per body link). Increase
+``num_slots`` only when a single primary may have several physically
+distinct contact points that you want to inspect separately, for
+example:
+
+- Computing a center of pressure on a flat foot from its corner
+  contacts.
+- Reasoning about grasp quality from multiple fingertip-to-object
+  contact points.
+- Detecting tipping by watching whether one corner of a contact patch
+  loses contact.
+
+In those cases pair ``num_slots`` with ``reduce`` in
+``{"mindist", "maxforce", "none"}``. With ``reduce="netforce"`` it has
+no effect.
+
+.. note::
+
+   ``num_slots`` is a ceiling on what the sensor will store, not a
+   guarantee that MuJoCo will produce that many contacts. The collision
+   detector caps the number of contact points generated for each
+   geom-pair according to the geom types involved. For example a
+   sphere-vs-plane pair produces at most one contact, and a box-vs-box
+   pair produces at most four. Setting ``num_slots=8`` on a sphere
+   primary against a plane secondary therefore leaves seven slots
+   permanently zero. Check
+   `MuJoCo's collision documentation <https://mujoco.readthedocs.io/en/stable/computation/index.html#collision-detection>`_
+   for the per-pair limits.
 
 Fields
 ^^^^^^
@@ -225,21 +293,34 @@ requested fields are allocated; the rest are ``None`` on the output
 dataclass. Available fields are ``"found"``, ``"force"``,
 ``"torque"``, ``"dist"``, ``"pos"``, ``"normal"``, and ``"tangent"``.
 
+.. note::
+
+   ``torque`` and the friction-tangent component of ``force`` are zero
+   unless the contact pair has friction enabled, which requires
+   ``condim >= 3`` on at least one geom in the pair. With ``condim=1``
+   (frictionless), the contact only produces a normal force. This is a
+   physics property of the contact, not a sensor limitation.
+
 Air time tracking
 ^^^^^^^^^^^^^^^^^
 
 Locomotion tasks often need to know when feet land and take off for
-gait rewards. Setting ``track_air_time=True`` enables per-element
+gait rewards. Setting ``track_air_time=True`` enables per-primary
 timing. The sensor maintains four additional tensors on
-``ContactData``: ``current_air_time``, ``last_air_time``,
-``current_contact_time``, and ``last_contact_time``. Two helper
-methods provide edge detection for transition events.
+``ContactData``, each shaped ``[B, P]``: ``current_air_time``,
+``last_air_time``, ``current_contact_time``, and
+``last_contact_time``. Two helper methods provide edge detection for
+transition events:
 
 .. code-block:: python
 
     sensor = env.scene["feet_air"]
-    first_contact = sensor.compute_first_contact(dt)  # Just landed
-    first_air = sensor.compute_first_air(dt)           # Just took off
+    first_contact = sensor.compute_first_contact(dt)  # [B, P], True for primaries that just landed
+    first_air = sensor.compute_first_air(dt)           # [B, P], True for primaries that just took off
+
+Air time is per primary even when ``num_slots > 1``: the sensor reduces
+``found`` across slots so that any slot in contact counts as the
+primary being in contact.
 
 .. _contact-sensor-history:
 

--- a/src/mjlab/sensor/contact_sensor.py
+++ b/src/mjlab/sensor/contact_sensor.py
@@ -1,4 +1,22 @@
-"""Contact sensors track collisions between geoms, bodies, or subtrees."""
+"""Contact sensors track collisions between geoms, bodies, or subtrees.
+
+A ``ContactSensor`` resolves regex patterns into a set of *primary* MuJoCo
+elements and (optionally) a single *secondary* element to filter against. Each
+physics step it pulls per-primary contact data from MuJoCo's native contact
+sensor and packages it into a batched ``ContactData`` dataclass.
+
+Shape conventions on ``ContactData``:
+
+- ``P`` = number of primary elements resolved from the pattern (see
+  :attr:`ContactSensor.primary_names` for the index→name mapping).
+- ``N`` = ``P * num_slots`` (per-contact axis, primary-major layout).
+- Per-contact fields (``found``, ``force``, ``torque``, ``dist``, ``pos``,
+  ``normal``, ``tangent``) have shape ``[B, N, ...]``.
+- Per-primary fields (``current_air_time`` etc.) have shape ``[B, P]``.
+
+Most users want the default ``num_slots=1``, in which case ``N == P`` and the
+two shape families coincide.
+"""
 
 from __future__ import annotations
 
@@ -51,10 +69,16 @@ _MODE_TO_OBJTYPE = {
 class ContactMatch:
   """Specifies what to match on one side of a contact.
 
-  mode: "geom", "body", or "subtree"
-  pattern: Regex or tuple of regexes (expands within entity if specified)
-  entity: Entity name to search within (None = treat pattern as literal MuJoCo name)
-  exclude: Filter out matches using these regex patterns or exact names.
+  Args:
+    mode: MuJoCo element type to match against ("geom", "body", or "subtree").
+    pattern: A regex (or tuple of regexes) matched against element names within
+      ``entity``. If ``entity`` is unset, the pattern is treated as a literal
+      MuJoCo name (no regex expansion).
+    entity: Entity name to scope the pattern to. If ``None``/``""``, the
+      pattern is taken as a literal MuJoCo name.
+    exclude: Names to filter out of the match. Each entry is treated as a
+      regex if it contains any regex metacharacters, otherwise as an exact
+      name.
   """
 
   mode: Literal["geom", "body", "subtree"]
@@ -65,25 +89,61 @@ class ContactMatch:
 
 @dataclass
 class ContactSensorCfg(SensorCfg):
-  """Tracks contacts between primary and secondary patterns.
+  """Configuration for a :class:`ContactSensor`.
 
-  Output shape: [B, N * num_slots] or [B, N * num_slots, 3] where N = # of primaries
+  A contact sensor watches contacts between a ``primary`` set of elements and
+  an optional ``secondary`` element. Patterns expand to multiple primaries
+  (e.g. all four feet on a quadruped); each primary becomes one column on the
+  per-contact axis of the output tensors.
 
-  Fields (choose subset):
-    - found: 0=no contact, >0=match count before reduction
-    - force, torque: 3D vectors in contact frame (or global if reduce="netforce")
-    - dist: penetration depth
-    - pos, normal, tangent: 3D vectors in global frame (normal: primary→secondary)
+  See the module docstring for shape conventions (``P``, ``N``, primary-major
+  layout) and :attr:`ContactSensor.primary_names` for index→name lookup.
 
-  Reduction modes (selects top num_slots from all matches):
-    - "none": fast, non-deterministic
-    - "mindist", "maxforce": closest/strongest contacts
-    - "netforce": sum all forces (global frame)
+  Args:
+    primary: Elements to measure (e.g. the robot's feet). Typically a regex
+      that resolves to multiple elements.
+    secondary: Optional filter on what the primary may contact (e.g. terrain).
+      ``None`` means "any contact with a primary counts".
+    fields: Which contact quantities to extract. Only requested fields are
+      allocated and computed; the rest are ``None`` on ``ContactData``.
 
-  Policies:
-    - secondary_policy: "first", "any", or "error" when secondary matches multiple
-    - track_air_time: enables landing/takeoff detection
-    - global_frame: rotates force/torque to global (requires normal+tangent fields)
+      - ``"found"``: 0 = no contact; >0 = number of matched contacts.
+      - ``"force"``, ``"torque"``: 3D vectors in the contact frame (or in the
+        global frame when ``reduce="netforce"`` or ``global_frame=True``).
+      - ``"dist"``: penetration depth (scalar).
+      - ``"pos"``, ``"normal"``, ``"tangent"``: 3D vectors in the global
+        frame (normal points primary → secondary).
+
+    reduce: How to collapse simultaneous contacts on the same primary down to
+      ``num_slots`` representative contacts.
+
+      - ``"none"``: fast, non-deterministic ordering.
+      - ``"mindist"``: keep the closest (deepest) contacts.
+      - ``"maxforce"``: keep the strongest contacts.
+      - ``"netforce"``: sum all contacts into a single net wrench (always
+        produces one slot per primary regardless of ``num_slots``).
+
+    num_slots: Number of contacts to retain per primary after reduction.
+      Almost always ``1``: most policies want one representative contact per
+      primary, and pattern expansion already gives you many primaries. Only
+      raise this when a single primary may have multiple distinct contacts
+      you want to inspect separately, paired with ``reduce`` in
+      ``{"none", "mindist", "maxforce"}``. Ignored by ``reduce="netforce"``.
+    secondary_policy: How to handle a secondary pattern that resolves to
+      multiple elements: ``"first"`` picks the first match, ``"any"`` drops
+      the secondary filter entirely, ``"error"`` raises.
+    track_air_time: Allocate per-primary air/contact time accumulators
+      (useful for gait rewards). Requires ``"found"`` in ``fields``. Slot
+      reduction within a primary uses an "any slot in contact" rule.
+    global_frame: Rotate ``force``/``torque`` from the contact frame to the
+      global frame. Requires ``"normal"`` and ``"tangent"`` in ``fields``.
+      Implicit when ``reduce="netforce"``.
+    history_length: If >0, keep a rolling buffer of the last N substeps of
+      ``force``/``torque``/``dist`` data. Set to your decimation value so the
+      buffer covers exactly one policy step; useful for catching brief
+      collisions that resolve mid-substep. ``0`` disables the buffer.
+    debug: Print each MuJoCo sensor as it is added to the spec. Useful for
+      checking that pattern expansion produced the elements you expected.
   """
 
   primary: ContactMatch
@@ -95,19 +155,6 @@ class ContactSensorCfg(SensorCfg):
   track_air_time: bool = False
   global_frame: bool = False
   history_length: int = 0
-  """Number of substeps to store in history buffer for force/torque/dist fields.
-
-  When 0 (default): No history buffer is allocated. History fields (force_history,
-  torque_history, dist_history) are None. Use the regular fields (force, torque, dist)
-  for the current instantaneous values.
-
-  When >0: Allocates a history buffer that stores the last N substeps of contact data.
-  Shape is [B, N, history_length, ...] where index 0 is the most recent substep.
-  Set to your decimation value to capture all substeps within one policy step.
-
-  Note: history_length=1 is redundant with the regular fields but provides a consistent
-  [B, N, H, ...] shape if your code expects a history dimension.
-  """
   debug: bool = False
 
   def build(self) -> ContactSensor:
@@ -126,7 +173,7 @@ class _ContactSlot:
 
 @dataclass
 class _AirTimeState:
-  """Tracks how long contacts have been in air/contact. Shape: [B, N]."""
+  """Tracks how long contacts have been in air/contact. Shape: [B, P]."""
 
   current_air_time: torch.Tensor
   last_air_time: torch.Tensor
@@ -137,7 +184,12 @@ class _AirTimeState:
 
 @dataclass
 class ContactData:
-  """Contact sensor output (only requested fields are populated)."""
+  """Contact sensor output (only requested fields are populated).
+
+  Shape conventions: P = number of primaries; N = P * num_slots (per-contact
+  fields are laid out primary-major). Air-time fields are per-primary and
+  reduce across slots (any slot in contact → primary in contact).
+  """
 
   found: torch.Tensor | None = None
   """[B, N] 0=no contact, >0=match count"""
@@ -155,13 +207,13 @@ class ContactData:
   """[B, N, 3] global frame"""
 
   current_air_time: torch.Tensor | None = None
-  """[B, N] time in air (if track_air_time=True)"""
+  """[B, P] time in air per primary (if track_air_time=True)"""
   last_air_time: torch.Tensor | None = None
-  """[B, N] duration of last air phase (if track_air_time=True)"""
+  """[B, P] duration of last air phase per primary (if track_air_time=True)"""
   current_contact_time: torch.Tensor | None = None
-  """[B, N] time in contact (if track_air_time=True)"""
+  """[B, P] time in contact per primary (if track_air_time=True)"""
   last_contact_time: torch.Tensor | None = None
-  """[B, N] duration of last contact phase (if track_air_time=True)"""
+  """[B, P] duration of last contact phase per primary (if track_air_time=True)"""
 
   force_history: torch.Tensor | None = None
   """[B, N, H, 3] contact forces over last H substeps (index 0 = most recent)"""
@@ -191,6 +243,16 @@ class ContactSensor(Sensor[ContactData]):
     self._air_time_state: _AirTimeState | None = None
     self._history_state: dict[str, torch.Tensor] | None = None
 
+  @property
+  def primary_names(self) -> list[str]:
+    """Primary names in the order they appear along the per-contact dim.
+
+    Per-contact fields ([B, N, ...]) are laid out primary-major, so primary
+    `primary_names[i]` occupies indices [i * num_slots : (i + 1) * num_slots].
+    Per-primary fields ([B, P, ...]) have one entry per name in this list.
+    """
+    return list(dict.fromkeys(slot.primary_name for slot in self._slots))
+
   def edit_spec(self, scene_spec: mujoco.MjSpec, entities: dict[str, Entity]) -> None:
     """Expand patterns and add MuJoCo sensors (one per primary x field pair)."""
     self._slots.clear()
@@ -203,6 +265,11 @@ class ContactSensor(Sensor[ContactData]):
         entities, self.cfg.secondary, self.cfg.secondary_policy
       )
 
+    # MuJoCo allows packing multiple fields into one contact sensor via the
+    # `dataspec` bitfield, but we register one sensor per (primary, field) pair
+    # so each sensor's `sensordata` block is laid out as `[B, num_slots * dim]`
+    # and `_extract_sensor_data` can reshape per field without computing
+    # per-field offsets within an interleaved per-slot layout.
     for prim in primary_names:
       for field in self.cfg.fields:
         sensor_name = f"{self.cfg.name}_{prim}_{field}"
@@ -239,9 +306,10 @@ class ContactSensor(Sensor[ContactData]):
     self._data = data
     self._device = device
 
+    n_primary = len(self.primary_names)
+
     if self.cfg.track_air_time:
       n_envs = data.time.shape[0]
-      n_primary = len(set(slot.primary_name for slot in self._slots))
       self._air_time_state = _AirTimeState(
         current_air_time=torch.zeros((n_envs, n_primary), device=device),
         last_air_time=torch.zeros((n_envs, n_primary), device=device),
@@ -252,7 +320,6 @@ class ContactSensor(Sensor[ContactData]):
 
     if self.cfg.history_length > 0:
       n_envs = data.time.shape[0]
-      n_primary = len(set(slot.primary_name for slot in self._slots))
       n_contacts = n_primary * self.cfg.num_slots
       h = self.cfg.history_length
       self._history_state = {}
@@ -309,7 +376,7 @@ class ContactSensor(Sensor[ContactData]):
       self._update_history()
 
   def compute_first_contact(self, dt: float, abs_tol: float = 1.0e-8) -> torch.Tensor:
-    """Returns [B, N] bool: True for contacts established within last dt seconds."""
+    """Returns [B, P] bool: True for primaries that landed within the last dt seconds."""
     if self._air_time_state is None:
       raise RuntimeError(
         f"Sensor '{self.cfg.name}' must have track_air_time=True "
@@ -320,7 +387,7 @@ class ContactSensor(Sensor[ContactData]):
     return is_in_contact & within_dt
 
   def compute_first_air(self, dt: float, abs_tol: float = 1.0e-8) -> torch.Tensor:
-    """Returns [B, N] bool: True for contacts broken within last dt seconds."""
+    """Returns [B, P] bool: True for primaries that took off within the last dt seconds."""
     if self._air_time_state is None:
       raise RuntimeError(
         f"Sensor '{self.cfg.name}' must have track_air_time=True "
@@ -387,7 +454,12 @@ class ContactSensor(Sensor[ContactData]):
     elapsed_time = current_time - self._air_time_state.last_time
     elapsed_time = elapsed_time.unsqueeze(-1)
 
-    is_contact = contact_data.found > 0
+    # Reduce `found` from [B, P*num_slots] to [B, P]: a primary is in contact
+    # if any of its slots reports a match. Air-time is tracked per primary.
+    found = contact_data.found
+    if self.cfg.num_slots > 1:
+      found = found.view(found.size(0), -1, self.cfg.num_slots).any(dim=-1)
+    is_contact = found > 0
 
     state = self._air_time_state
     is_first_contact = (state.current_air_time > 0) & is_contact
@@ -550,53 +622,55 @@ class ContactSensor(Sensor[ContactData]):
     reduce_mode = _CONTACT_REDUCE_MAP[self.cfg.reduce]
     intprm = [data_bits, reduce_mode, self.cfg.num_slots]
 
-    primary_entity = self.cfg.primary.entity
-    if primary_entity and primary_entity != "":
-      prefixed_primary = f"{primary_entity}/{primary_name}"
-    else:
-      prefixed_primary = primary_name
-
     kwargs: dict[str, Any] = {
       "name": sensor_name,
       "type": mujoco.mjtSensor.mjSENS_CONTACT,
       "objtype": _MODE_TO_OBJTYPE[self.cfg.primary.mode],
-      "objname": prefixed_primary,
+      "objname": _prefix_name(primary_name, self.cfg.primary.entity),
       "intprm": intprm,
     }
 
     if secondary_name is not None:
       assert self.cfg.secondary is not None
-      secondary_entity = self.cfg.secondary.entity
-      if secondary_entity and secondary_entity != "":
-        prefixed_secondary = f"{secondary_entity}/{secondary_name}"
-      else:
-        prefixed_secondary = secondary_name
       kwargs["reftype"] = _MODE_TO_OBJTYPE[self.cfg.secondary.mode]
-      kwargs["refname"] = prefixed_secondary
+      kwargs["refname"] = _prefix_name(secondary_name, self.cfg.secondary.entity)
 
     if self.cfg.debug:
-
-      def _ename(v):
-        return getattr(v, "name", str(v))
-
-      objtype_name = _ename(kwargs["objtype"]).removeprefix("mjOBJ_")
-      reftype_val = kwargs.get("reftype")
-      refname_val = kwargs.get("refname")
-      reftype_name = (
-        _ename(reftype_val).removeprefix("mjOBJ_")
-        if reftype_val is not None
-        else "<any>"
-      )
-
-      ref_str = "<any>" if refname_val is None else f"{reftype_name}:{refname_val}"
-
-      print(
-        "Adding contact sensor\n"
-        f"  name    : {sensor_name}\n"
-        f"  object  : {objtype_name}:{kwargs['objname']}\n"
-        f"  ref     : {ref_str}\n"
-        f"  field   : {field}  bits=0b{intprm[0]:b}\n"
-        f"  reduce  : {self.cfg.reduce}  num_slots={self.cfg.num_slots}"
-      )
+      self._print_debug(sensor_name, field, intprm, kwargs)
 
     scene_spec.add_sensor(**kwargs)
+
+  def _print_debug(
+    self,
+    sensor_name: str,
+    field: str,
+    intprm: list[int],
+    kwargs: dict[str, Any],
+  ) -> None:
+    objtype_name = _objtype_name(kwargs["objtype"])
+    reftype_val = kwargs.get("reftype")
+    refname_val = kwargs.get("refname")
+    if refname_val is None:
+      ref_str = "<any>"
+    else:
+      ref_str = f"{_objtype_name(reftype_val)}:{refname_val}"
+    print(
+      "Adding contact sensor\n"
+      f"  name    : {sensor_name}\n"
+      f"  object  : {objtype_name}:{kwargs['objname']}\n"
+      f"  ref     : {ref_str}\n"
+      f"  field   : {field}  bits=0b{intprm[0]:b}\n"
+      f"  reduce  : {self.cfg.reduce}  num_slots={self.cfg.num_slots}"
+    )
+
+
+def _prefix_name(name: str, entity: str | None) -> str:
+  """Prepend ``entity/`` to a MuJoCo name when an entity scope is set."""
+  if entity:
+    return f"{entity}/{name}"
+  return name
+
+
+def _objtype_name(objtype: Any) -> str:
+  """Pretty-print a MuJoCo object type, dropping the ``mjOBJ_`` prefix."""
+  return getattr(objtype, "name", str(objtype)).removeprefix("mjOBJ_")

--- a/tests/test_contact_sensor.py
+++ b/tests/test_contact_sensor.py
@@ -743,6 +743,58 @@ def test_num_slots_greater_than_one(device):
   assert data_3.normal.shape == (2, 6, 3)
 
 
+def test_multi_slot_air_time_and_primary_names(device):
+  """Multi-slot air-time stays per-primary, primaries are exposed by name.
+
+  Regression for issue #914: previously `num_slots > 1` with `track_air_time`
+  crashed in `_update_air_time_tracking` because air-time state was [B, P]
+  while `found` was [B, P * num_slots]. The fix reduces `found` across slots.
+  This test pins both the regression and the new `primary_names` API.
+  """
+  cfg = ContactSensorCfg(
+    name="feet_contact",
+    primary=ContactMatch(
+      mode="geom",
+      pattern=("left_foot_geom", "right_foot_geom"),
+      entity="biped",
+    ),
+    secondary=None,
+    fields=("found",),
+    num_slots=3,
+    track_air_time=True,
+  )
+
+  scene, sim = create_scene_with_sensor(BIPED_XML, "biped", cfg, device)
+  sensor = scene["feet_contact"]
+
+  # `primary_names` reflects pattern order and indexes the per-primary axis.
+  assert sensor.primary_names == ["left_foot_geom", "right_foot_geom"]
+
+  # Settle the biped on the ground so feet are in stable contact.
+  root_state = torch.zeros((2, 13), device=sim.device)
+  root_state[:, 2] = 0.25
+  root_state[:, 3] = 1.0
+  scene["biped"].write_root_state_to_sim(root_state)
+  for _ in range(20):
+    sim.step()
+    scene.update(dt=sim.cfg.mujoco.timestep)
+
+  data = sensor.data
+  assert data.found is not None
+  assert data.current_contact_time is not None
+
+  # Per-contact axis is P * num_slots; per-primary axis is P.
+  assert data.found.shape == (2, 2 * 3)
+  assert data.current_contact_time.shape == (2, len(sensor.primary_names))
+
+  # Air-time update actually ran and accumulated time for primaries in
+  # contact (not just "didn't crash"). Each foot reports a contact in some
+  # slot, so its per-primary contact time should grow above zero.
+  any_contact_per_primary = (data.found > 0).view(2, 2, 3).any(dim=-1)
+  assert torch.all(any_contact_per_primary), "expected both feet in contact"
+  assert torch.all(data.current_contact_time > 0)
+
+
 ##
 # History tests.
 ##


### PR DESCRIPTION
The contact sensor crashed with a broadcast error when `num_slots > 1`, `track_air_time=True`, and more than one primary were combined: `found` came out as [B, P*num_slots] while the air-time state was [B, P], so the `&` in `_update_air_time_tracking` failed at runtime. The fix reduces `found` across slots before the comparison, treating a primary as in contact when any of its slots reports a match. Air-time semantics stay per-primary, which is what every existing config already assumed.

While in there, this also clears up the longer-standing confusion behind issue #914: `N` was overloaded between per-contact fields ([B, P*num_slots, ...]) and per-primary fields ([B, P]). Docstrings on `ContactSensorCfg`, `ContactData`, and the helper methods now spell that out, and `ContactSensor.primary_names` exposes the resolved primary names so callers can map columns back to names. The sensors guide gains an output-shape table, a "when to set `num_slots > 1`" subsection, and notes about MuJoCo's per-geom-pair contact caps and `condim`-driven friction.

A consolidated regression test settles a biped with `num_slots=3` and `track_air_time=True`, asserts the new `primary_names` API, and checks that per-primary `current_contact_time` actually accumulates (not just that the call doesn't crash).

Fixes #914