### PR TITLE
Fix noise model key collision across observation groups

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -41,6 +41,15 @@ Fixed
   notebook cell and verifies that every ``from mjlab... import X``
   reference resolves, so future renames in the mjlab public API can't
   silently rot the tutorials (:issue:`913`).
+- Fixed ``ObservationManager`` silently sharing a single ``NoiseModelCfg``
+  instance across observation groups that declared terms with the same
+  name. ``_group_obs_class_instances`` was keyed by term name alone, so
+  the last group processed in ``_prepare_terms`` overwrote earlier
+  groups' instances. Symptoms included the wrong noise config being
+  applied, shared per-episode state for ``NoiseModelWithAdditiveBias``
+  (e.g. bias drawn from the wrong ``bias_noise_cfg``), and missed
+  ``reset()`` calls for overwritten instances. Instances are now keyed
+  by ``(group_name, term_name)`` so each group owns its own noise model.
 
 Version 1.3.0 (April 14, 2026)
 ------------------------------

--- a/src/mjlab/managers/observation_manager.py
+++ b/src/mjlab/managers/observation_manager.py
@@ -253,8 +253,9 @@ class ObservationManager(ManagerBase):
           self._group_obs_term_history_buffer[group_name][term_name].reset(
             batch_ids=batch_ids
           )
-    for mod in self._group_obs_class_instances.values():
-      mod.reset(env_ids=env_ids)
+    for group_mods in self._group_obs_class_instances.values():
+      for mod in group_mods.values():
+        mod.reset(env_ids=env_ids)
     return {}
 
   def _check_and_handle_nans(
@@ -330,7 +331,7 @@ class ObservationManager(ManagerBase):
       if isinstance(term_cfg.noise, noise_cfg.NoiseCfg):
         obs = term_cfg.noise.apply(obs)
       elif isinstance(term_cfg.noise, noise_cfg.NoiseModelCfg):
-        obs = self._group_obs_class_instances[term_name](obs)
+        obs = self._group_obs_class_instances[group_name][term_name](obs)
       if term_cfg.clip:
         obs = obs.clip_(min=term_cfg.clip[0], max=term_cfg.clip[1])
       if term_cfg.scale is not None:
@@ -392,7 +393,7 @@ class ObservationManager(ManagerBase):
     self._group_obs_class_term_cfgs: dict[str, list[ObservationTermCfg]] = dict()
     self._group_obs_concatenate: dict[str, bool] = dict()
     self._group_obs_concatenate_dim: dict[str, int] = dict()
-    self._group_obs_class_instances: dict[str, noise_model.NoiseModel] = {}
+    self._group_obs_class_instances: dict[str, dict[str, noise_model.NoiseModel]] = {}
     self._group_obs_term_delay_buffer: dict[str, dict[str, DelayBuffer]] = dict()
     self._group_obs_term_history_buffer: dict[str, dict[str, CircularBuffer]] = dict()
 
@@ -406,6 +407,7 @@ class ObservationManager(ManagerBase):
       self._group_obs_term_dim[group_name] = list()
       self._group_obs_term_cfgs[group_name] = list()
       self._group_obs_class_term_cfgs[group_name] = list()
+      self._group_obs_class_instances[group_name] = {}
       group_entry_delay_buffer: dict[str, DelayBuffer] = dict()
       group_entry_history_buffer: dict[str, CircularBuffer] = dict()
 
@@ -452,7 +454,7 @@ class ObservationManager(ManagerBase):
             f"Class type for observation term '{term_name}' NoiseModelCfg"
             f" is not a subclass of 'NoiseModel'. Received: '{type(noise_model_cls)}'."
           )
-          self._group_obs_class_instances[term_name] = noise_model_cls(
+          self._group_obs_class_instances[group_name][term_name] = noise_model_cls(
             term_cfg.noise, num_envs=self._env.num_envs, device=self._env.device
           )
 

--- a/tests/test_observation_noise.py
+++ b/tests/test_observation_noise.py
@@ -11,7 +11,10 @@ from mjlab.managers.observation_manager import (
   ObservationManager,
   ObservationTermCfg,
 )
-from mjlab.utils.noise.noise_cfg import ConstantNoiseCfg
+from mjlab.utils.noise.noise_cfg import (
+  ConstantNoiseCfg,
+  NoiseModelWithAdditiveBiasCfg,
+)
 
 
 @pytest.fixture
@@ -229,6 +232,48 @@ def test_noise_tensor_caching(device):
   expected = torch.full((4, 3), 1.5, device=device)
   assert torch.allclose(result1, expected)
   assert torch.allclose(result2, expected)
+
+
+def test_shared_term_name_noise_models_are_per_group(mock_env, device):
+  """Each group owns its own noise model instance when they share a term name.
+
+  ConstantNoiseCfg(op="add") shifts the additive-bias tensor by the configured
+  amount on every reset, so each group's observation drifts by its own value
+  after each manager.reset().
+  """
+
+  def obs_func(env):
+    return torch.zeros((env.num_envs, 3), device=device)
+
+  def group(bias: float) -> ObservationGroupCfg:
+    return ObservationGroupCfg(
+      terms={
+        "obs": ObservationTermCfg(
+          func=obs_func,
+          params={},
+          noise=NoiseModelWithAdditiveBiasCfg(
+            noise_cfg=ConstantNoiseCfg(bias=0.0, operation="add"),
+            bias_noise_cfg=ConstantNoiseCfg(bias=bias, operation="add"),
+          ),
+        ),
+      },
+      enable_corruption=True,
+    )
+
+  manager = ObservationManager({"actor": group(10.0), "critic": group(-1.0)}, mock_env)
+
+  obs = manager.compute()
+  assert isinstance(obs["actor"], torch.Tensor)
+  assert isinstance(obs["critic"], torch.Tensor)
+  assert torch.allclose(obs["actor"], torch.full((4, 3), 10.0, device=device))
+  assert torch.allclose(obs["critic"], torch.full((4, 3), -1.0, device=device))
+
+  manager.reset()
+  obs = manager.compute()
+  assert isinstance(obs["actor"], torch.Tensor)
+  assert isinstance(obs["critic"], torch.Tensor)
+  assert torch.allclose(obs["actor"], torch.full((4, 3), 20.0, device=device))
+  assert torch.allclose(obs["critic"], torch.full((4, 3), -2.0, device=device))
 
 
 def test_multiple_terms_with_different_noise(mock_env, device):


### PR DESCRIPTION
`ObservationManager._group_obs_class_instances` was keyed by term name alone. When two groups declared a term with the same name using a `NoiseModelCfg`, the later group's instance silently overwrote the earlier one in `_prepare_terms`, and both groups then routed every noise call through the surviving instance.

Three symptoms fall out:

- The wrong noise config is applied (the loser's `NoiseModelCfg` is dropped).
- Per-episode state leaks across groups (e.g. `_bias` in `NoiseModelWithAdditiveBias` is drawn from whichever group won).
- `manager.reset()` dispatches only to the surviving instance.

The fix keys the dict by `(group_name, term_name)`, matching the nesting already used for delay and history buffers.

A regression test drives `compute → reset → compute` with a deterministic `ConstantNoiseCfg` additive bias and checks per-group isolation of instance, config, and reset dispatch in a single pass.