### PR TITLE
Fix CurriculumManager.get_active_iterable_terms TypeError on dict state

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -50,6 +50,11 @@ Fixed
   (e.g. bias drawn from the wrong ``bias_noise_cfg``), and missed
   ``reset()`` calls for overwritten instances. Instances are now keyed
   by ``(group_name, term_name)`` so each group owns its own noise model.
+- Fixed ``CurriculumManager.get_active_iterable_terms`` raising
+  ``TypeError`` when a term's state was a dict. The dict branch indexed
+  the output list by term name instead of appending to the local ``data``
+  list. No in-tree caller currently invokes this method, so the bug was
+  latent.
 
 Version 1.3.0 (April 14, 2026)
 ------------------------------

--- a/src/mjlab/managers/curriculum_manager.py
+++ b/src/mjlab/managers/curriculum_manager.py
@@ -84,7 +84,7 @@ class CurriculumManager(ManagerBase):
           for _key, value in term_state.items():
             if isinstance(value, torch.Tensor):
               value = value.item()
-            terms[term_name].append(value)
+            data.append(value)
         else:
           if isinstance(term_state, torch.Tensor):
             term_state = term_state.item()

--- a/tests/test_curriculum_manager.py
+++ b/tests/test_curriculum_manager.py
@@ -1,0 +1,41 @@
+"""Tests for CurriculumManager."""
+
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from mjlab.managers.curriculum_manager import CurriculumManager, CurriculumTermCfg
+
+
+@pytest.fixture
+def mock_env():
+  env = Mock()
+  env.num_envs = 2
+  return env
+
+
+def test_get_active_iterable_terms_handles_dict_and_scalar_state(mock_env):
+  """Dict- and scalar-shaped curriculum states both yield flat value lists.
+
+  Regression: the dict branch previously indexed `terms` (a list) by term
+  name, raising TypeError. Only observable through callers that invoke
+  get_active_iterable_terms, which no in-tree caller currently does.
+  """
+
+  def dict_state_func(env, env_ids):
+    return {"a": torch.tensor(1.5), "b": 2.0}
+
+  def scalar_state_func(env, env_ids):
+    return torch.tensor(7.0)
+
+  cfg = {
+    "dict_term": CurriculumTermCfg(func=dict_state_func, params={}),
+    "scalar_term": CurriculumTermCfg(func=scalar_state_func, params={}),
+  }
+  manager = CurriculumManager(cfg, mock_env)
+  manager.compute()
+
+  terms = dict(manager.get_active_iterable_terms(0))
+  assert terms["dict_term"] == [1.5, 2.0]
+  assert terms["scalar_term"] == [7.0]


### PR DESCRIPTION
`CurriculumManager.get_active_iterable_terms` crashed with `TypeError: list indices must be integers or slices, not str` whenever a term's state was a dict. The dict branch at `curriculum_manager.py:87` indexed the output list by term name instead of appending to the local `data` list that the scalar branch already populates.

No in-tree caller invokes this method today (viewer overlays call the reward and metrics variants but not curriculum), so the bug was latent. It would surface the moment anyone wires curriculum terms into a viewer overlay or similar iteration path.

One-line fix plus a small unit test that exercises both the dict and scalar branches.