### PR TITLE
Fix opaque error when an observation group has no active terms

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -31,6 +31,11 @@ Changed
 Fixed
 ^^^^^
 
+- ``ObservationManager`` now raises a clear ``ValueError`` when an
+  observation group ends up with zero active terms (e.g. all terms set
+  to ``None``), instead of failing later with an opaque ``torch.stack``
+  or ``torch.cat`` error. To disable a group, set the entire group to
+  ``None``.
 - Fixed a runtime broadcast error in ``ContactSensor`` when combining
   ``num_slots > 1`` with ``track_air_time=True`` and more than one primary.
   Air-time tracking now reduces ``found`` across slots so that a primary is

--- a/src/mjlab/managers/observation_manager.py
+++ b/src/mjlab/managers/observation_manager.py
@@ -483,5 +483,12 @@ class ObservationManager(ManagerBase):
             obs_dims = (obs_dims[0], int(np.prod(obs_dims[1:])))
 
         self._group_obs_term_dim[group_name].append(obs_dims[1:])
+
+      if not self._group_obs_term_names[group_name]:
+        raise ValueError(
+          f"Observation group '{group_name}' has no active terms. "
+          "Set the entire group to None to disable it."
+        )
+
       self._group_obs_term_delay_buffer[group_name] = group_entry_delay_buffer
       self._group_obs_term_history_buffer[group_name] = group_entry_history_buffer

--- a/tests/test_observation_manager.py
+++ b/tests/test_observation_manager.py
@@ -1,0 +1,40 @@
+"""Tests for ObservationManager behavior."""
+
+from unittest.mock import Mock
+
+import pytest
+from conftest import get_test_device
+
+from mjlab.managers.observation_manager import (
+  ObservationGroupCfg,
+  ObservationManager,
+)
+
+
+@pytest.fixture
+def mock_env():
+  env = Mock()
+  env.num_envs = 4
+  env.device = get_test_device()
+  env.step_dt = 0.02
+  return env
+
+
+def test_empty_terms_dict_raises(mock_env):
+  """A group declared with no terms should fail fast at construction."""
+  cfg = {"actor": ObservationGroupCfg(terms={})}
+
+  with pytest.raises(ValueError, match="'actor' has no active terms"):
+    ObservationManager(cfg, mock_env)
+
+
+def test_all_terms_none_raises(mock_env):
+  """A group whose every term is None should also fail fast."""
+  cfg = {
+    "actor": ObservationGroupCfg(
+      terms={"a": None, "b": None},  # type: ignore[dict-item]
+    ),
+  }
+
+  with pytest.raises(ValueError, match="'actor' has no active terms"):
+    ObservationManager(cfg, mock_env)


### PR DESCRIPTION
`ObservationManager` already supports setting individual terms (or an entire group) to `None` to disable them. But if a group ends up with *zero* active terms (empty `terms={}`, or every term nulled out by a subclass), construction crashed later with an opaque `torch.stack` / `torch.cat` error on an empty list.

Now we fail fast in `_prepare_terms` with a clear `ValueError` pointing the user at the supported disable path (set the whole group to `None`).