### PR TITLE
Fix out_of_terrain_bounds stale grid dims and missing border

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -31,6 +31,13 @@ Changed
 Fixed
 ^^^^^
 
+- Fixed ``out_of_terrain_bounds`` using stale terrain dimensions. It read
+  ``TerrainGeneratorCfg.num_cols`` directly, which is ignored in curriculum
+  mode (the generator uses ``len(sub_terrains)`` columns instead), and it
+  did not account for ``border_width``. The termination now reads the
+  effective grid shape from ``terrain.terrain_origins`` and includes the
+  border in the footprint, so robots no longer reset while still on valid
+  terrain (or fail to reset after running off it) (:issue:`923`).
 - ``ObservationManager`` now raises a clear ``ValueError`` when an
   observation group ends up with zero active terms (e.g. all terms set
   to ``None``), instead of failing later with an opaque ``torch.stack``

--- a/src/mjlab/tasks/velocity/mdp/terminations.py
+++ b/src/mjlab/tasks/velocity/mdp/terminations.py
@@ -47,7 +47,7 @@ def out_of_terrain_bounds(
     )
 
   terrain_generator = terrain.cfg.terrain_generator
-  if terrain_generator is None:
+  if terrain_generator is None or terrain.terrain_origins is None:
     return torch.zeros(
       (env.num_envs,),
       device=env.device,
@@ -57,8 +57,11 @@ def out_of_terrain_bounds(
   asset: Entity = env.scene[asset_cfg.name]
   root_xy_w = asset.data.root_link_pos_w[:, :2]
 
-  half_x = 0.5 * (terrain_generator.num_rows * terrain_generator.size[0])
-  half_y = 0.5 * (terrain_generator.num_cols * terrain_generator.size[1])
+  # Use the generated grid shape (curriculum mode overrides cfg.num_cols with
+  # len(sub_terrains)), and include the flat border around the patch grid.
+  num_rows, num_cols = terrain.terrain_origins.shape[:2]
+  half_x = 0.5 * (num_rows * terrain_generator.size[0]) + terrain_generator.border_width
+  half_y = 0.5 * (num_cols * terrain_generator.size[1]) + terrain_generator.border_width
   limit_x = max(0.0, half_x - margin)
   limit_y = max(0.0, half_y - margin)
 

--- a/tests/test_terminations.py
+++ b/tests/test_terminations.py
@@ -175,8 +175,13 @@ def mock_grid_terrain_env():
   terrain = Mock()
   terrain.cfg.terrain_type = "generator"
   terrain.cfg.terrain_generator.size = (8.0, 8.0)
-  terrain.cfg.terrain_generator.num_rows = 10
-  terrain.cfg.terrain_generator.num_cols = 10
+  terrain.cfg.terrain_generator.border_width = 0.0
+  # Config num_rows/num_cols may differ from the effective grid (e.g. curriculum
+  # mode sets num_cols = len(sub_terrains) regardless of cfg.num_cols). The
+  # termination should read terrain_origins, not the config fields.
+  terrain.cfg.terrain_generator.num_rows = 999
+  terrain.cfg.terrain_generator.num_cols = 999
+  terrain.terrain_origins = torch.zeros(10, 10, 3, device=device)
 
   env.scene.terrain = terrain
 
@@ -199,3 +204,13 @@ def test_out_of_terrain_bounds_outside(mock_grid_terrain_env):
   asset.data.root_link_pos_w[2, 0] = 40.0
   result = out_of_terrain_bounds(env)
   assert result[2] and not result[0] and not result[1] and not result[3]
+
+
+def test_out_of_terrain_bounds_includes_border_width(mock_grid_terrain_env):
+  env, asset = mock_grid_terrain_env
+  # 2m flat border extends the footprint: half_x = 40 + 2 = 42m.
+  env.scene.terrain.cfg.terrain_generator.border_width = 2.0
+  asset.data.root_link_pos_w[0, 0] = 41.0  # Inside border, should not fire.
+  asset.data.root_link_pos_w[1, 0] = 42.0  # Past border edge (limit 41.7m).
+  result = out_of_terrain_bounds(env)
+  assert not result[0] and result[1]


### PR DESCRIPTION
Fixes #923.

`out_of_terrain_bounds` computed the terrain footprint from `TerrainGeneratorCfg.num_rows` and `num_cols` directly. Two problems:

- In **curriculum mode**, the generator ignores `cfg.num_cols` and uses `len(sub_terrains)` columns instead (since #811). The termination was reading a stale value and computing the wrong half-extent.
- `border_width` was never included. The real footprint is `num_* * size + 2 * border_width`, so robots could fire the termination while still on the flat border.

The termination now reads the effective grid shape from `terrain.terrain_origins` and adds `border_width` to the half-extents. No change to terrain generation or spawning.

### Tests

- Updated `mock_grid_terrain_env` to set `terrain_origins` and pin `cfg.num_rows/num_cols = 999` so the termination can't fall back to the config fields.
- Added a `border_width=2.0` regression test.