### PR TITLE
Skip observation groups with no active terms instead of raising

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -38,11 +38,12 @@ Fixed
   effective grid shape from ``terrain.terrain_origins`` and includes the
   border in the footprint, so robots no longer reset while still on valid
   terrain (or fail to reset after running off it) (:issue:`923`).
-- ``ObservationManager`` now raises a clear ``ValueError`` when an
-  observation group ends up with zero active terms (e.g. all terms set
-  to ``None``), instead of failing later with an opaque ``torch.stack``
-  or ``torch.cat`` error. To disable a group, set the entire group to
-  ``None``.
+- ``ObservationManager`` now skips observation groups that end up with
+  zero active terms (e.g. all terms set to ``None``) with a log message,
+  instead of crashing later in ``torch.stack``/``torch.cat``. This lets
+  a shared runner config define groups that become empty under certain
+  runtime flags (e.g. model-specific terms all disabled for one variant).
+  The whole group can still be set to ``None`` to disable it explicitly.
 - Fixed a runtime broadcast error in ``ContactSensor`` when combining
   ``num_slots > 1`` with ``track_air_time=True`` and more than one primary.
   Air-time tracking now reduces ``found`` across slots so that a primary is

--- a/src/mjlab/managers/observation_manager.py
+++ b/src/mjlab/managers/observation_manager.py
@@ -403,6 +403,10 @@ class ObservationManager(ManagerBase):
         print(f"group: {group_name} set to None, skipping...")
         continue
 
+      if not any(t is not None for t in group_cfg.terms.values()):
+        print(f"group: {group_name} has no active terms, skipping...")
+        continue
+
       self._group_obs_term_names[group_name] = list()
       self._group_obs_term_dim[group_name] = list()
       self._group_obs_term_cfgs[group_name] = list()
@@ -483,12 +487,6 @@ class ObservationManager(ManagerBase):
             obs_dims = (obs_dims[0], int(np.prod(obs_dims[1:])))
 
         self._group_obs_term_dim[group_name].append(obs_dims[1:])
-
-      if not self._group_obs_term_names[group_name]:
-        raise ValueError(
-          f"Observation group '{group_name}' has no active terms. "
-          "Set the entire group to None to disable it."
-        )
 
       self._group_obs_term_delay_buffer[group_name] = group_entry_delay_buffer
       self._group_obs_term_history_buffer[group_name] = group_entry_history_buffer

--- a/tests/test_observation_manager.py
+++ b/tests/test_observation_manager.py
@@ -3,11 +3,13 @@
 from unittest.mock import Mock
 
 import pytest
+import torch
 from conftest import get_test_device
 
 from mjlab.managers.observation_manager import (
   ObservationGroupCfg,
   ObservationManager,
+  ObservationTermCfg,
 )
 
 
@@ -20,21 +22,42 @@ def mock_env():
   return env
 
 
-def test_empty_terms_dict_raises(mock_env):
-  """A group declared with no terms should fail fast at construction."""
+def _dummy_term(mock_env):
+  def func(_env, **_kwargs):
+    return torch.zeros(mock_env.num_envs, 3, device=mock_env.device)
+
+  return ObservationTermCfg(func=func)
+
+
+def test_empty_terms_dict_skipped(mock_env):
+  """A group declared with no terms is skipped rather than raising."""
   cfg = {"actor": ObservationGroupCfg(terms={})}
+  mgr = ObservationManager(cfg, mock_env)
 
-  with pytest.raises(ValueError, match="'actor' has no active terms"):
-    ObservationManager(cfg, mock_env)
+  assert "actor" not in mgr.active_terms
+  assert "actor" not in mgr.group_obs_dim
 
 
-def test_all_terms_none_raises(mock_env):
-  """A group whose every term is None should also fail fast."""
+def test_all_terms_none_skipped(mock_env):
+  """A group whose every term is None is skipped rather than raising."""
   cfg = {
     "actor": ObservationGroupCfg(
       terms={"a": None, "b": None},  # type: ignore[dict-item]
     ),
   }
+  mgr = ObservationManager(cfg, mock_env)
 
-  with pytest.raises(ValueError, match="'actor' has no active terms"):
-    ObservationManager(cfg, mock_env)
+  assert "actor" not in mgr.active_terms
+  assert "actor" not in mgr.group_obs_dim
+
+
+def test_empty_group_skipped_alongside_active_group(mock_env):
+  """Active groups coexist with empty ones; only the empty group is dropped."""
+  cfg = {
+    "actor": ObservationGroupCfg(terms={"a": _dummy_term(mock_env)}),
+    "critic": ObservationGroupCfg(terms={}),
+  }
+  mgr = ObservationManager(cfg, mock_env)
+
+  assert "actor" in mgr.active_terms
+  assert "critic" not in mgr.active_terms


### PR DESCRIPTION
ObservationManager skips groups whose terms dict is empty or whose terms are all None, logging the skip. Supports shared runner configs where some groups become empty under runtime flags.

Fixes #921