### PR TITLE
Fix time tolerance for landing and take off detection

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -31,6 +31,14 @@ Changed
 Fixed
 ^^^^^
 
+- Fixed ``ContactSensor.compute_first_contact`` and ``compute_first_air``
+  occasionally missing events when a contact began or ended right at the
+  last physics substep of a control step. ``current_contact_time`` /
+  ``current_air_time`` accumulate in float32 and can drift a few ULPs past
+  ``dt``, but the default ``abs_tol`` of ``1e-8`` sat at the noise floor
+  and rejected the comparison. Raised the default to ``1e-6``, which stays
+  well below typical control ``dt`` while comfortably covering float32
+  accumulation noise (:issue:`933`). Contribution by @paLeziart.
 - Fixed ``out_of_terrain_bounds`` using stale terrain dimensions. It read
   ``TerrainGeneratorCfg.num_cols`` directly, which is ignored in curriculum
   mode (the generator uses ``len(sub_terrains)`` columns instead), and it

--- a/src/mjlab/sensor/contact_sensor.py
+++ b/src/mjlab/sensor/contact_sensor.py
@@ -375,7 +375,7 @@ class ContactSensor(Sensor[ContactData]):
     if self._history_state is not None:
       self._update_history()
 
-  def compute_first_contact(self, dt: float, abs_tol: float = 1.0e-8) -> torch.Tensor:
+  def compute_first_contact(self, dt: float, abs_tol: float = 1.0e-6) -> torch.Tensor:
     """Returns [B, P] bool: True for primaries that landed within the last dt seconds."""
     if self._air_time_state is None:
       raise RuntimeError(
@@ -386,7 +386,7 @@ class ContactSensor(Sensor[ContactData]):
     within_dt = self._air_time_state.current_contact_time < (dt + abs_tol)
     return is_in_contact & within_dt
 
-  def compute_first_air(self, dt: float, abs_tol: float = 1.0e-8) -> torch.Tensor:
+  def compute_first_air(self, dt: float, abs_tol: float = 1.0e-6) -> torch.Tensor:
     """Returns [B, P] bool: True for primaries that took off within the last dt seconds."""
     if self._air_time_state is None:
       raise RuntimeError(


### PR DESCRIPTION
This pull request intends to fix an issue with missed landing and take-off events due to the time tolerance being too low for the typical numerical noise we can encounter. This happens for the `compute_first_contact` and `compute_first_air` methods of the `ContactSensor` class.

For debugging, I modified the `compute_first_contact` method as follows, with `dt = 0.02`
```
def compute_first_contact(self, dt: float, abs_tol: float = 1.0e-8) -> torch.Tensor:
    """Returns [B, N] bool: True for contacts established within last dt seconds."""
    if self._air_time_state is None:
      raise RuntimeError(
        f"Sensor '{self.cfg.name}' must have track_air_time=True "
        "to use compute_first_contact"
      )
    is_in_contact = self._air_time_state.current_contact_time > 0.0
    within_dt = self._air_time_state.current_contact_time < (dt + abs_tol)
    print(self._air_time_state.current_contact_time[0, 0].item(), within_dt[0, 0].item())  # ADD PRINT HERE
    return is_in_contact & within_dt
```
When the contact happens during a sub-step of simulation, the contact is properly detected.
```
0.004999995231628418 True
[...]
0.014999985694885254 True
```
But if the contact happens _right at the last sub-step_, and the numerical noise is positive, then you can get `0.02000001072883606 False` which means the contact is missed because `0.02000001072883606 > 0.02000001`

This will mess up learning with rewards that rely on landing or take off since the event will not trigger sometimes. A simple solution to fix this issue is to slightly increase the time tolerance.

The default time tolerance is 1.0e-8. This PR changes the value to 1.0e-6 for both methods.

Sorry for the double PR I messed up my email address in the first PR.