### PR TITLE
Fix per-world mesh allocations missing device scope

### DIFF
--- a/src/mjlab/sim/sim.py
+++ b/src/mjlab/sim/sim.py
@@ -232,17 +232,17 @@ class Simulation:
       per_world_mesh,
     )
 
-    result = per_world_mesh(
-      spec,
-      self.num_envs,
-      variant_info,
-      configure_model=self.cfg.mujoco.apply,
-    )
-    self._mj_model = result.mj_model
-    self._mj_data = mujoco.MjData(self._mj_model)
-    mujoco.mj_forward(self._mj_model, self._mj_data)
-
     with wp.ScopedDevice(self.wp_device):
+      result = per_world_mesh(
+        spec,
+        self.num_envs,
+        variant_info,
+        configure_model=self.cfg.mujoco.apply,
+      )
+      self._mj_model = result.mj_model
+      self._mj_data = mujoco.MjData(self._mj_model)
+      mujoco.mj_forward(self._mj_model, self._mj_data)
+
       self._wp_model = result.wp_model
       self._wp_model.opt.ls_parallel = self.cfg.ls_parallel
       self._wp_model.opt.contact_sensor_maxmatch = self.cfg.contact_sensor_maxmatch


### PR DESCRIPTION
`per_world_mesh()` internally calls `mjwarp.put_model` and ~12 `wp.array(...)` allocations for the per-world dataid table and variant-dependent fields (`geom_size`, `body_mass`, `body_inertia`, …). In the current `_init_with_variants`, these run outside `wp.ScopedDevice(self.wp_device)`, so all warp arrays land on warp's default device (usually `cuda:0`). On single-GPU setups this happens to match `self.wp_device` and the bug is invisible, but in multi-GPU training each worker's variant model ends up on `cuda:0` instead of its target device — causing cross-device kernel launch errors (and, as the model grows, unexpected memory pressure on `cuda:0` because every worker's arrays pile up there).                                                                                                  
                                                                                                                                                                                                                                                                                   
  The non-variant path (`_init_with_model`) already wraps `mjwarp.put_model` in `ScopedDevice`; this PR does the same in `_init_with_variants`. With the patch applied, per-world-mesh training runs successfully on a 4× RTX 5090 box — each DDP rank's variant arrays allocate on its own device, no cross-device errors, no `cuda:0` pile-up.  