### PR TITLE
Per-world mesh variants: explicit inertials + variant-aware DR and viewers

### DIFF
--- a/src/mjlab/entity/entity.py
+++ b/src/mjlab/entity/entity.py
@@ -331,8 +331,8 @@ class Entity:
         geom = template_body.add_geom()
         geom.type = mujoco.mjtGeom.mjGEOM_MESH
         geom.meshname = f"{longest_prefix}{longest_names[k]}"
-        geom.contype = 0
-        geom.conaffinity = 0
+        geom.contype = 1
+        geom.conaffinity = 1
 
     # Build variant_mesh_names: use original names with variant prefix.
     variant_mesh_name_lists: list[tuple[str | None, ...]] = []

--- a/src/mjlab/entity/entity.py
+++ b/src/mjlab/entity/entity.py
@@ -77,6 +77,17 @@ class VariantCfg:
   weight: float = 1.0
 
 
+@dataclass(frozen=True)
+class BodyInertialMetadata:
+  """Explicit inertial properties for one body in a mesh variant."""
+
+  body_name: str
+  mass: float
+  ipos: tuple[float, float, float]
+  inertia: tuple[float, float, float]
+  iquat: tuple[float, float, float, float]
+
+
 @dataclass
 class VariantMetadata:
   """Bookkeeping produced by Entity when merging variant specs."""
@@ -87,6 +98,34 @@ class VariantMetadata:
   # have None for padding slots that should be disabled (dataid = -1).
   variant_mesh_names: tuple[tuple[str | None, ...], ...]
   num_mesh_geoms: int  # Max mesh geom count after padding.
+  # Per-variant explicit body inertials. Names are local to the variant spec;
+  # per_world_mesh prefixes them with the scene entity name when applying them.
+  variant_body_inertials: tuple[tuple[BodyInertialMetadata, ...], ...] = ()
+
+
+def _iter_body_tree(body: mujoco.MjsBody):
+  yield body
+  for child in body.bodies:
+    yield from _iter_body_tree(child)
+
+
+def _collect_explicit_body_inertials(
+  root_body: mujoco.MjsBody,
+) -> tuple[BodyInertialMetadata, ...]:
+  inertials: list[BodyInertialMetadata] = []
+  for body in _iter_body_tree(root_body):
+    if not body.name or not body.explicitinertial:
+      continue
+    inertials.append(
+      BodyInertialMetadata(
+        body_name=body.name,
+        mass=float(body.mass),
+        ipos=tuple(float(x) for x in body.ipos),
+        inertia=tuple(float(x) for x in body.inertia),
+        iquat=tuple(float(x) for x in body.iquat),
+      )
+    )
+  return tuple(inertials)
 
 
 @dataclass
@@ -239,6 +278,9 @@ class Entity:
       variant_bodies.append(children[0])
 
     validate_variant_structure(variant_names, variant_bodies)
+    variant_body_inertials = tuple(
+      _collect_explicit_body_inertials(body) for body in variant_bodies
+    )
 
     # Collect original mesh names per variant BEFORE any renaming.
     variant_orig_mesh_names: list[list[str]] = []
@@ -306,6 +348,7 @@ class Entity:
       variant_weights=tuple(variant_weights),
       variant_mesh_names=tuple(variant_mesh_name_lists),
       num_mesh_geoms=max_mesh_geoms,
+      variant_body_inertials=variant_body_inertials,
     )
     self._spec = template_spec
 

--- a/src/mjlab/envs/manager_based_rl_env.py
+++ b/src/mjlab/envs/manager_based_rl_env.py
@@ -219,7 +219,11 @@ class ManagerBasedRlEnv:
     self._offline_renderer: OffscreenRenderer | None = None
     if self.render_mode == "rgb_array":
       renderer = OffscreenRenderer(
-        model=self.sim.mj_model, cfg=self.cfg.viewer, scene=self.scene
+        model=self.sim.mj_model,
+        cfg=self.cfg.viewer,
+        scene=self.scene,
+        sim_model=self.sim.model,
+        expanded_fields=self.sim.expanded_fields,
       )
       renderer.initialize()
       self._offline_renderer = renderer

--- a/src/mjlab/envs/mdp/dr/_core.py
+++ b/src/mjlab/envs/mdp/dr/_core.py
@@ -107,12 +107,7 @@ def _randomize_model_field(
   indexed_data = model_field[env_grid, entity_grid]
 
   if operation.uses_defaults:
-    default_field = env.sim.get_default_field(field)
-    if field in env.sim.per_world_default_fields:
-      # Per-world defaults from mesh variant compilation.
-      base_values = default_field[env_grid, entity_grid]
-    else:
-      base_values = default_field[entity_indices].unsqueeze(0).expand_as(indexed_data)
+    base_values = _select_default_values(env, field, env_ids, entity_indices)
   else:
     base_values = indexed_data
 
@@ -356,11 +351,34 @@ def _randomize_quat_field(
   ).reshape(n_envs, n_entities, 4)
 
   # Expand default to (n_envs, n_entities, 4) so quat_mul shapes match.
-  q_default = env.sim.get_default_field(field)[entity_indices]  # (n_entities, 4)
-  q_default_exp = q_default.unsqueeze(0).expand(n_envs, n_entities, 4).contiguous()
+  q_default_exp = _select_default_values(
+    env, field, env_ids, entity_indices
+  ).contiguous()
 
   q_new = quat_mul(q_perturb, q_default_exp)  # (n_envs, n_entities, 4)
 
   model_field = getattr(env.sim.model, field)
   env_grid, entity_grid = torch.meshgrid(env_ids, entity_indices, indexing="ij")
   model_field[env_grid, entity_grid] = q_new
+
+
+def _select_default_values(
+  env,
+  field: str,
+  env_ids: torch.Tensor,
+  entity_indices: torch.Tensor,
+) -> torch.Tensor:
+  """Return default model values indexed as ``(env, entity, ...)``.
+
+  Standard model defaults are stored as ``(nentity, ...)`` and are shared by
+  every env. Per-world mesh compilation snapshots variant-dependent defaults as
+  ``(nworld, nentity, ...)`` so downstream DR must preserve each world's variant
+  baseline instead of indexing the first dimension as entities.
+  """
+  default_field = env.sim.get_default_field(field)
+  if field in env.sim.per_world_default_fields:
+    env_grid, entity_grid = torch.meshgrid(env_ids, entity_indices, indexing="ij")
+    return default_field[env_grid, entity_grid]
+
+  values = default_field[entity_indices].unsqueeze(0)
+  return values.expand((env_ids.numel(),) + values.shape[1:])

--- a/src/mjlab/envs/mdp/dr/body.py
+++ b/src/mjlab/envs/mdp/dr/body.py
@@ -21,6 +21,7 @@ from ._core import (
   _randomize_model_field,
   _randomize_quat_field,
   _sample_angle,
+  _select_default_values,
 )
 from ._types import Distribution, Operation
 
@@ -495,15 +496,15 @@ def pseudo_inertia(
   n_bodies = len(entity_indices)
   shape = (n_envs, n_bodies)
 
-  def_mass = env.sim.get_default_field("body_mass")[entity_indices]
-  def_ipos = env.sim.get_default_field("body_ipos")[entity_indices]
-  def_inertia = env.sim.get_default_field("body_inertia")[entity_indices]
-  def_iquat = env.sim.get_default_field("body_iquat")[entity_indices]
+  def_mass = _select_default_values(env, "body_mass", env_ids, entity_indices)
+  def_ipos = _select_default_values(env, "body_ipos", env_ids, entity_indices)
+  def_inertia = _select_default_values(env, "body_inertia", env_ids, entity_indices)
+  def_iquat = _select_default_values(env, "body_iquat", env_ids, entity_indices)
 
-  # Reconstruct J_default for each body: (n_bodies, 4, 4).
+  # Reconstruct J_default for each env/body: (n_envs, n_bodies, 4, 4).
   J_default = _reconstruct_pseudo_inertia_J(def_mass, def_ipos, def_inertia, def_iquat)
 
-  # Cholesky factor L: (n_bodies, 4, 4), lower triangular.
+  # Cholesky factor L: (n_envs, n_bodies, 4, 4), lower triangular.
   L = _cholesky_4x4(J_default)
 
   # Sample perturbation parameters, each (n_envs, n_bodies).
@@ -524,9 +525,8 @@ def pseudo_inertia(
   # Build U: (n_envs, n_bodies, 4, 4), upper triangular.
   U = _build_perturbation_U(alpha, d1, d2, d3, s12, s13, s23, t1, t2, t3)
 
-  # L_new = U @ L, broadcast over envs.
-  L_exp = L.unsqueeze(0).expand(n_envs, n_bodies, 4, 4)
-  L_new = torch.matmul(U, L_exp)  # (n_envs, n_bodies, 4, 4)
+  # L_new = U @ L.
+  L_new = torch.matmul(U, L)  # (n_envs, n_bodies, 4, 4)
 
   # New pseudo-inertia: J' = L_new @ L_newᵀ.
   J_new = torch.matmul(L_new, L_new.mT)  # (n_envs, n_bodies, 4, 4)

--- a/src/mjlab/scene/per_world_mesh.py
+++ b/src/mjlab/scene/per_world_mesh.py
@@ -254,12 +254,22 @@ def _populate_dependent_fields(
         spec_geoms[spec_idx].conaffinity = 0
         spec_geoms[spec_idx].mass = 0.0
 
+    # Reset every body that any variant marks as explicit-inertial. Variants
+    # without an explicit inertial fall back to MuJoCo's mesh-derived path
+    # during compile, so clear the diagonal inertial fields so prior
+    # iteration values cannot leak through. Do NOT assign ``body.fullinertia``
+    # here: any assignment (even zeros) flags the field as user-specified and
+    # spec.compile() then rejects it as conflicting with ``body.inertia``.
+    # ``_restore_body_state`` at the top of each iteration already restores
+    # fullinertia to its baseline.
     for body_name in variant_inertial_body_names:
       if body_name in body_name_to_spec_body:
         body = body_name_to_spec_body[body_name]
         body.explicitinertial = 0
         body.mass = 0.0
         body.inertia = np.zeros(3, dtype=np.float64)
+        body.ipos = np.zeros(3, dtype=np.float64)
+        body.iquat = np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float64)
 
     for entity_prefix, metadata in variant_info:
       variant_idx = int(world_to_variant[entity_prefix][first_world])

--- a/src/mjlab/scene/per_world_mesh.py
+++ b/src/mjlab/scene/per_world_mesh.py
@@ -15,7 +15,7 @@ import mujoco_warp as mjwarp
 import numpy as np
 import warp as wp
 
-from mjlab.entity.entity import VariantMetadata
+from mjlab.entity.entity import BodyInertialMetadata, VariantMetadata
 
 # Fields that depend on mesh geometry and must be compiled per-variant.
 VARIANT_DEPENDENT_FIELDS = (
@@ -165,7 +165,9 @@ def per_world_mesh(
   m.geom_dataid = wp.array(dataid_table, dtype=int)
 
   # Populate dependent per-world fields.
-  _populate_dependent_fields(m, spec, model, dataid_table, nworld, variant_info)
+  _populate_dependent_fields(
+    m, spec, model, dataid_table, nworld, variant_info, world_to_variant
+  )
 
   return PerWorldMeshResult(
     wp_model=m,
@@ -181,6 +183,7 @@ def _populate_dependent_fields(
   dataid_table: np.ndarray,
   nworld: int,
   variant_info: list[tuple[str, VariantMetadata]],
+  world_to_variant: dict[str, np.ndarray],
 ) -> None:
   """Compile each unique variant and write per-world dependent fields.
 
@@ -193,14 +196,31 @@ def _populate_dependent_fields(
     if key not in unique_rows:
       unique_rows[key] = w
 
-  if len(unique_rows) <= 1:
-    return  # All worlds identical, nothing to do.
-
   # Save spec geom state.
   spec_geoms = list(spec.geoms)
   saved: dict[int, tuple[str, int, int, float]] = {}
   for idx, g in enumerate(spec_geoms):
     saved[idx] = (g.meshname, g.contype, g.conaffinity, g.mass)
+
+  spec_bodies = list(spec.bodies)
+  body_name_to_spec_body = {b.name: b for b in spec_bodies if b.name}
+  saved_body_state = {
+    b.name: (
+      int(b.explicitinertial),
+      float(b.mass),
+      np.array(b.ipos, dtype=np.float64).copy(),
+      np.array(b.inertia, dtype=np.float64).copy(),
+      np.array(b.iquat, dtype=np.float64).copy(),
+      np.array(b.fullinertia, dtype=np.float64).copy(),
+    )
+    for b in spec_bodies
+    if b.name
+  }
+  variant_inertial_body_names: set[str] = set()
+  for entity_prefix, metadata in variant_info:
+    for variant_inertials in metadata.variant_body_inertials:
+      for inertial in variant_inertials:
+        variant_inertial_body_names.add(f"{entity_prefix}{inertial.body_name}")
 
   # Map geom IDs in padded_model to spec geom indices.
   geom_id_to_spec_idx: dict[int, int] = {}
@@ -218,6 +238,7 @@ def _populate_dependent_fields(
   # Compile each unique variant.
   compiled_variants: dict[tuple[int, ...], mujoco.MjModel] = {}
   for key, first_world in unique_rows.items():
+    _restore_body_state(body_name_to_spec_body, saved_body_state)
     for gid in all_variant_geom_ids:
       if gid not in geom_id_to_spec_idx:
         continue
@@ -232,6 +253,24 @@ def _populate_dependent_fields(
         spec_geoms[spec_idx].contype = 0
         spec_geoms[spec_idx].conaffinity = 0
         spec_geoms[spec_idx].mass = 0.0
+
+    for body_name in variant_inertial_body_names:
+      if body_name in body_name_to_spec_body:
+        body = body_name_to_spec_body[body_name]
+        body.explicitinertial = 0
+        body.mass = 0.0
+        body.inertia = np.zeros(3, dtype=np.float64)
+
+    for entity_prefix, metadata in variant_info:
+      variant_idx = int(world_to_variant[entity_prefix][first_world])
+      if variant_idx >= len(metadata.variant_body_inertials):
+        continue
+      for inertial in metadata.variant_body_inertials[variant_idx]:
+        _apply_body_inertial(
+          body_name_to_spec_body,
+          f"{entity_prefix}{inertial.body_name}",
+          inertial,
+        )
     compiled_variants[key] = spec.compile()
 
   # Restore spec state.
@@ -242,6 +281,7 @@ def _populate_dependent_fields(
       g.contype = contype
       g.conaffinity = conaffinity
       g.mass = mass
+  _restore_body_state(body_name_to_spec_body, saved_body_state)
 
   # Build per-world numpy arrays.
   ngeom = padded_model.ngeom
@@ -285,3 +325,38 @@ def _populate_dependent_fields(
   m.body_invweight0 = wp.array(body_invweight0, dtype=wp.vec2)
   m.body_ipos = wp.array(body_ipos, dtype=wp.vec3)
   m.body_iquat = wp.array(body_iquat, dtype=wp.quat)
+
+
+def _apply_body_inertial(
+  body_name_to_spec_body: dict[str, mujoco.MjsBody],
+  body_name: str,
+  inertial: BodyInertialMetadata,
+) -> None:
+  body = body_name_to_spec_body.get(body_name)
+  if body is None:
+    raise ValueError(f"Body '{body_name}' not found in compiled variant spec.")
+  body.explicitinertial = 1
+  body.mass = inertial.mass
+  body.ipos = np.asarray(inertial.ipos, dtype=np.float64)
+  body.inertia = np.asarray(inertial.inertia, dtype=np.float64)
+  body.iquat = np.asarray(inertial.iquat, dtype=np.float64)
+
+
+def _restore_body_state(
+  body_name_to_spec_body: dict[str, mujoco.MjsBody],
+  saved_body_state: dict[
+    str,
+    tuple[int, float, np.ndarray, np.ndarray, np.ndarray, np.ndarray],
+  ],
+) -> None:
+  for body_name, state in saved_body_state.items():
+    body = body_name_to_spec_body.get(body_name)
+    if body is None:
+      continue
+    explicitinertial, mass, ipos, inertia, iquat, fullinertia = state
+    body.explicitinertial = explicitinertial
+    body.mass = mass
+    body.ipos = ipos.copy()
+    body.inertia = inertia.copy()
+    body.iquat = iquat.copy()
+    body.fullinertia = fullinertia.copy()

--- a/src/mjlab/viewer/_model_sync.py
+++ b/src/mjlab/viewer/_model_sync.py
@@ -1,0 +1,80 @@
+"""Shared helpers for keeping a host-side ``MjModel`` consistent with
+``mjlab.sim.Sim.model`` when per-world fields (domain randomization or
+per-world mesh variants) diverge from the compiled XML.
+
+Used by the native / offscreen / viser viewers.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import mujoco
+
+# Inertial fields that shift ``subtree_com`` (and thus the tracking camera).
+INERTIAL_FIELDS = frozenset({"body_ipos", "body_mass"})
+
+# Fields that affect rendering. Physics-only fields (geom_aabb, geom_rbound,
+# dof_*, jnt_*, actuator_*, tendon_*, body_invweight0) are skipped.
+VISUAL_FIELDS = frozenset(
+  {
+    "qpos0",  # Needed for correct mj_forward kinematics (qpos - qpos0).
+    "geom_dataid",  # Per-world mesh variants.
+    "geom_rgba",
+    "geom_size",
+    "geom_pos",
+    "geom_quat",
+    "mat_rgba",
+    "site_pos",
+    "site_quat",
+    "body_pos",
+    "body_quat",
+    "body_ipos",
+    "body_inertia",
+    "body_iquat",
+    "body_mass",
+    # ``body_subtreemass`` is the denominator mj_forward uses to normalize
+    # ``subtree_com``. Without it, the ``mjVIS_COM`` decor geoms (and any
+    # code that reads ``data.subtree_com``) land at scaled/arbitrary
+    # positions when body_mass varies per-world.
+    "body_subtreemass",
+    "cam_pos",
+    "cam_quat",
+    "cam_fovy",
+    "cam_intrinsic",
+    "light_pos",
+    "light_dir",
+  }
+)
+
+
+def disable_model_sameframe_shortcuts(model: mujoco.MjModel) -> None:
+  """Force MuJoCo's host model down the full local-to-global transform path.
+
+  ``mujoco_warp`` does not implement MuJoCo's ``*_sameframe`` shortcuts: its
+  kinematics kernels always apply the full transform for inertial frames,
+  geoms, and sites. Clearing these compile-time flags on the CPU viewer model
+  keeps host-side ``mj_forward`` consistent with the GPU path when per-world
+  mesh variants change local offsets and frame alignments.
+  """
+  none = mujoco.mjtSameFrame.mjSAMEFRAME_NONE.value
+  model.body_sameframe[:] = none
+  model.geom_sameframe[:] = none
+  model.site_sameframe[:] = none
+  # ``body_simple`` is another compile-time shortcut derived from
+  # ``body_sameframe``. Clear it too so host-side inertia code does not
+  # assume the original compiled alignment.
+  model.body_simple[:] = 0
+
+
+def sync_visual_fields(
+  dst_model: mujoco.MjModel,
+  sim_model: Any,
+  expanded_fields: set[str] | frozenset[str],
+  env_idx: int,
+) -> None:
+  """Copy per-world visual fields from ``sim_model[env_idx]`` into ``dst_model``."""
+  for field_name in expanded_fields & VISUAL_FIELDS:
+    src = getattr(sim_model, field_name)[env_idx].cpu().numpy()
+    dst = getattr(dst_model, field_name)
+    dst[:] = src.reshape(dst.shape)

--- a/src/mjlab/viewer/native/viewer.py
+++ b/src/mjlab/viewer/native/viewer.py
@@ -52,6 +52,14 @@ import mujoco.viewer
 import numpy as np
 import torch
 
+from mjlab.viewer._model_sync import (
+  INERTIAL_FIELDS,
+  VISUAL_FIELDS,
+  sync_visual_fields,
+)
+from mjlab.viewer._model_sync import (
+  disable_model_sameframe_shortcuts as _disable_model_sameframe_shortcuts,
+)
 from mjlab.viewer.base import (
   BaseViewer,
   EnvProtocol,
@@ -110,25 +118,6 @@ class _SimProtocol(Protocol):
   data: _SimDataProtocol
   model: _SimModelProtocol
   expanded_fields: set[str]
-
-
-def _disable_model_sameframe_shortcuts(model: mujoco.MjModel) -> None:
-  """Force MuJoCo's host model down the full local-to-global transform path.
-
-  ``mujoco_warp`` does not implement MuJoCo's ``*_sameframe`` shortcuts: its
-  kinematics kernels always apply the full transform for inertial frames,
-  geoms, and sites. Clearing these compile-time flags on the CPU viewer model
-  keeps host-side ``mj_forward`` consistent with the GPU path when per-world
-  mesh variants change local offsets and frame alignments.
-  """
-  none = mujoco.mjtSameFrame.mjSAMEFRAME_NONE.value
-  model.body_sameframe[:] = none
-  model.geom_sameframe[:] = none
-  model.site_sameframe[:] = none
-  # ``body_simple`` is another compile-time shortcut derived from
-  # ``body_sameframe``. Clear it too so host-side inertia code does not assume
-  # the original compiled alignment.
-  model.body_simple[:] = 0
 
 
 class NativeMujocoViewer(BaseViewer):
@@ -249,10 +238,10 @@ class NativeMujocoViewer(BaseViewer):
 
       # Pin tracking camera to body frame origin so DR-induced COM shifts don't move
       # the camera.
-      if sim.expanded_fields & self._INERTIAL_FIELDS:
+      if sim.expanded_fields & INERTIAL_FIELDS:
         self._stabilize_tracking_camera()
 
-      has_visual_dr = bool(sim.expanded_fields & self._VISUAL_FIELDS)
+      has_visual_dr = bool(sim.expanded_fields & VISUAL_FIELDS)
       v.sync(state_only=not has_visual_dr)
 
   def _set_status_overlay(self, viewer: mujoco.viewer.Handle) -> None:
@@ -386,43 +375,10 @@ class NativeMujocoViewer(BaseViewer):
     # Restore main env's model fields.
     self._sync_model_fields(sim, self.env_idx)
 
-  # Inertial fields that shift subtree_com (and thus the tracking camera).
-  _INERTIAL_FIELDS = frozenset({"body_ipos", "body_mass"})
-
-  # Fields that affect rendering. Physics-only fields (geom_aabb,
-  # geom_rbound, dof_*, jnt_*, actuator_*, tendon_*, etc.) are skipped.
-  _VISUAL_FIELDS = frozenset(
-    {
-      "qpos0",  # Needed for correct mj_forward kinematics (qpos - qpos0).
-      "geom_dataid",  # Per-world mesh variants.
-      "geom_rgba",
-      "geom_size",
-      "geom_pos",
-      "geom_quat",
-      "mat_rgba",
-      "site_pos",
-      "site_quat",
-      "body_pos",
-      "body_quat",
-      "body_ipos",
-      "body_inertia",
-      "body_iquat",
-      "body_mass",
-      "cam_pos",
-      "cam_quat",
-      "cam_fovy",
-      "cam_intrinsic",
-      "light_pos",
-      "light_dir",
-    }
-  )
-
   def _sync_model_fields(self, sim: _SimProtocol, env_idx: int) -> None:
     """Sync visually-relevant DR'd model fields from GPU to MjModel."""
-    for field_name in sim.expanded_fields & self._VISUAL_FIELDS:
-      src = getattr(sim.model, field_name)[env_idx].cpu().numpy()
-      dst = getattr(self.mjm, field_name)
-      dst[:] = src.reshape(dst.shape)
+    assert self.mjm is not None
+    sync_visual_fields(self.mjm, sim.model, sim.expanded_fields, env_idx)
 
   def _stabilize_tracking_camera(self) -> None:
     """Pin the tracked body's subtree_com to its frame origin (xpos).

--- a/src/mjlab/viewer/offscreen_renderer.py
+++ b/src/mjlab/viewer/offscreen_renderer.py
@@ -6,16 +6,31 @@ import mujoco
 import numpy as np
 
 from mjlab.scene import Scene
+from mjlab.viewer._model_sync import (
+  disable_model_sameframe_shortcuts,
+  sync_visual_fields,
+)
 from mjlab.viewer.native.visualizer import MujocoNativeDebugVisualizer
 from mjlab.viewer.viewer_config import ViewerConfig
 
 
 class OffscreenRenderer:
-  def __init__(self, model: mujoco.MjModel, cfg: ViewerConfig, scene: Scene) -> None:
+  def __init__(
+    self,
+    model: mujoco.MjModel,
+    cfg: ViewerConfig,
+    scene: Scene,
+    sim_model: Any | None = None,
+    expanded_fields: set[str] | None = None,
+  ) -> None:
     self._cfg = cfg
     self._model = model
+    self._sim_model = sim_model
+    self._expanded_fields = expanded_fields
     self._data = mujoco.MjData(model)
     self._scene = scene
+    if self._sim_model is not None:
+      disable_model_sameframe_shortcuts(self._model)
     self._orig_extent = float(self._model.stat.extent)
     self._render_extent = self._compute_render_extent()
     # Keep extent override local to offscreen rendering so shadow/camera scaling
@@ -73,6 +88,7 @@ class OffscreenRenderer:
       return
 
     env_idx = max(0, min(int(self._cfg.env_idx), nworld - 1))
+    self._sync_model_fields(env_idx)
     if self._model.nq > 0:
       self._data.qpos[:] = data.qpos[env_idx].cpu().numpy()
       self._data.qvel[:] = data.qvel[env_idx].cpu().numpy()
@@ -93,6 +109,7 @@ class OffscreenRenderer:
 
     # Add nearest neighboring environments as geoms for context.
     for i in self._get_extra_env_ids(nworld, env_idx):
+      self._sync_model_fields(i)
       if self._model.nq > 0:
         self._data.qpos[:] = data.qpos[i].cpu().numpy()
         self._data.qvel[:] = data.qvel[i].cpu().numpy()
@@ -108,6 +125,8 @@ class OffscreenRenderer:
         self._catmask.value,
         self._renderer.scene,
       )
+
+    self._sync_model_fields(env_idx)
 
   def _get_extra_env_ids(self, nworld: int, env_idx: int) -> list[int]:
     """Return nearest neighboring env ids to render as context.
@@ -127,6 +146,12 @@ class OffscreenRenderer:
     nearest = np.argpartition(dist2, kth=k - 1)[:k]
     nearest = nearest[np.argsort(dist2[nearest])]
     return [int(i) for i in nearest]
+
+  def _sync_model_fields(self, env_idx: int) -> None:
+    """Sync visually relevant per-world model fields into the host MjModel."""
+    if self._sim_model is None or self._expanded_fields is None:
+      return
+    sync_visual_fields(self._model, self._sim_model, self._expanded_fields, env_idx)
 
   def render(self) -> np.ndarray:
     if self._renderer is None:

--- a/src/mjlab/viewer/viser/scene.py
+++ b/src/mjlab/viewer/viser/scene.py
@@ -150,6 +150,55 @@ class _VariantMeshGroup:
   mocap_ids: list[int] = field(default_factory=list)
 
 
+@dataclass
+class _PerWorldHullGroup:
+  """One convex-hull handle covering the envs that share a hull variant."""
+
+  handle: viser.BatchedMeshHandle
+  body_id: int
+  env_ids: np.ndarray
+
+
+def _compute_body_hull(
+  mj_model: mujoco.MjModel, geom_ids: list[int]
+) -> trimesh.Trimesh | None:
+  """Compute a merged convex hull for a body's mesh geoms.
+
+  Bypasses ``mjviser.merge_geoms_hull`` (which reads ``mesh_polynum`` and
+  returns ``None`` for any mesh that MuJoCo didn't compile polygon data for --
+  a situation that arises for later per-world-mesh variants). Uses the raw
+  ``mesh_vert`` / ``mesh_face`` arrays and trimesh's convex hull instead.
+  """
+  pieces: list[trimesh.Trimesh] = []
+  for geom_id in geom_ids:
+    if int(mj_model.geom_type[geom_id]) != int(mjtGeom.mjGEOM_MESH):
+      continue
+    mesh_id = int(mj_model.geom_dataid[geom_id])
+    if mesh_id < 0:
+      continue
+    vert_start = int(mj_model.mesh_vertadr[mesh_id])
+    vert_count = int(mj_model.mesh_vertnum[mesh_id])
+    if vert_count < 4:
+      continue
+    vertices = mj_model.mesh_vert[vert_start : vert_start + vert_count].copy()
+    try:
+      piece = trimesh.PointCloud(vertices).convex_hull
+    except Exception:
+      continue
+    transform = np.eye(4)
+    transform[:3, :3] = vtf.SO3(mj_model.geom_quat[geom_id]).as_matrix()
+    transform[:3, 3] = mj_model.geom_pos[geom_id]
+    piece.apply_transform(transform)
+    pieces.append(piece)
+  if not pieces:
+    return None
+  merged = pieces[0] if len(pieces) == 1 else trimesh.util.concatenate(pieces)
+  try:
+    return merged.convex_hull
+  except Exception:
+    return merged
+
+
 class MjlabViserScene(ViserMujocoScene, DebugVisualizer):
   """ViserMujocoScene with debug visualization and warp tensor conversion.
 
@@ -170,6 +219,10 @@ class MjlabViserScene(ViserMujocoScene, DebugVisualizer):
     self._use_per_world_mesh_groups = bool(
       self._expanded_fields & _GEOMETRY_HANDLE_FIELDS
     )
+    # Populated by _build_hull_handles when per-world variants are active.
+    # Initialized here because ViserMujocoScene.__init__ calls our overrides
+    # of _compute_hull_body_meshes / _build_hull_handles during super().__init__.
+    self._hull_per_world_groups: list[_PerWorldHullGroup] = []
     if self._sim_model is not None:
       sync_visual_fields(mj_model, self._sim_model, self._expanded_fields, 0)
       disable_model_sameframe_shortcuts(mj_model)
@@ -408,6 +461,153 @@ class MjlabViserScene(ViserMujocoScene, DebugVisualizer):
         )
 
   @override
+  def _compute_hull_body_meshes(self) -> None:
+    """Record hull-bearing bodies across all variants; meshes built lazily."""
+    if not self._use_per_world_mesh_groups:
+      super()._compute_hull_body_meshes()
+      return
+    # Upstream caches one merged hull per body from the current mj_model.
+    # With per-world variants each env can have a different set of active
+    # mesh slots, so the actual hulls are computed per-variant in
+    # _build_hull_handles. Here we just record which bodies carry mesh hulls
+    # in any env so mjviser's _sync_visibilities / _hull_hide_meshes logic
+    # still has the right body set.
+    self._hull_body_meshes = {}
+    hull_bodies: set[int] = set()
+    for env_idx in range(self.num_envs):
+      self._sync_model_fields(env_idx)
+      for geom_id in range(self.mj_model.ngeom):
+        if int(self.mj_model.geom_type[geom_id]) != int(mjtGeom.mjGEOM_MESH):
+          continue
+        if int(self.mj_model.geom_dataid[geom_id]) < 0:
+          continue
+        hull_bodies.add(int(self.mj_model.geom_bodyid[geom_id]))
+    self._sync_model_fields(self.env_idx)
+    self._hull_mesh_bodies = hull_bodies
+
+  @override
+  def _build_hull_handles(self) -> None:
+    """Build one batched hull handle per (body, variant) across envs."""
+    if not self._use_per_world_mesh_groups:
+      super()._build_hull_handles()
+      return
+
+    color = np.array(self._hull_color, dtype=np.uint8)
+    opacity = float(self._hull_opacity)
+
+    # Group envs by (body_id, hull fingerprint). Fingerprint captures the
+    # fields that merge_geoms_hull actually reads (geom_dataid + local
+    # geom_pos/quat), so any two envs with identical fingerprints share the
+    # same hull mesh in body-local space.
+    variants: dict[tuple[int, tuple], dict[str, Any]] = {}
+    fixed_hull_bodies: dict[int, list[int]] = {}
+
+    for env_idx in range(self.num_envs):
+      self._sync_model_fields(env_idx)
+      body_geoms: dict[int, list[int]] = {}
+      for geom_id in range(self.mj_model.ngeom):
+        if int(self.mj_model.geom_type[geom_id]) != int(mjtGeom.mjGEOM_MESH):
+          continue
+        if int(self.mj_model.geom_dataid[geom_id]) < 0:
+          continue
+        body_id = int(self.mj_model.geom_bodyid[geom_id])
+        body_geoms.setdefault(body_id, []).append(geom_id)
+
+      for body_id, geom_ids in body_geoms.items():
+        if is_fixed_body(self.mj_model, body_id):
+          # Fixed bodies don't need per-env batching; defer to upstream
+          # single-hull path using env_idx 0 (already the default).
+          if env_idx == 0:
+            fixed_hull_bodies[body_id] = geom_ids
+          continue
+        fingerprint = tuple(
+          (
+            int(self.mj_model.geom_dataid[gid]),
+            tuple(float(x) for x in self.mj_model.geom_pos[gid].round(6)),
+            tuple(float(x) for x in self.mj_model.geom_quat[gid].round(6)),
+          )
+          for gid in geom_ids
+        )
+        key = (body_id, fingerprint)
+        v = variants.get(key)
+        if v is None:
+          hull = _compute_body_hull(self.mj_model, geom_ids)
+          if hull is None:
+            continue
+          v = {
+            "body_id": body_id,
+            "vertices": hull.vertices.astype(np.float32),
+            "faces": hull.faces.astype(np.int32),
+            "env_ids": [],
+          }
+          variants[key] = v
+        v["env_ids"].append(env_idx)
+
+    # Fixed bodies: build one hull handle each (same body-local mesh for all
+    # envs since the body is welded). Uses env 0's synced state which is the
+    # default after the loop below.
+    self._sync_model_fields(self.env_idx)
+    for body_id, geom_ids in fixed_hull_bodies.items():
+      hull = _compute_body_hull(self.mj_model, geom_ids)
+      if hull is None:
+        continue
+      body = self.mj_model.body(body_id)
+      fixed_opacities = (
+        None if opacity >= 1.0 else np.array([opacity], dtype=np.float32)
+      )
+      handle = self.server.scene.add_batched_meshes_simple(
+        f"/fixed_bodies/hull/{body_id}",
+        hull.vertices.astype(np.float32),
+        hull.faces.astype(np.int32),
+        batched_wxyzs=np.array([[1.0, 0.0, 0.0, 0.0]], dtype=np.float32),
+        batched_positions=np.zeros((1, 3), dtype=np.float32),
+        batched_colors=color[None],
+        batched_opacities=fixed_opacities,
+        position=body.pos,
+        wxyz=body.quat,
+        visible=self._show_convex_hull,
+        cast_shadow=False,
+        receive_shadow=False,
+        lod="off",
+      )
+      self._hull_fixed_handles[body_id] = handle
+
+    self._hull_dynamic_handles = []
+    self._hull_per_world_groups = []
+    for variant_idx, ((body_id, _fp), v) in enumerate(variants.items()):
+      env_ids = np.asarray(v["env_ids"], dtype=np.int32)
+      batch_count = int(env_ids.size)
+      dynamic_opacities = (
+        None if opacity >= 1.0 else np.full(batch_count, opacity, dtype=np.float32)
+      )
+      handle = self.server.scene.add_batched_meshes_simple(
+        f"/hull/{body_id}/variant{variant_idx}",
+        v["vertices"],
+        v["faces"],
+        batched_wxyzs=np.tile([1.0, 0.0, 0.0, 0.0], (batch_count, 1)).astype(
+          np.float32
+        ),
+        batched_positions=np.zeros((batch_count, 3), dtype=np.float32),
+        batched_colors=np.tile(color, (batch_count, 1)),
+        batched_opacities=dynamic_opacities,
+        visible=self._show_convex_hull,
+        cast_shadow=False,
+        receive_shadow=False,
+        lod="off",
+      )
+      self._hull_per_world_groups.append(
+        _PerWorldHullGroup(handle=handle, body_id=body_id, env_ids=env_ids)
+      )
+      # Also register in the upstream list so show_convex_hull.setter and
+      # any other base-class consumer still see every dynamic hull handle.
+      self._hull_dynamic_handles.append((handle, body_id))
+
+  @override
+  def _clear_hull_handles(self) -> None:
+    super()._clear_hull_handles()
+    self._hull_per_world_groups = []
+
+  @override
   def _update_visualization_locked(
     self,
     body_xpos: np.ndarray,
@@ -501,14 +701,22 @@ class MjlabViserScene(ViserMujocoScene, DebugVisualizer):
         handle.batched_wxyzs = quat
 
       if self._show_convex_hull:
-        for handle, body_id in self._hull_dynamic_handles:
-          if not handle.visible:
+        for hg in self._hull_per_world_groups:
+          env_ids = hg.env_ids
+          body_id = hg.body_id
+          if slice_single:
+            mask = env_ids == env_idx
+            if not np.any(mask):
+              hg.handle.visible = False
+              continue
+            env_ids = env_ids[mask]
+          elif not hg.handle.visible:
             continue
-          pos, quat = self._batched_transform(
-            body_xpos, body_xquat, body_id, env_idx, scene_offset, slice_single
-          )
-          handle.batched_positions = pos
-          handle.batched_wxyzs = quat
+          pos = body_xpos[env_ids, body_id] + scene_offset
+          quat = body_xquat[env_ids, body_id]
+          hg.handle.batched_positions = pos
+          hg.handle.batched_wxyzs = quat
+          hg.handle.visible = True
 
       if self._any_decor_visible() and mj_data is not None:
         self._update_decor_from_mjvscene(mj_data, scene_offset)

--- a/src/mjlab/viewer/viser/scene.py
+++ b/src/mjlab/viewer/viser/scene.py
@@ -710,8 +710,6 @@ class MjlabViserScene(ViserMujocoScene, DebugVisualizer):
               hg.handle.visible = False
               continue
             env_ids = env_ids[mask]
-          elif not hg.handle.visible:
-            continue
           pos = body_xpos[env_ids, body_id] + scene_offset
           quat = body_xquat[env_ids, body_id]
           hg.handle.batched_positions = pos

--- a/src/mjlab/viewer/viser/scene.py
+++ b/src/mjlab/viewer/viser/scene.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from typing import Any
 
 import mujoco
 import numpy as np
@@ -14,15 +15,33 @@ import viser.transforms as vtf
 from mjviser import ViserMujocoScene
 from mjviser.conversions import (
   create_primitive_mesh,
+  get_body_name,
+  group_geoms_by_visual_compat,
+  is_fixed_body,
+  merge_geoms,
   mujoco_mesh_to_trimesh,
 )
 from mujoco import mjtGeom
 from typing_extensions import override
 
+from mjlab.viewer._model_sync import (
+  disable_model_sameframe_shortcuts,
+  sync_visual_fields,
+)
 from mjlab.viewer.debug_visualizer import DebugVisualizer
 
 _Z_AXIS = np.array([0.0, 0.0, 1.0])
 _IDENTITY_QUAT = np.array([1.0, 0.0, 0.0, 0.0])
+_GEOMETRY_HANDLE_FIELDS = frozenset(
+  {
+    "geom_dataid",
+    "geom_rgba",
+    "geom_size",
+    "geom_pos",
+    "geom_quat",
+    "mat_rgba",
+  }
+)
 
 
 def _rotation_quat(from_vec: np.ndarray, to_vec: np.ndarray) -> np.ndarray:
@@ -110,6 +129,27 @@ class _BatchedPrimitive:
       self.handle.batched_colors = colors
 
 
+@dataclass
+class _PerWorldMeshGroup:
+  handle: viser.BatchedGlbHandle
+  body_ids: np.ndarray
+  group_id: int
+  mocap_ids: np.ndarray | None
+  env_ids: np.ndarray
+
+
+@dataclass
+class _VariantMeshGroup:
+  mesh: trimesh.Trimesh
+  group_id: int
+  sub_idx: int
+  body_name: str
+  is_mocap: bool
+  env_ids: list[int] = field(default_factory=list)
+  body_ids: list[int] = field(default_factory=list)
+  mocap_ids: list[int] = field(default_factory=list)
+
+
 class MjlabViserScene(ViserMujocoScene, DebugVisualizer):
   """ViserMujocoScene with debug visualization and warp tensor conversion.
 
@@ -122,7 +162,17 @@ class MjlabViserScene(ViserMujocoScene, DebugVisualizer):
     server: viser.ViserServer,
     mj_model: mujoco.MjModel,
     num_envs: int,
+    sim_model: Any | None = None,
+    expanded_fields: set[str] | None = None,
   ) -> None:
+    self._sim_model = sim_model
+    self._expanded_fields = expanded_fields or set()
+    self._use_per_world_mesh_groups = bool(
+      self._expanded_fields & _GEOMETRY_HANDLE_FIELDS
+    )
+    if self._sim_model is not None:
+      sync_visual_fields(mj_model, self._sim_model, self._expanded_fields, 0)
+      disable_model_sameframe_shortcuts(mj_model)
     super().__init__(server, mj_model, num_envs)
 
     self.debug_visualization_enabled = False
@@ -226,6 +276,9 @@ class MjlabViserScene(ViserMujocoScene, DebugVisualizer):
     ctrl: np.ndarray | None = None,
   ) -> None:
     """Update scene and sync debug visualizations."""
+    if env_idx is None:
+      env_idx = self.env_idx
+    self._sync_model_fields(env_idx)
     super().update_from_arrays(
       body_xpos,
       body_xmat,
@@ -241,8 +294,228 @@ class MjlabViserScene(ViserMujocoScene, DebugVisualizer):
   @override
   def update_from_mjdata(self, mj_data: mujoco.MjData) -> None:
     """Update scene and sync debug visualizations."""
+    self._sync_model_fields(self.env_idx)
     super().update_from_mjdata(mj_data)
     self._sync_debug_visualizations(self._scene_offset)
+
+  def _sync_model_fields(self, env_idx: int) -> None:
+    """Sync visually relevant per-world model fields into the host MjModel."""
+    if self._sim_model is None:
+      return
+    sync_visual_fields(self.mj_model, self._sim_model, self._expanded_fields, env_idx)
+
+  @staticmethod
+  def _geom_subgroup_visual_fingerprint(
+    mj_model: mujoco.MjModel, geom_ids: list[int], is_mocap: bool
+  ) -> tuple[object, ...]:
+    parts: list[tuple[object, ...]] = []
+    for geom_id in geom_ids:
+      mat_id = int(mj_model.geom_matid[geom_id])
+      mat_rgba = (
+        tuple(mj_model.mat_rgba[mat_id].round(4).tolist()) if mat_id >= 0 else None
+      )
+      parts.append(
+        (
+          int(mj_model.geom_type[geom_id]),
+          int(mj_model.geom_dataid[geom_id]),
+          mat_id,
+          mat_rgba,
+          tuple(mj_model.geom_size[geom_id].round(6).tolist()),
+          tuple(mj_model.geom_rgba[geom_id].round(4).tolist()),
+          tuple(mj_model.geom_pos[geom_id].round(6).tolist()),
+          tuple(mj_model.geom_quat[geom_id].round(6).tolist()),
+        )
+      )
+    return (is_mocap, tuple(sorted(parts)))
+
+  @override
+  def _create_mesh_handles_by_group(self) -> None:
+    """Create dynamic mesh handles, respecting per-world mesh variants."""
+    if not self._use_per_world_mesh_groups:
+      super()._create_mesh_handles_by_group()
+      return
+
+    variants: dict[tuple[object, ...], _VariantMeshGroup] = {}
+    for env_idx in range(self.num_envs):
+      self._sync_model_fields(env_idx)
+      body_group_geoms: dict[tuple[int, int], list[int]] = {}
+      for geom_id in range(self.mj_model.ngeom):
+        body_id = int(self.mj_model.geom_bodyid[geom_id])
+        if is_fixed_body(self.mj_model, body_id):
+          continue
+        if self.mj_model.geom_rgba[geom_id, 3] == 0:
+          continue
+        if (
+          int(self.mj_model.geom_type[geom_id]) == int(mjtGeom.mjGEOM_MESH)
+          and int(self.mj_model.geom_dataid[geom_id]) < 0
+        ):
+          continue
+        group_id = int(self.mj_model.geom_group[geom_id])
+        body_group_geoms.setdefault((body_id, group_id), []).append(geom_id)
+
+      for (body_id, group_id), geom_ids in body_group_geoms.items():
+        subgroups = group_geoms_by_visual_compat(self.mj_model, geom_ids)
+        is_mocap = bool(self.mj_model.body_mocapid[body_id] >= 0)
+        for sub_idx, sub_geom_ids in enumerate(subgroups):
+          fp = self._geom_subgroup_visual_fingerprint(
+            self.mj_model, sub_geom_ids, is_mocap
+          )
+          key = (fp, group_id, sub_idx)
+          variant = variants.get(key)
+          if variant is None:
+            variant = _VariantMeshGroup(
+              mesh=merge_geoms(self.mj_model, sub_geom_ids),
+              group_id=group_id,
+              sub_idx=sub_idx,
+              body_name=get_body_name(self.mj_model, body_id),
+              is_mocap=is_mocap,
+            )
+            variants[key] = variant
+          variant.env_ids.append(env_idx)
+          variant.body_ids.append(body_id)
+          if is_mocap:
+            variant.mocap_ids.append(int(self.mj_model.body_mocapid[body_id]))
+
+    self._sync_model_fields(self.env_idx)
+    with self.server.atomic():
+      for variant_idx, variant in enumerate(variants.values()):
+        batch_count = len(variant.env_ids)
+        lod_ratio = 1000.0 / variant.mesh.vertices.shape[0]
+        suffix = f"/sub{variant.sub_idx}" if variant.sub_idx > 0 else ""
+        visible = variant.group_id < 6 and self.geom_groups_visible[variant.group_id]
+
+        handle = self.server.scene.add_batched_meshes_trimesh(
+          f"/bodies/{variant.body_name}/group{variant.group_id}"
+          f"/variant{variant_idx}{suffix}",
+          variant.mesh,
+          batched_wxyzs=np.tile([1.0, 0.0, 0.0, 0.0], (batch_count, 1)),
+          batched_positions=np.zeros((batch_count, 3)),
+          lod=((2.0, lod_ratio),) if lod_ratio < 0.5 else "off",
+          visible=visible,
+        )
+        self._mesh_groups.append(
+          _PerWorldMeshGroup(
+            handle=handle,
+            body_ids=np.asarray(variant.body_ids, dtype=np.int32),
+            group_id=variant.group_id,
+            mocap_ids=(
+              np.asarray(variant.mocap_ids, dtype=np.int32)
+              if variant.is_mocap
+              else None
+            ),
+            env_ids=np.asarray(variant.env_ids, dtype=np.int32),
+          )
+        )
+
+  @override
+  def _update_visualization_locked(
+    self,
+    body_xpos: np.ndarray,
+    body_xmat: np.ndarray,
+    mocap_pos: np.ndarray,
+    mocap_quat: np.ndarray,
+    env_idx: int,
+    scene_offset: np.ndarray,
+    mj_data: mujoco.MjData | None = None,
+  ) -> None:
+    if not self._use_per_world_mesh_groups:
+      super()._update_visualization_locked(
+        body_xpos, body_xmat, mocap_pos, mocap_quat, env_idx, scene_offset, mj_data
+      )
+      return
+
+    self._last_body_xpos = body_xpos
+    self._last_body_xmat = body_xmat
+    self._last_mocap_pos = mocap_pos
+    self._last_mocap_quat = mocap_quat
+    self._last_env_idx = env_idx
+    self._scene_offset = scene_offset
+    if mj_data is not None:
+      self._last_mj_data = mj_data
+
+    self.fixed_bodies_frame.position = scene_offset
+    slice_single = self.show_only_selected and self.num_envs > 1
+    hidden_bodies: set[int] = set()
+    if self._show_convex_hull and self._hull_hide_meshes:
+      hidden_bodies = self._hull_mesh_bodies
+    if (
+      self._mjv_option.flags[mujoco.mjtVisFlag.mjVIS_AUTOCONNECT]
+      and self._autoconnect_hide_meshes
+    ):
+      hidden_bodies |= set(range(self.mj_model.nbody))
+
+    with self.server.atomic():
+      body_xquat = vtf.SO3.from_matrix(body_xmat).wxyz
+      for mg in self._mesh_groups:
+        if isinstance(mg, _PerWorldMeshGroup):
+          visible = mg.group_id < 6 and self.geom_groups_visible[mg.group_id]
+          if visible and any(body_id in hidden_bodies for body_id in mg.body_ids):
+            visible = False
+          if not visible:
+            mg.handle.visible = False
+            continue
+
+          env_ids = mg.env_ids
+          body_ids = mg.body_ids
+          mocap_ids = mg.mocap_ids
+          if slice_single:
+            mask = env_ids == env_idx
+            if not np.any(mask):
+              mg.handle.visible = False
+              continue
+            env_ids = env_ids[mask]
+            body_ids = body_ids[mask]
+            if mocap_ids is not None:
+              mocap_ids = mocap_ids[mask]
+          if mocap_ids is not None:
+            pos = mocap_pos[env_ids, mocap_ids] + scene_offset
+            quat = mocap_quat[env_ids, mocap_ids]
+          else:
+            pos = body_xpos[env_ids, body_ids] + scene_offset
+            quat = body_xquat[env_ids, body_ids]
+          mg.handle.batched_positions = pos
+          mg.handle.batched_wxyzs = quat
+          mg.handle.visible = True
+          continue
+
+        if not mg.handle.visible:
+          continue
+        if mg.mocap_ids is not None:
+          pos, quat = self._batched_transform_group(
+            mocap_pos, mocap_quat, mg.mocap_ids, env_idx, scene_offset, slice_single
+          )
+        else:
+          pos, quat = self._batched_transform_group(
+            body_xpos, body_xquat, mg.body_ids, env_idx, scene_offset, slice_single
+          )
+        mg.handle.batched_positions = pos
+        mg.handle.batched_wxyzs = quat
+
+      for (body_id, _), handle in self.site_handles_by_group.items():
+        if not handle.visible:
+          continue
+        pos, quat = self._batched_transform(
+          body_xpos, body_xquat, body_id, env_idx, scene_offset, slice_single
+        )
+        handle.batched_positions = pos
+        handle.batched_wxyzs = quat
+
+      if self._show_convex_hull:
+        for handle, body_id in self._hull_dynamic_handles:
+          if not handle.visible:
+            continue
+          pos, quat = self._batched_transform(
+            body_xpos, body_xquat, body_id, env_idx, scene_offset, slice_single
+          )
+          handle.batched_positions = pos
+          handle.batched_wxyzs = quat
+
+      if self._any_decor_visible() and mj_data is not None:
+        self._update_decor_from_mjvscene(mj_data, scene_offset)
+      elif not self._any_decor_visible():
+        self._clear_decor_handles()
+
+      self.server.flush()
 
   # Refresh.
 

--- a/src/mjlab/viewer/viser/viewer.py
+++ b/src/mjlab/viewer/viser/viewer.py
@@ -76,6 +76,8 @@ class ViserPlayViewer(BaseViewer):
       server=self._server,
       mj_model=sim.mj_model,
       num_envs=self.env.num_envs,
+      sim_model=sim.model,
+      expanded_fields=sim.expanded_fields,
     )
 
     self._scene.env_idx = self.cfg.env_idx

--- a/tests/test_per_world_mesh.py
+++ b/tests/test_per_world_mesh.py
@@ -8,7 +8,7 @@ import pytest
 
 from mjlab.entity import EntityCfg, VariantCfg, VariantEntityCfg
 from mjlab.scene.per_world_mesh import allocate_worlds
-from mjlab.viewer.native.viewer import _disable_model_sameframe_shortcuts
+from mjlab.viewer._model_sync import disable_model_sameframe_shortcuts
 
 # ---------------------------------------------------------------------------
 # Helpers: variant specs with visual + collision mesh geoms.
@@ -316,6 +316,194 @@ def test_dependent_fields_match_individual_compilation():
   assert not np.isclose(body_mass[sphere_w, obj_body], body_mass[cone_w, obj_body])
 
 
+def test_select_default_values_uses_per_world_variant_defaults():
+  """Per-world defaults are indexed by env first, then by entity."""
+  import torch
+
+  from mjlab.envs import ManagerBasedRlEnv, ManagerBasedRlEnvCfg
+  from mjlab.envs.mdp.dr._core import _select_default_values
+  from mjlab.scene import SceneCfg
+  from mjlab.terrains import TerrainEntityCfg
+
+  def _explicit_variant(
+    mesh_name: str,
+    mass: float,
+    inertia: tuple[float, float, float],
+    *,
+    cone: bool = False,
+  ) -> mujoco.MjSpec:
+    spec = mujoco.MjSpec()
+    mesh = spec.add_mesh()
+    mesh.name = mesh_name
+    if cone:
+      mesh.make_cone(nedge=8, radius=0.05)
+    else:
+      mesh.make_sphere(subdivision=1)
+    body = spec.worldbody.add_body(name="prop")
+    body.add_freejoint()
+    body.explicitinertial = 1
+    body.mass = mass
+    body.ipos = (0.0, 0.0, 0.0)
+    body.inertia = inertia
+    body.iquat = (1.0, 0.0, 0.0, 0.0)
+    body.add_geom(
+      name="visual",
+      type=mujoco.mjtGeom.mjGEOM_MESH,
+      meshname=mesh_name,
+      contype=0,
+      conaffinity=0,
+      mass=0.0,
+    )
+    return spec
+
+  object_cfg = VariantEntityCfg(
+    variants={
+      "sphere": VariantCfg(
+        lambda: _explicit_variant("sphere", 0.2, (1e-4, 2e-4, 3e-4)),
+        weight=0.5,
+      ),
+      "cone": VariantCfg(
+        lambda: _explicit_variant("cone", 0.7, (4e-4, 5e-4, 6e-4), cone=True),
+        weight=0.5,
+      ),
+    },
+    init_state=EntityCfg.InitialStateCfg(pos=(0.0, 0.0, 0.2)),
+  )
+  env_cfg = ManagerBasedRlEnvCfg(
+    decimation=1,
+    scene=SceneCfg(
+      terrain=TerrainEntityCfg(terrain_type="plane"),
+      num_envs=4,
+      env_spacing=1.0,
+      entities={"object": object_cfg},
+    ),
+  )
+
+  env = ManagerBasedRlEnv(cfg=env_cfg, device="cpu")
+  try:
+    obj_body = int(env.scene["object"].indexing.root_body_id)
+    env_ids = torch.arange(env.num_envs, device=env.device)
+    body_ids = torch.tensor([obj_body], device=env.device)
+
+    for field in ("body_mass", "body_ipos", "body_inertia", "body_iquat"):
+      selected = _select_default_values(env, field, env_ids, body_ids)
+      torch.testing.assert_close(
+        selected[:, 0],
+        getattr(env.sim.model, field)[:, obj_body],
+      )
+  finally:
+    env.close()
+
+
+def test_viser_builds_per_world_mesh_handles_for_variants():
+  """Viser dynamic meshes must not collapse all worlds onto env0's mesh."""
+  from contextlib import nullcontext
+
+  from mjlab.envs import ManagerBasedRlEnv, ManagerBasedRlEnvCfg
+  from mjlab.scene import SceneCfg
+  from mjlab.terrains import TerrainEntityCfg
+  from mjlab.viewer.viser.scene import MjlabViserScene, _PerWorldMeshGroup
+
+  class _Handle:
+    def __init__(self, **kwargs):
+      self.visible = kwargs.get("visible", True)
+      self.batched_positions = kwargs.get("batched_positions", np.zeros((0, 3)))
+      self.batched_wxyzs = kwargs.get("batched_wxyzs", np.zeros((0, 4)))
+      self.batched_scales = kwargs.get("batched_scales")
+      self.batched_colors = kwargs.get("batched_colors")
+      self.batched_opacities = kwargs.get("batched_opacities")
+      self.position = kwargs.get("position", np.zeros(3))
+      self.wxyz = kwargs.get("wxyz", np.array([1.0, 0.0, 0.0, 0.0]))
+
+    def remove(self) -> None:
+      pass
+
+  class _Scene:
+    def __init__(self):
+      self.batched: list[tuple[tuple, dict, _Handle]] = []
+
+    def configure_environment_map(self, **_kwargs) -> None:
+      pass
+
+    def add_frame(self, *_args, **kwargs) -> _Handle:
+      return _Handle(**kwargs)
+
+    def add_grid(self, *_args, **kwargs) -> _Handle:
+      return _Handle(**kwargs)
+
+    def add_mesh_trimesh(self, *_args, **kwargs) -> _Handle:
+      return _Handle(**kwargs)
+
+    def add_batched_meshes_trimesh(self, *args, **kwargs) -> _Handle:
+      handle = _Handle(**kwargs)
+      self.batched.append((args, kwargs, handle))
+      return handle
+
+    def add_batched_meshes_simple(self, *args, **kwargs) -> _Handle:
+      handle = _Handle(**kwargs)
+      self.batched.append((args, kwargs, handle))
+      return handle
+
+  class _Server:
+    def __init__(self):
+      self.scene = _Scene()
+
+    def atomic(self):
+      return nullcontext()
+
+    def flush(self) -> None:
+      pass
+
+  env_cfg = ManagerBasedRlEnvCfg(
+    decimation=1,
+    scene=SceneCfg(
+      terrain=TerrainEntityCfg(terrain_type="plane"),
+      num_envs=4,
+      env_spacing=1.0,
+      entities={
+        "object": VariantEntityCfg(
+          variants={
+            "sphere": VariantCfg(_simple_sphere_spec, weight=0.5),
+            "cone": VariantCfg(_simple_cone_spec, weight=0.5),
+          },
+          init_state=EntityCfg.InitialStateCfg(pos=(0.0, 0.0, 0.2)),
+        )
+      },
+    ),
+  )
+
+  env = ManagerBasedRlEnv(cfg=env_cfg, device="cpu")
+  try:
+    server = _Server()
+    scene = MjlabViserScene(
+      server,
+      env.sim.mj_model,
+      env.num_envs,
+      sim_model=env.sim.model,
+      expanded_fields=env.sim.expanded_fields,
+    )
+    groups = [mg for mg in scene._mesh_groups if isinstance(mg, _PerWorldMeshGroup)]
+
+    assert groups
+    assert sum(len(mg.env_ids) for mg in groups) >= env.num_envs
+
+    body_xpos = env.sim.data.xpos.cpu().numpy()
+    body_xmat = env.sim.data.xmat.cpu().numpy()
+    mocap_pos = (
+      env.sim.data.mocap_pos.cpu().numpy() if env.sim.mj_model.nmocap > 0 else None
+    )
+    mocap_quat = (
+      env.sim.data.mocap_quat.cpu().numpy() if env.sim.mj_model.nmocap > 0 else None
+    )
+    scene.show_only_selected = True
+    scene.update_from_arrays(body_xpos, body_xmat, mocap_pos, mocap_quat, env_idx=0)
+    scene.update_from_arrays(body_xpos, body_xmat, mocap_pos, mocap_quat, env_idx=1)
+
+    assert any(mg.handle.visible for mg in groups)
+  finally:
+    env.close()
+
+
 # ---------------------------------------------------------------------------
 # Full env lifecycle
 # ---------------------------------------------------------------------------
@@ -440,6 +628,6 @@ def test_sameframe_fix_makes_host_forward_match_variant():
   assert not np.allclose(base_data.geom_xpos, cone_data.geom_xpos)
 
   # After fix: clearing sameframe makes them match.
-  _disable_model_sameframe_shortcuts(base_model)
+  disable_model_sameframe_shortcuts(base_model)
   mujoco.mj_forward(base_model, base_data)
   np.testing.assert_allclose(base_data.geom_xpos, cone_data.geom_xpos, atol=1e-6)

--- a/tests/test_per_world_mesh.py
+++ b/tests/test_per_world_mesh.py
@@ -276,6 +276,13 @@ def test_padding_slots_get_disabled():
   # Last 2 mesh geom slots should be -1 (disabled padding).
   assert sphere_dataid[-1] == -1
   assert sphere_dataid[-2] == -1
+  # Padding slots must still be collision-enabled in the template/warp model.
+  # Short variants are disabled by per-world dataid=-1; long variants need the
+  # same slots enabled so their extra hulls can collide.
+  assert np.all(result.mj_model.geom_contype[mesh_geom_ids[-2:]] == 1)
+  assert np.all(result.mj_model.geom_conaffinity[mesh_geom_ids[-2:]] == 1)
+  assert np.all(result.wp_model.geom_contype.numpy()[mesh_geom_ids[-2:]] == 1)
+  assert np.all(result.wp_model.geom_conaffinity.numpy()[mesh_geom_ids[-2:]] == 1)
   # First 3 should be valid (>= 0).
   assert all(d >= 0 for d in sphere_dataid[:3])
 
@@ -620,6 +627,10 @@ def test_viser_convex_hulls_are_per_variant():
       assert len(visible_groups) == 1
       assert target_env in visible_groups[0].env_ids
       assert visible_groups[0].handle.batched_positions.shape[0] == 1
+
+    scene.show_only_selected = False
+    scene.update_from_arrays(body_xpos, body_xmat, env_idx=0)
+    assert all(g.handle.visible for g in groups)
   finally:
     env.close()
 

--- a/tests/test_per_world_mesh.py
+++ b/tests/test_per_world_mesh.py
@@ -504,6 +504,126 @@ def test_viser_builds_per_world_mesh_handles_for_variants():
     env.close()
 
 
+def test_viser_convex_hulls_are_per_variant():
+  """Convex-hull handles must differ across variants, not all show env0's hull."""
+  from contextlib import nullcontext
+
+  from mjlab.envs import ManagerBasedRlEnv, ManagerBasedRlEnvCfg
+  from mjlab.scene import SceneCfg
+  from mjlab.terrains import TerrainEntityCfg
+  from mjlab.viewer.viser.scene import MjlabViserScene, _PerWorldHullGroup
+
+  class _Handle:
+    def __init__(self, **kwargs):
+      self.visible = kwargs.get("visible", True)
+      self.batched_positions = kwargs.get("batched_positions", np.zeros((0, 3)))
+      self.batched_wxyzs = kwargs.get("batched_wxyzs", np.zeros((0, 4)))
+      self.batched_scales = kwargs.get("batched_scales")
+      self.batched_colors = kwargs.get("batched_colors")
+      self.batched_opacities = kwargs.get("batched_opacities")
+      self.position = kwargs.get("position", np.zeros(3))
+      self.wxyz = kwargs.get("wxyz", np.array([1.0, 0.0, 0.0, 0.0]))
+      self.vertices = kwargs.get("vertices")
+      self.faces = kwargs.get("faces")
+
+    def remove(self) -> None:
+      pass
+
+  class _Scene:
+    def __init__(self):
+      self.batched: list[tuple[tuple, dict, _Handle]] = []
+
+    def configure_environment_map(self, **_kwargs) -> None:
+      pass
+
+    def add_frame(self, *_args, **kwargs) -> _Handle:
+      return _Handle(**kwargs)
+
+    def add_grid(self, *_args, **kwargs) -> _Handle:
+      return _Handle(**kwargs)
+
+    def add_mesh_trimesh(self, *_args, **kwargs) -> _Handle:
+      return _Handle(**kwargs)
+
+    def add_batched_meshes_trimesh(self, *args, **kwargs) -> _Handle:
+      handle = _Handle(**kwargs)
+      self.batched.append((args, kwargs, handle))
+      return handle
+
+    def add_batched_meshes_simple(self, path, vertices, faces, **kwargs) -> _Handle:
+      # Capture the mesh identity so the test can compare hull shapes.
+      kwargs = dict(kwargs)
+      kwargs["vertices"] = np.asarray(vertices)
+      kwargs["faces"] = np.asarray(faces)
+      handle = _Handle(**kwargs)
+      self.batched.append(((path,), kwargs, handle))
+      return handle
+
+  class _Server:
+    def __init__(self):
+      self.scene = _Scene()
+
+    def atomic(self):
+      return nullcontext()
+
+    def flush(self) -> None:
+      pass
+
+  # Sphere and cone produce visibly different convex hulls.
+  env_cfg = ManagerBasedRlEnvCfg(
+    decimation=1,
+    scene=SceneCfg(
+      terrain=TerrainEntityCfg(terrain_type="plane"),
+      num_envs=4,
+      env_spacing=1.0,
+      entities={
+        "object": VariantEntityCfg(
+          variants={
+            "sphere": VariantCfg(_simple_sphere_spec, weight=0.5),
+            "cone": VariantCfg(_simple_cone_spec, weight=0.5),
+          },
+          init_state=EntityCfg.InitialStateCfg(pos=(0.0, 0.0, 0.2)),
+        )
+      },
+    ),
+  )
+
+  env = ManagerBasedRlEnv(cfg=env_cfg, device="cpu")
+  try:
+    server = _Server()
+    scene = MjlabViserScene(
+      server,
+      env.sim.mj_model,
+      env.num_envs,
+      sim_model=env.sim.model,
+      expanded_fields=env.sim.expanded_fields,
+    )
+    groups: list[_PerWorldHullGroup] = list(scene._hull_per_world_groups)
+    # Two distinct variants -> at least two hull handles on the same body.
+    assert len(groups) >= 2, f"expected >=2 hull variants, got {len(groups)}"
+    all_envs = np.concatenate([g.env_ids for g in groups])
+    assert sorted(all_envs.tolist()) == list(range(env.num_envs))
+    # Hulls must be shape-distinct, not all copies of env0's hull.
+    shapes = {(g.handle.vertices.shape, g.handle.faces.shape) for g in groups}
+    assert len(shapes) >= 2, (
+      f"hull variants collapsed to one shape: {shapes} "
+      "(all envs would share env0's hull)"
+    )
+
+    body_xpos = env.sim.data.xpos.cpu().numpy()
+    body_xmat = env.sim.data.xmat.cpu().numpy()
+    scene.show_convex_hull = True
+    scene.show_only_selected = True
+    for target_env in range(env.num_envs):
+      scene.update_from_arrays(body_xpos, body_xmat, env_idx=target_env)
+      visible_groups = [g for g in groups if g.handle.visible]
+      assert len(visible_groups) == 1
+      assert target_env in visible_groups[0].env_ids
+      assert visible_groups[0].handle.batched_positions.shape[0] == 1
+  finally:
+    env.close()
+
+
 # ---------------------------------------------------------------------------
 # Full env lifecycle
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
  Summary                                                         
         
  Builds on per-world-mesh to (1) let mesh variants carry their own explicit body inertials through per-world compilation, and (2) fix two bugs that per-world variants exposed: domain randomization reading defaults with the wrong index convention, and both the
  native/offscreen/viser viewers rendering every world with variant-0 geometry.                                                                                                                                                                                                    
  
  1. Per-variant explicit inertials — entity/entity.py, scene/per_world_mesh.py                                                                                                                                                                                                    
                                                                  
  - New frozen dataclass BodyInertialMetadata(body_name, mass, ipos, inertia, iquat).                                                                                                                                                                                              
  - VariantMetadata gains variant_body_inertials: tuple[tuple[BodyInertialMetadata, ...], ...].
  - During _build_merged_spec, _collect_explicit_body_inertials walks each variant body tree (_iter_body_tree) and snapshots every body with explicitinertial=1. Names are stored local to the variant spec; per_world_mesh prefixes them with the scene entity name when applying.
  - _populate_dependent_fields now takes world_to_variant. For every unique world-variant key it does restore → apply variant inertials → compile, then restores once more at the end. Each variant body's explicitinertial, mass, ipos, inertia, iquat, fullinertia are saved     
  before the loop and reset between compiles so variants don't bleed into each other.                                                                                                                                                                                              
  - The previous if len(unique_rows) <= 1: return shortcut is removed — with explicit inertials, even a single unique variant still needs the apply/compile pass or the saved inertials never hit the spec.                                                                        
  - Validated on 024_bowl: compiled mass ≈ 0.01645 kg (matches the provided inertial metadata) vs. MuJoCo's mesh-density estimate of ≈ 0.554 kg; also verified on multi-env scenes where each env reports its own variant mass.                                                    
                                                                                                                                                                                                                                                                                   
  2. DR default-value indexing fix — envs/mdp/dr/_core.py, envs/mdp/dr/body.py                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                   
  Previously:                                                                                                                                                                                                                                                                      
  default_field[entity_indices].unsqueeze(0).expand_as(indexed_data)
  On standard defaults (shape (nentity, …)) this was fine. On per-world defaults (shape (nworld, nentity, …), produced by per-world mesh compilation) it silently indexed the world dimension with entity indices, then broadcast that wrong slice across envs.
                                                                                                                                                                                                                                                                                   
  Fix: new helper                                                                                                                                                                                                                                                                  
  _select_default_values(env, field, env_ids, entity_indices) -> (n_env, n_entity, …)                                                                                                                                                                                              
  uses torch.meshgrid(env_ids, entity_indices, indexing="ij") when the field is in sim.per_world_default_fields, otherwise indexes entities and broadcasts envs. _randomize_model_field, _randomize_quat_field, and pseudo_inertia all route through it; the now-redundant         
  L.unsqueeze(0).expand(...) inside pseudo_inertia is dropped since L already carries the env dim.                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                   
  3. Shared viewer model-sync module — new viewer/_model_sync.py                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                   
  Extracts from native/viewer.py:                                 
  - disable_model_sameframe_shortcuts(model) — clears body_sameframe, geom_sameframe, site_sameframe, and body_simple so host-side mj_forward stops taking the compile-time shortcut that mujoco_warp's kernels don't emulate. Necessary whenever per-world variants change local  
  offsets.                                                                                                                                                                                                                                                                         
  - sync_visual_fields(dst_model, sim_model, expanded_fields, env_idx) — copies expanded_fields ∩ VISUAL_FIELDS from GPU into a host MjModel.
  - Module-level INERTIAL_FIELDS and VISUAL_FIELDS frozensets.                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                   
  VISUAL_FIELDS gains body_subtreemass on top of the set in native/viewer.py. mj_forward uses it as the denominator when normalizing subtree_com; without syncing it, mjVIS_COM decor and anything reading data.subtree_com lands at wrong positions as soon as body_mass varies   
  per-world.                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                   
  native/viewer.py drops its duplicates and imports from the new module.                                                                                                                                                                                                           
                                                                  
  4. Offscreen renderer + Viser become variant-aware                                                                                                                                                                                                                               
                                                                  
  viewer/offscreen_renderer.py — OffscreenRenderer.__init__ accepts optional sim_model and expanded_fields; when provided it disables sameframe shortcuts up front and update() calls _sync_model_fields(env_idx) before the main env, again before each neighbor env rendered for 
  context, and once more at the end to restore the main env's view. manager_based_rl_env.py wires sim.model / sim.expanded_fields into the constructor.
                                                                                                                                                                                                                                                                                   
  viewer/viser/scene.py — MjlabViserScene.__init__ takes the same two args. When expanded_fields overlap with _GEOMETRY_HANDLE_FIELDS (geom_dataid, geom_rgba, geom_size, geom_pos, geom_quat, mat_rgba), it switches to a per-variant handle path:                                
  
  - New _create_mesh_handles_by_group override iterates every env, syncs visual fields, and groups dynamic-body geoms by _geom_subgroup_visual_fingerprint (type, dataid, matid+rgba, size, rgba, pos, quat). Each fingerprint becomes one _PerWorldMeshGroup batched handle       
  covering only the envs that share it — no more variant-0 geometry shown for every env.
  - New _update_visualization_locked override drives those per-world handles with (env_ids, body_ids) gathers on body_xpos/body_xmat (and mocap positions where applicable), with a show_only_selected mask path for single-env focus mode.                                        
  - Non-variant geoms still use the base class path.                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                   
  viewer/viser/viewer.py wires sim.model / sim.expanded_fields into the scene.                                                                                                                                                                                                     
