### PR TITLE
Add --log-root CLI option to train, play, and evaluate

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,6 +8,10 @@ Upcoming version (not yet released)
 Added
 ^^^^^
 
+- Added ``--log-root`` CLI option to ``train``, ``play``, and ``evaluate``
+  scripts for choosing where training logs are stored. Defaults to
+  ``logs/rsl_rl`` (unchanged behavior). Useful for directing outputs to a
+  scratch disk or shared mount.
 - Added ``ContactSensor.primary_names`` property to expose the resolved
   primary names in the order they appear along the per-contact axis of the
   output tensors. This makes it possible to map a contact-data column back

--- a/src/mjlab/rl/config.py
+++ b/src/mjlab/rl/config.py
@@ -95,8 +95,9 @@ class RslRlBaseRunnerCfg:
   save_interval: int = 50
   """The number of iterations between saves."""
   experiment_name: str = "exp1"
-  """Directory name used to group runs under
-  ``logs/rsl_rl/{experiment_name}/``."""
+  """Directory name used to group runs under ``{log_root}/{experiment_name}/``.
+  The log root defaults to ``logs/rsl_rl`` and can be overridden with
+  ``--log-root`` on the CLI."""
   run_name: str = ""
   """Optional label appended to the timestamped run directory
   (e.g. ``2025-01-27_14-30-00_{run_name}``). Also becomes the

--- a/src/mjlab/scripts/play.py
+++ b/src/mjlab/scripts/play.py
@@ -50,6 +50,7 @@ class PlayConfig:
   no_terminations: bool = False
   """Disable all termination conditions (useful for viewing motions with dummy agents)."""
   log_root: str = "logs/rsl_rl"
+  """Root directory under which experiment logs are written."""
 
   # Internal flag used by demo script.
   _demo_mode: tyro.conf.Suppress[bool] = False

--- a/src/mjlab/scripts/play.py
+++ b/src/mjlab/scripts/play.py
@@ -49,6 +49,7 @@ class PlayConfig:
   viewer: Literal["auto", "native", "viser"] = "auto"
   no_terminations: bool = False
   """Disable all termination conditions (useful for viewing motions with dummy agents)."""
+  log_root: str = "logs/rsl_rl"
 
   # Internal flag used by demo script.
   _demo_mode: tyro.conf.Suppress[bool] = False
@@ -130,7 +131,7 @@ def run_play(task_id: str, cfg: PlayConfig):
   log_dir: Path | None = None
   resume_path: Path | None = None
   if TRAINED_MODE:
-    log_root_path = (Path("logs") / "rsl_rl" / agent_cfg.experiment_name).resolve()
+    log_root_path = (Path(cfg.log_root) / agent_cfg.experiment_name).resolve()
     if cfg.checkpoint_file is not None:
       resume_path = Path(cfg.checkpoint_file)
       if not resume_path.exists():

--- a/src/mjlab/scripts/train.py
+++ b/src/mjlab/scripts/train.py
@@ -32,6 +32,7 @@ class TrainConfig:
   video_interval: int = 2000
   enable_nan_guard: bool = False
   log_root: str = "logs/rsl_rl"
+  """Root directory under which experiment logs are written."""
   torchrunx_log_dir: str | None = None
   wandb_run_path: str | None = None
   wandb_checkpoint_name: str | None = None

--- a/src/mjlab/scripts/train.py
+++ b/src/mjlab/scripts/train.py
@@ -31,6 +31,7 @@ class TrainConfig:
   video_length: int = 200
   video_interval: int = 2000
   enable_nan_guard: bool = False
+  log_root: str = "logs/rsl_rl"
   torchrunx_log_dir: str | None = None
   wandb_run_path: str | None = None
   wandb_checkpoint_name: str | None = None
@@ -181,8 +182,7 @@ def launch_training(task_id: str, args: TrainConfig | None = None):
   args = args or TrainConfig.from_task(task_id)
 
   # Create log directory once before launching workers.
-  log_root_path = Path("logs") / "rsl_rl" / args.agent.experiment_name
-  log_root_path.resolve()
+  log_root_path = (Path(args.log_root) / args.agent.experiment_name).resolve()
   log_dir_name = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
   if args.agent.run_name:
     log_dir_name += f"_{args.agent.run_name}"

--- a/src/mjlab/tasks/tracking/scripts/evaluate.py
+++ b/src/mjlab/tasks/tracking/scripts/evaluate.py
@@ -42,6 +42,7 @@ class EvaluateConfig:
   """Device to run on. Defaults to CUDA if available."""
   output_file: str | None = None
   """Optional path to save metrics as JSON."""
+  log_root: str = "logs/rsl_rl"
 
 
 def run_evaluate(task_id: str, cfg: EvaluateConfig) -> dict[str, float]:
@@ -74,7 +75,7 @@ def run_evaluate(task_id: str, cfg: EvaluateConfig) -> dict[str, float]:
   env = ManagerBasedRlEnv(cfg=env_cfg, device=device)
   env = RslRlVecEnvWrapper(env, clip_actions=agent_cfg.clip_actions)
 
-  log_root_path = (Path("logs") / "rsl_rl" / agent_cfg.experiment_name).resolve()
+  log_root_path = (Path(cfg.log_root) / agent_cfg.experiment_name).resolve()
   resume_path, _ = get_wandb_checkpoint_path(
     log_root_path, Path(cfg.wandb_run_path), cfg.wandb_checkpoint_name
   )

--- a/src/mjlab/tasks/tracking/scripts/evaluate.py
+++ b/src/mjlab/tasks/tracking/scripts/evaluate.py
@@ -43,6 +43,7 @@ class EvaluateConfig:
   output_file: str | None = None
   """Optional path to save metrics as JSON."""
   log_root: str = "logs/rsl_rl"
+  """Root directory under which experiment logs are written."""
 
 
 def run_evaluate(task_id: str, cfg: EvaluateConfig) -> dict[str, float]:


### PR DESCRIPTION
The log root was hardcoded, which forces workarounds in repos that have a designated output directory. This adds a --log-root option to train, play, and evaluate so the user can point logs to the right place. The default is unchanged (logs/rsl_rl), so existing workflows keep working.