### PR TITLE
Validate reward/termination/metrics term output shapes at env init

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,6 +8,11 @@ Upcoming version (not yet released)
 Added
 ^^^^^
 
+- ``RewardManager``, ``TerminationManager``, and ``MetricsManager`` now
+  validate that every term function returns a tensor of shape
+  ``(num_envs,)`` at environment init, raising a clear ``ValueError``
+  naming the offending term instead of silently broadcasting or crashing
+  later during training.
 - Added ``ContactSensor.primary_names`` property to expose the resolved
   primary names in the order they appear along the per-contact axis of the
   output tensors. This makes it possible to map a contact-data column back

--- a/src/mjlab/envs/manager_based_rl_env.py
+++ b/src/mjlab/envs/manager_based_rl_env.py
@@ -341,6 +341,12 @@ class ManagerBasedRlEnv:
       self.recorder_manager = NullRecorderManager()
     print_info(f"[INFO] {self.recorder_manager}")
 
+    self.extras.setdefault("log", {})
+
+    self.reward_manager.validate_term_shapes()
+    self.termination_manager.validate_term_shapes()
+    self.metrics_manager.validate_term_shapes()
+
     # Configure spaces for the environment.
     self._configure_gym_env_spaces()
 

--- a/src/mjlab/managers/metrics_manager.py
+++ b/src/mjlab/managers/metrics_manager.py
@@ -155,6 +155,15 @@ class MetricsManager(ManagerBase):
       terms.append((name, [self._step_values[env_idx, idx].cpu().item()]))
     return terms
 
+  def validate_term_shapes(self) -> None:
+    for term_name, term_cfg in zip(self._term_names, self._term_cfgs, strict=False):
+      value = term_cfg.func(self._env, **term_cfg.params)
+      if value.shape != (self.num_envs,):
+        raise ValueError(
+          f"Metrics term '{term_name}' returned shape {value.shape},"
+          f" expected ({self.num_envs},)."
+        )
+
   def _prepare_terms(self):
     for term_name, term_cfg in self.cfg.items():
       term_cfg: MetricsTermCfg | None
@@ -193,6 +202,9 @@ class NullMetricsManager:
 
   def reset(self, env_ids: torch.Tensor | None = None) -> dict[str, float]:
     return {}
+
+  def validate_term_shapes(self) -> None:
+    pass
 
   def compute_substep(self) -> None:
     pass

--- a/src/mjlab/managers/reward_manager.py
+++ b/src/mjlab/managers/reward_manager.py
@@ -160,6 +160,15 @@ class RewardManager(ManagerBase):
       raise ValueError(f"Term '{term_name}' not found in active terms.")
     return self._term_cfgs[self._term_names.index(term_name)]
 
+  def validate_term_shapes(self) -> None:
+    for term_name, term_cfg in zip(self._term_names, self._term_cfgs, strict=False):
+      value = term_cfg.func(self._env, **term_cfg.params)
+      if value.shape != (self.num_envs,):
+        raise ValueError(
+          f"Reward term '{term_name}' returned shape {value.shape},"
+          f" expected ({self.num_envs},)."
+        )
+
   def _prepare_terms(self):
     for term_name, term_cfg in self.cfg.items():
       term_cfg: RewardTermCfg | None

--- a/src/mjlab/managers/termination_manager.py
+++ b/src/mjlab/managers/termination_manager.py
@@ -127,6 +127,15 @@ class TerminationManager(ManagerBase):
       terms.append((key, [self._term_dones[key][env_idx].float().cpu().item()]))
     return terms
 
+  def validate_term_shapes(self) -> None:
+    for term_name, term_cfg in zip(self._term_names, self._term_cfgs, strict=False):
+      value = term_cfg.func(self._env, **term_cfg.params)
+      if value.shape != (self.num_envs,):
+        raise ValueError(
+          f"Termination term '{term_name}' returned shape {value.shape},"
+          f" expected ({self.num_envs},)."
+        )
+
   def _prepare_terms(self):
     for term_name, term_cfg in self.cfg.items():
       term_cfg: TerminationTermCfg | None

--- a/tests/test_metrics_manager.py
+++ b/tests/test_metrics_manager.py
@@ -221,6 +221,40 @@ def test_reduce_mean_and_last_coexist(mock_env):
   assert info["Episode_Metrics/last_term"].item() == pytest.approx(6.0)
 
 
+def test_metrics_shape_validation_accepts_correct_shape(mock_env):
+  """Metrics terms returning (num_envs,) pass shape validation."""
+  cfg = {"ok": MetricsTermCfg(func=lambda env: torch.ones(env.num_envs), params={})}
+  manager = MetricsManager(cfg, mock_env)
+  manager.validate_term_shapes()
+  assert "ok" in manager.active_terms
+
+
+def test_metrics_shape_validation_rejects_scalar(mock_env):
+  """Metrics terms returning a scalar are rejected by shape validation."""
+  cfg = {"bad": MetricsTermCfg(func=lambda env: torch.tensor(1.0), params={})}
+  manager = MetricsManager(cfg, mock_env)
+  with pytest.raises(ValueError, match="expected \\(4,\\)"):
+    manager.validate_term_shapes()
+
+
+def test_metrics_shape_validation_rejects_2d(mock_env):
+  """Metrics terms returning (num_envs, 1) are rejected by shape validation."""
+  cfg = {"bad": MetricsTermCfg(func=lambda env: torch.ones(env.num_envs, 1), params={})}
+  manager = MetricsManager(cfg, mock_env)
+  with pytest.raises(ValueError, match="expected \\(4,\\)"):
+    manager.validate_term_shapes()
+
+
+def test_metrics_shape_validation_rejects_wrong_num_envs(mock_env):
+  """Metrics terms returning wrong num_envs are rejected by shape validation."""
+  cfg = {
+    "bad": MetricsTermCfg(func=lambda env: torch.ones(env.num_envs + 1), params={})
+  }
+  manager = MetricsManager(cfg, mock_env)
+  with pytest.raises(ValueError, match="expected \\(4,\\)"):
+    manager.validate_term_shapes()
+
+
 def test_no_substep_terms_no_overhead(mock_env):
   """When no per_substep terms exist, compute_substep is a no-op."""
   cfg = {

--- a/tests/test_rewards.py
+++ b/tests/test_rewards.py
@@ -331,6 +331,52 @@ def test_reward_scaling_default_is_enabled(mock_env):
   assert torch.allclose(rewards, torch.full((4,), 0.01))
 
 
+def test_reward_shape_validation_accepts_correct_shape(mock_env):
+  """Reward terms returning (num_envs,) pass shape validation."""
+  cfg = {
+    "ok": RewardTermCfg(
+      func=lambda env: torch.ones(env.num_envs), weight=1.0, params={}
+    )
+  }
+  manager = RewardManager(cfg, mock_env)
+  manager.validate_term_shapes()
+  assert "ok" in manager.active_terms
+
+
+def test_reward_shape_validation_rejects_scalar(mock_env):
+  """Reward terms returning a scalar are rejected by shape validation."""
+  cfg = {
+    "bad": RewardTermCfg(func=lambda env: torch.tensor(1.0), weight=1.0, params={})
+  }
+  manager = RewardManager(cfg, mock_env)
+  with pytest.raises(ValueError, match="expected \\(4,\\)"):
+    manager.validate_term_shapes()
+
+
+def test_reward_shape_validation_rejects_2d(mock_env):
+  """Reward terms returning (num_envs, 1) are rejected by shape validation."""
+  cfg = {
+    "bad": RewardTermCfg(
+      func=lambda env: torch.ones(env.num_envs, 1), weight=1.0, params={}
+    )
+  }
+  manager = RewardManager(cfg, mock_env)
+  with pytest.raises(ValueError, match="expected \\(4,\\)"):
+    manager.validate_term_shapes()
+
+
+def test_reward_shape_validation_rejects_wrong_num_envs(mock_env):
+  """Reward terms returning wrong num_envs are rejected by shape validation."""
+  cfg = {
+    "bad": RewardTermCfg(
+      func=lambda env: torch.ones(env.num_envs + 1), weight=1.0, params={}
+    )
+  }
+  manager = RewardManager(cfg, mock_env)
+  with pytest.raises(ValueError, match="expected \\(4,\\)"):
+    manager.validate_term_shapes()
+
+
 def test_joint_torques_l2_with_actuator_ids(mock_env):
   """Test that joint_torques_l2 only penalizes specified actuators."""
   mock_env.scene["robot"].data.actuator_force = torch.tensor([[1.0, 2.0, 3.0, 4.0]] * 4)

--- a/tests/test_terminations.py
+++ b/tests/test_terminations.py
@@ -107,6 +107,62 @@ def test_nan_detection_with_termination_manager(mock_env_with_sim):
 
 
 @pytest.fixture
+def mock_env():
+  """Minimal mock environment for shape validation tests."""
+  env = Mock()
+  env.num_envs = 4
+  env.device = "cpu"
+  env.scene = {"robot": Mock()}
+  return env
+
+
+def test_termination_shape_validation_accepts_correct_shape(mock_env):
+  """Termination terms returning (num_envs,) pass shape validation."""
+  cfg = {
+    "ok": TerminationTermCfg(
+      func=lambda env: torch.zeros(env.num_envs, dtype=torch.bool), params={}
+    )
+  }
+  manager = TerminationManager(cfg, mock_env)
+  manager.validate_term_shapes()
+  assert "ok" in manager.active_terms
+
+
+def test_termination_shape_validation_rejects_scalar(mock_env):
+  """Termination terms returning a scalar are rejected by shape validation."""
+  cfg = {"bad": TerminationTermCfg(func=lambda env: torch.tensor(True), params={})}
+  manager = TerminationManager(cfg, mock_env)
+  with pytest.raises(ValueError, match="expected \\(4,\\)"):
+    manager.validate_term_shapes()
+
+
+def test_termination_shape_validation_rejects_2d(mock_env):
+  """Termination terms returning (num_envs, 1) are rejected by shape validation."""
+  cfg = {
+    "bad": TerminationTermCfg(
+      func=lambda env: torch.ones(env.num_envs, 1, dtype=torch.bool),
+      params={},
+    )
+  }
+  manager = TerminationManager(cfg, mock_env)
+  with pytest.raises(ValueError, match="expected \\(4,\\)"):
+    manager.validate_term_shapes()
+
+
+def test_termination_shape_validation_rejects_wrong_num_envs(mock_env):
+  """Termination terms returning wrong num_envs are rejected by shape validation."""
+  cfg = {
+    "bad": TerminationTermCfg(
+      func=lambda env: torch.zeros(env.num_envs + 1, dtype=torch.bool),
+      params={},
+    )
+  }
+  manager = TerminationManager(cfg, mock_env)
+  with pytest.raises(ValueError, match="expected \\(4,\\)"):
+    manager.validate_term_shapes()
+
+
+@pytest.fixture
 def mock_terrain_env():
   device = get_test_device()
   num_envs = 4


### PR DESCRIPTION
Reward, termination, and metrics term functions must return tensors of shape `(num_envs,)`, but this was never checked. A wrong shape would either silently broadcast (scalar, 2D) or crash with an opaque error during training.

Our built-in MDP functions all return the correct shape, but custom tasks developed through the plugin system can easily get this wrong with no useful feedback. Each manager now exposes `validate_term_shapes()`, called once from `load_managers()` after all managers are ready, which dry-runs every term and raises a clear `ValueError` naming the offending term.

Made with [Cursor](https://cursor.com)