### PR TITLE
Validate manager term shapes at compute time

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -12,6 +12,11 @@ Added
   scripts for choosing where training logs are stored. Defaults to
   ``logs/rsl_rl`` (unchanged behavior). Useful for directing outputs to a
   scratch disk or shared mount.
+- ``RewardManager``, ``TerminationManager``, and ``MetricsManager`` now
+  validate that every term function returns a tensor of shape
+  ``(num_envs,)`` when evaluated, raising a clear ``ValueError``
+  naming the offending term instead of silently broadcasting or crashing
+  with an opaque error later during training.
 - Added ``ContactSensor.primary_names`` property to expose the resolved
   primary names in the order they appear along the per-contact axis of the
   output tensors. This makes it possible to map a contact-data column back

--- a/src/mjlab/managers/manager_base.py
+++ b/src/mjlab/managers/manager_base.py
@@ -121,6 +121,14 @@ class ManagerBase(abc.ABC):
     del env_ids  # Unused.
     return {}
 
+  def _check_term_shape(self, term_name: str, value: torch.Tensor) -> None:
+    if value.shape != (self.num_envs,):
+      manager_name = type(self).__name__
+      raise ValueError(
+        f"{manager_name} term '{term_name}' returned shape {tuple(value.shape)}, "
+        f"expected ({self.num_envs},)."
+      )
+
   def get_active_iterable_terms(
     self, env_idx: int
   ) -> Sequence[tuple[str, Sequence[float]]]:

--- a/src/mjlab/managers/metrics_manager.py
+++ b/src/mjlab/managers/metrics_manager.py
@@ -127,7 +127,7 @@ class MetricsManager(ManagerBase):
     if not self._substep_term_indices:
       return
     for i, idx in enumerate(self._substep_term_indices):
-      value = self._term_cfgs[idx].func(self._env, **self._term_cfgs[idx].params)
+      value = self._compute_term(idx)
       self._substep_accum[i] += value
     self._substep_count += 1
 
@@ -142,8 +142,7 @@ class MetricsManager(ManagerBase):
       self._substep_count = 0
     for idx in self._step_term_indices:
       name = self._term_names[idx]
-      term_cfg = self._term_cfgs[idx]
-      value = term_cfg.func(self._env, **term_cfg.params)
+      value = self._compute_term(idx)
       self._episode_sums[name] += value
       self._step_values[:, idx] = value
 
@@ -171,6 +170,13 @@ class MetricsManager(ManagerBase):
         self._step_term_indices.append(idx)
       if hasattr(term_cfg.func, "reset") and callable(term_cfg.func.reset):
         self._class_term_cfgs.append(term_cfg)
+
+  def _compute_term(self, idx: int) -> torch.Tensor:
+    name = self._term_names[idx]
+    term_cfg = self._term_cfgs[idx]
+    value = term_cfg.func(self._env, **term_cfg.params)
+    self._check_term_shape(name, value)
+    return value
 
 
 class NullMetricsManager:

--- a/src/mjlab/managers/reward_manager.py
+++ b/src/mjlab/managers/reward_manager.py
@@ -122,7 +122,9 @@ class RewardManager(ManagerBase):
       if term_cfg.weight == 0.0:
         self._step_reward[:, term_idx] = 0.0
         continue
-      value = term_cfg.func(self._env, **term_cfg.params) * term_cfg.weight * scale
+      value = term_cfg.func(self._env, **term_cfg.params)
+      self._check_term_shape(name, value)
+      value = value * term_cfg.weight * scale
       # NaN/Inf can occur from corrupted physics state; zero them to avoid policy crash.
       value = torch.nan_to_num(value, nan=0.0, posinf=0.0, neginf=0.0)
       self._reward_buf += value

--- a/src/mjlab/managers/termination_manager.py
+++ b/src/mjlab/managers/termination_manager.py
@@ -104,6 +104,7 @@ class TerminationManager(ManagerBase):
     self._terminated_buf[:] = False
     for name, term_cfg in zip(self._term_names, self._term_cfgs, strict=False):
       value = term_cfg.func(self._env, **term_cfg.params)
+      self._check_term_shape(name, value)
       if term_cfg.time_out:
         self._truncated_buf |= value
       else:

--- a/tests/test_metrics_manager.py
+++ b/tests/test_metrics_manager.py
@@ -221,6 +221,26 @@ def test_reduce_mean_and_last_coexist(mock_env):
   assert info["Episode_Metrics/last_term"].item() == pytest.approx(6.0)
 
 
+def test_metrics_step_shape_validation_rejects_bad_compute_output(mock_env):
+  """Step metrics must return one scalar per environment."""
+  cfg = {"bad": MetricsTermCfg(func=lambda env: torch.ones(env.num_envs, 1))}
+  manager = MetricsManager(cfg, mock_env)
+  with pytest.raises(ValueError, match="MetricsManager term 'bad'.*expected \\(4,\\)"):
+    manager.compute()
+
+
+def test_metrics_substep_shape_validation_rejects_bad_compute_output(mock_env):
+  """Substep metrics must return one scalar per environment."""
+  cfg = {
+    "bad": MetricsTermCfg(
+      func=lambda env: torch.ones(env.num_envs, 1), per_substep=True
+    )
+  }
+  manager = MetricsManager(cfg, mock_env)
+  with pytest.raises(ValueError, match="MetricsManager term 'bad'.*expected \\(4,\\)"):
+    manager.compute_substep()
+
+
 def test_no_substep_terms_no_overhead(mock_env):
   """When no per_substep terms exist, compute_substep is a no-op."""
   cfg = {

--- a/tests/test_rewards.py
+++ b/tests/test_rewards.py
@@ -331,6 +331,14 @@ def test_reward_scaling_default_is_enabled(mock_env):
   assert torch.allclose(rewards, torch.full((4,), 0.01))
 
 
+def test_reward_shape_validation_rejects_bad_compute_output(mock_env):
+  """Reward terms must return one scalar per environment."""
+  cfg = {"bad": RewardTermCfg(func=lambda env: torch.ones(env.num_envs, 1), weight=1.0)}
+  manager = RewardManager(cfg, mock_env)
+  with pytest.raises(ValueError, match="RewardManager term 'bad'.*expected \\(4,\\)"):
+    manager.compute(dt=0.01)
+
+
 def test_joint_torques_l2_with_actuator_ids(mock_env):
   """Test that joint_torques_l2 only penalizes specified actuators."""
   mock_env.scene["robot"].data.actuator_force = torch.tensor([[1.0, 2.0, 3.0, 4.0]] * 4)

--- a/tests/test_terminations.py
+++ b/tests/test_terminations.py
@@ -107,6 +107,30 @@ def test_nan_detection_with_termination_manager(mock_env_with_sim):
 
 
 @pytest.fixture
+def mock_env():
+  """Minimal mock environment for shape validation tests."""
+  env = Mock()
+  env.num_envs = 4
+  env.device = "cpu"
+  env.scene = {"robot": Mock()}
+  return env
+
+
+def test_termination_shape_validation_rejects_bad_compute_output(mock_env):
+  """Termination terms must return one boolean per environment."""
+  cfg = {
+    "bad": TerminationTermCfg(
+      func=lambda env: torch.zeros(env.num_envs, 1, dtype=torch.bool)
+    )
+  }
+  manager = TerminationManager(cfg, mock_env)
+  with pytest.raises(
+    ValueError, match="TerminationManager term 'bad'.*expected \\(4,\\)"
+  ):
+    manager.compute()
+
+
+@pytest.fixture
 def mock_terrain_env():
   device = get_test_device()
   num_envs = 4


### PR DESCRIPTION
Validate reward, termination, and metrics term outputs where they are consumed instead of dry-running terms during environment initialization. This avoids calling user callbacks outside their normal lifecycle while still raising a clear error when a term does not return one value per environment.

Closes #941.