### PR TITLE
Disable terrain debug visualization sites by default

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -25,6 +25,11 @@ Added
 Changed
 ^^^^^^^
 
+- ``TerrainEntityCfg`` debug visualization sites (environment origins,
+  terrain origins, flat patches) are now off by default. Set
+  ``debug_vis=True`` to re-enable them. The sites inflated ``nsite`` and
+  caused a measurable slowdown in the per-step ``site_local_to_global``
+  kernel (:issue:`942`).
 - Task package load failures during ``mjlab`` import now print the full
   traceback (and the entry point's module path) to ``stderr`` instead of
   just the exception message, making it easier to pinpoint the source of

--- a/src/mjlab/terrains/terrain_entity.py
+++ b/src/mjlab/terrains/terrain_entity.py
@@ -95,6 +95,9 @@ class TerrainEntityCfg(EntityCfg):
     default_factory=lambda: (_DEFAULT_SUN_LIGHT,)
   )
   """Lights for the scene. Defaults to a directional sun light."""
+  debug_vis: bool = False
+  """Add visualization sites for environment origins, terrain origins, and
+  flat patches. Defaults to False."""
 
   def build(self) -> TerrainEntity:
     raise TypeError(
@@ -158,9 +161,10 @@ class TerrainEntity(Entity):
     else:
       raise ValueError(f"Unknown terrain type: {self.cfg.terrain_type}")
 
-    self._add_env_origin_sites()
-    self._add_terrain_origin_sites()
-    self._add_flat_patch_sites()
+    if self.cfg.debug_vis:
+      self._add_env_origin_sites()
+      self._add_terrain_origin_sites()
+      self._add_flat_patch_sites()
 
   def _add_initial_state_keyframe(self) -> None:
     pass  # No joints, no keyframe.


### PR DESCRIPTION
The three site-adding methods in TerrainEntity (env origins, terrain origins, flat patches) inflate nsite and cause a measurable slowdown in the per-step site_local_to_global kernel. These sites are purely for debug visualization and not read by any runtime code.

This adds a debug_vis flag to TerrainEntityCfg (defaults to False) so the sites are only created when explicitly requested.

Fixes #942