### PR TITLE
Raycast sensor optimization

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -25,6 +25,8 @@ Added
 Changed
 ^^^^^^^
 
+- Sped up ``RayCaster`` post-processing and ``quat_from_matrix``. 
+  ``quat_from_matrix`` output may differ by ~2e-7 vs. the previous implementation.
 - Bumped ``rsl-rl-lib`` from 5.0.1 to 5.2.0. This brings ``torch.compile`` support for
   PPO and Distillation, and optional std clamping and constant std in
   ``GaussianDistribution``. No code changes required on the mjlab side.

--- a/src/mjlab/sensor/raycast_sensor.py
+++ b/src/mjlab/sensor/raycast_sensor.py
@@ -781,17 +781,18 @@ class RayCastSensor(Sensor[RayCastData]):
     assert self._ray_dist is not None and self._ray_normal is not None
     distances = wp.to_torch(self._ray_dist)
     normals_w = wp.to_torch(self._ray_normal).view(B, self._num_rays, 3)
-    distances[distances > self.cfg.max_distance] = -1.0
+    distances.masked_fill_(distances > self.cfg.max_distance, -1.0)
 
     hit_mask = distances >= 0
-    hit_pos_w = self._cached_world_origins.clone()
-    hit_pos_w[hit_mask] = self._cached_world_origins[
-      hit_mask
-    ] + self._cached_world_rays[hit_mask] * distances[hit_mask].unsqueeze(-1)
-    self._hit_pos_w = hit_pos_w
+    # ``origin + ray * max(distance, 0)`` collapses miss rays to ``origin``
+    # (clamped distance is 0) without any branching.
+    clamped = distances.clamp(min=0.0)
+    self._hit_pos_w = (
+      self._cached_world_origins + self._cached_world_rays * clamped.unsqueeze(-1)
+    )
 
     # Zero out normals for misses.
-    normals_w[~hit_mask] = 0.0
+    normals_w.masked_fill_(~hit_mask.unsqueeze(-1), 0.0)
     self._distances = distances
     self._normals_w = normals_w
 

--- a/src/mjlab/utils/lab_api/math.py
+++ b/src/mjlab/utils/lab_api/math.py
@@ -303,20 +303,18 @@ def quat_from_euler_xyz(roll: torch.Tensor, pitch: torch.Tensor, yaw: torch.Tens
     return torch.stack([qw, qx, qy, qz], dim=-1)
 
 
-@torch.jit.script
 def _sqrt_positive_part(x: torch.Tensor) -> torch.Tensor:
-    """Returns torch.sqrt(torch.max(0, x)) but with a zero sub-gradient where x is 0.
+    """Returns torch.sqrt(torch.max(0, x)) but with a zero subgradient where x is 0.
 
     Reference:
         https://github.com/facebookresearch/pytorch3d/blob/main/pytorch3d/transforms/rotation_conversions.py#L91-L99
     """
-    ret = torch.zeros_like(x)
     positive_mask = x > 0
-    ret[positive_mask] = torch.sqrt(x[positive_mask])
-    return ret
+    safe_x = torch.where(positive_mask, x, 1.0)
+    return torch.where(positive_mask, torch.sqrt(safe_x), 0.0)
 
 
-@torch.jit.script
+@torch.compile(fullgraph=True)
 def quat_from_matrix(matrix: torch.Tensor) -> torch.Tensor:
     """Convert rotations given as rotation matrices to quaternions.
 
@@ -331,10 +329,10 @@ def quat_from_matrix(matrix: torch.Tensor) -> torch.Tensor:
     """
     if matrix.size(-1) != 3 or matrix.size(-2) != 3:
         raise ValueError(f"Invalid rotation matrix shape {matrix.shape}.")
-
     batch_dim = matrix.shape[:-2]
-    m00, m01, m02, m10, m11, m12, m20, m21, m22 = torch.unbind(matrix.reshape(batch_dim + (9,)), dim=-1)
-
+    m00, m01, m02, m10, m11, m12, m20, m21, m22 = torch.unbind(
+        matrix.reshape(batch_dim + (9,)), dim=-1
+    )
     q_abs = _sqrt_positive_part(
         torch.stack(
             [
@@ -346,32 +344,32 @@ def quat_from_matrix(matrix: torch.Tensor) -> torch.Tensor:
             dim=-1,
         )
     )
-
-    # we produce the desired quaternion multiplied by each of r, i, j, k
     quat_by_rijk = torch.stack(
         [
-            # pyre-fixme[58]: `**` is not supported for operand types `Tensor` and `int`.
-            torch.stack([q_abs[..., 0] ** 2, m21 - m12, m02 - m20, m10 - m01], dim=-1),
-            # pyre-fixme[58]: `**` is not supported for operand types `Tensor` and `int`.
-            torch.stack([m21 - m12, q_abs[..., 1] ** 2, m10 + m01, m02 + m20], dim=-1),
-            # pyre-fixme[58]: `**` is not supported for operand types `Tensor` and `int`.
-            torch.stack([m02 - m20, m10 + m01, q_abs[..., 2] ** 2, m12 + m21], dim=-1),
-            # pyre-fixme[58]: `**` is not supported for operand types `Tensor` and `int`.
-            torch.stack([m10 - m01, m20 + m02, m21 + m12, q_abs[..., 3] ** 2], dim=-1),
+            torch.stack(
+                [torch.square(q_abs[..., 0]), m21 - m12, m02 - m20, m10 - m01], dim=-1
+            ),
+            torch.stack(
+                [m21 - m12, torch.square(q_abs[..., 1]), m10 + m01, m02 + m20], dim=-1
+            ),
+            torch.stack(
+                [m02 - m20, m10 + m01, torch.square(q_abs[..., 2]), m12 + m21], dim=-1
+            ),
+            torch.stack(
+                [m10 - m01, m20 + m02, m21 + m12, torch.square(q_abs[..., 3])], dim=-1
+            ),
         ],
         dim=-2,
     )
-
-    # We floor here at 0.1 but the exact level is not important; if q_abs is small,
-    # the candidate won't be picked.
-    flr = torch.tensor(0.1).to(dtype=q_abs.dtype, device=q_abs.device)
-    quat_candidates = quat_by_rijk / (2.0 * q_abs[..., None].max(flr))
+    # Floor of 0.1 keeps the divisor away from zero; ill-conditioned
+    # candidates will not be selected by the argmax below.
+    quat_candidates = quat_by_rijk / (2.0 * q_abs[..., None].clamp_min(0.1))
 
     # if not for numerical problems, quat_candidates[i] should be same (up to a sign),
     # forall i; we pick the best-conditioned one (with the largest denominator)
-    return quat_candidates[torch.nn.functional.one_hot(q_abs.argmax(dim=-1), num_classes=4) > 0.5, :].reshape(
-        batch_dim + (4,)
-    )
+    indices = q_abs.argmax(dim=-1, keepdim=True)
+    gather_indices = indices.unsqueeze(-1).expand(batch_dim + (1, 4))
+    return torch.gather(quat_candidates, -2, gather_indices).squeeze(-2)
 
 
 def _axis_angle_rotation(axis: Literal["X", "Y", "Z"], angle: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
Removes boolean-mask indexing operations with `masked_fill_` and an implementation of hit_pos_w that uses a clamped distance to put hit_pos_w for misses at world_origins. These effectively remove all cuda syncs from the ray postprocess, unblocking the cpu thread while gpu-based sensing occurs.

Also optimizes `quat_from_matrix`. Similarly this removes cuda sync operations and catches the implementation up to the latest from https://github.com/facebookresearch/pytorch3d/blob/main/pytorch3d/transforms/rotation_conversions.py. Profiling now shows:

    device=NVIDIA GeForce RTX 4090

    shape              legacy us   current us   speedup     max |Δ|
    ---------------------------------------------------------------
    B = 4096              231.26        51.01     4.53x    1.79e-07
    B = 16384             243.55        56.07     4.34x    1.79e-07
    B = 65536             282.05        53.93     5.23x    1.79e-07
    
Profiled using: 
```python
def time_call(fn, x, *, warmup=20, iters=200) -> float:
    """Mean per-call latency in microseconds, measured with cudaEvents."""
    for _ in range(warmup):
        fn(x)
    torch.cuda.synchronize()
    starts = [torch.cuda.Event(enable_timing=True) for _ in range(iters)]
    ends = [torch.cuda.Event(enable_timing=True) for _ in range(iters)]
    for i in range(iters):
        starts[i].record()
        fn(x)
        ends[i].record()
    torch.cuda.synchronize()
    times_ms = [s.elapsed_time(e) for s, e in zip(starts, ends)]
    return statistics.mean(times_ms) * 1000.0  # us

m = random_rotations(shape, device=device, dtype=dtype)

# Numerical agreement (account for ±q sign ambiguity)
with torch.no_grad():
    ql = quat_from_matrix_legacy(m)
    qc = quat_from_matrix_current(m)
    sign = torch.sign((ql * qc).sum(dim=-1, keepdim=True))
    sign = torch.where(sign == 0, torch.ones_like(sign), sign)
    max_diff = (ql - qc * sign).abs().max().item()

t_legacy = time_call(lambda x: quat_from_matrix_legacy(x), m)
t_current = time_call(lambda x: quat_from_matrix_current(x), m)
speedup = t_legacy / t_current
```

With both of these changes, `Mjlab-Velocity-Rough-Unitree-Go1` trains ~3% faster