### PR TITLE
Skip Warp CUDA init in seed_rng when device is CPU

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -48,6 +48,11 @@ Changed
 Fixed
 ^^^^^
 
+- Fixed ``ManagerBasedRlEnv`` initializing Warp on all visible CUDA devices
+  even when constructed with ``device="cpu"``. ``seed_rng`` now accepts a
+  ``device`` argument and skips ``wp.rand_init`` on CPU devices, so a
+  CPU-only env no longer claims a CUDA context on machines with a visible
+  GPU (:issue:`949`).
 - Fixed ``ContactSensor.compute_first_contact`` and ``compute_first_air``
   occasionally missing events when a contact began or ended right at the
   last physics substep of a control step. ``current_contact_time`` /

--- a/src/mjlab/envs/manager_based_rl_env.py
+++ b/src/mjlab/envs/manager_based_rl_env.py
@@ -184,7 +184,7 @@ class ManagerBasedRlEnv:
     # Initialize base environment state.
     self.cfg = cfg
     if self.cfg.seed is not None:
-      self.cfg.seed = self.seed(self.cfg.seed)
+      self.cfg.seed = self.seed(self.cfg.seed, device=device)
     self._sim_step_counter = 0
     self.extras = {}
     self.obs_buf = {}
@@ -493,12 +493,11 @@ class ManagerBasedRlEnv:
       self._offline_renderer.close()
     self.recorder_manager.close()
 
-  @staticmethod
-  def seed(seed: int = -1) -> int:
+  def seed(self, seed: int = -1, device: str | torch.device | None = None) -> int:
     if seed == -1:
       seed = np.random.randint(0, 10_000)
     print_info(f"Setting seed: {seed}")
-    random_utils.seed_rng(seed)
+    random_utils.seed_rng(seed, device=device if device is not None else self.device)
     return seed
 
   def update_visualizers(self, visualizer: DebugVisualizer) -> None:

--- a/src/mjlab/utils/random.py
+++ b/src/mjlab/utils/random.py
@@ -6,8 +6,17 @@ import torch
 import warp as wp
 
 
-def seed_rng(seed: int, torch_deterministic: bool = False) -> None:
+def seed_rng(
+  seed: int,
+  torch_deterministic: bool = False,
+  device: str | torch.device | None = None,
+) -> None:
   """Seed all random number generators for reproducibility.
+
+  When ``device`` is a CPU device, ``wp.rand_init`` is skipped so that Warp's
+  CUDA runtime is not initialized on machines where a GPU is visible but the
+  caller has explicitly opted into CPU-only execution. When ``device`` is
+  ``None``, behavior is unchanged (Warp is seeded).
 
   Note: MuJoCo Warp is not fully deterministic yet.
   See: https://github.com/google-deepmind/mujoco_warp/issues/562
@@ -17,7 +26,8 @@ def seed_rng(seed: int, torch_deterministic: bool = False) -> None:
   random.seed(seed)
   np.random.seed(seed)
 
-  wp.rand_init(wp.int32(seed))
+  if device is None or torch.device(device).type != "cpu":
+    wp.rand_init(wp.int32(seed))
 
   # Ref: https://docs.pytorch.org/docs/stable/notes/randomness.html
   torch.manual_seed(seed)  # Seed RNG for all devices.

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -1,0 +1,30 @@
+"""Tests for mjlab.utils.random."""
+
+import subprocess
+import sys
+import textwrap
+
+
+def test_seed_rng_cpu_device_does_not_initialize_warp_cuda() -> None:
+  """seed_rng(device="cpu") must not initialize Warp's CUDA runtime.
+
+  Runs in a subprocess so that Warp is guaranteed uninitialized before the
+  call.
+  """
+  script = textwrap.dedent("""
+    import warp as wp
+    from mjlab.utils.random import seed_rng
+
+    assert wp._src.context.runtime is None, "Warp must not be initialized yet"
+    seed_rng(42, device="cpu")
+    rt = wp._src.context.runtime
+    if rt is not None:
+        cuda = [d for d in wp.get_devices() if "cuda" in str(d)]
+        assert not cuda, f"seed_rng(device='cpu') initialized CUDA devices {cuda}"
+  """)
+  result = subprocess.run(
+    [sys.executable, "-c", script], capture_output=True, text=True
+  )
+  assert result.returncode == 0, (
+    f"subprocess failed:\nstdout={result.stdout}\nstderr={result.stderr}"
+  )


### PR DESCRIPTION
ManagerBasedRlEnv unconditionally called wp.rand_init via seed_rng, which initializes Warp on every visible CUDA device. So constructing the env with device="cpu" still claimed a CUDA context on machines with a visible GPU.

seed_rng now takes an optional device argument and skips wp.rand_init when the device resolves to CPU. ManagerBasedRlEnv passes its constructor device through.

Fixes #949