### PR TITLE
Upgrade mujoco to 3.8 and mujoco-warp to 3.8.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,8 +37,8 @@ dependencies = [
   "torch>=2.7.0",
   "torchrunx>=0.3.4",
   "warp-lang>=1.12.0",
-  "mujoco-warp>=3.7.0.1",
-  "mujoco>=3.7.0",
+  "mujoco-warp>=3.8.0",
+  "mujoco>=3.8.0",
   "trimesh>=4.8.3",
   "viser>=1.0.26",
   "mjviser>=0.0.11",
@@ -100,7 +100,7 @@ conflicts = [
 # The nightly index (py.mujoco.org) only has dev builds, and PEP 440 ranks
 # 3.7.0.devN < 3.7.0, so the >=3.7.0 floor in [project.dependencies] would
 # reject them. This override loosens the constraint for uv resolution only.
-override-dependencies = ["mujoco>=3.7.0.dev0"]
+override-dependencies = ["mujoco>=3.8.0.dev0"]
 constraint-dependencies = [
   "GitPython>=3.1.47",
   "lxml>=6.1.0",
@@ -140,7 +140,7 @@ torch = [
   { index = "pytorch-cpu", extra = "cpu", marker = "sys_platform != 'darwin'" },
 ]
 mujoco = { index = "mujoco" }
-mujoco-warp = { git = "https://github.com/google-deepmind/mujoco_warp", rev = "ea7f05b" }
+mujoco-warp = { git = "https://github.com/google-deepmind/mujoco_warp", rev = "6f235d4" }
 
 [tool.ruff]
 src = ["src"]  # Helpful for recognizing first-party imports.

--- a/tests/test_sim.py
+++ b/tests/test_sim.py
@@ -56,7 +56,7 @@ def test_simulation_config_is_piped(robot_xml, device):
       ls_iterations=14,
       ccd_iterations=20,
       gravity=(0, 0, 7.5),
-      enableflags=("multiccd",),
+      enableflags=("energy",),
     ),
   )
 
@@ -70,7 +70,7 @@ def test_simulation_config_is_piped(robot_xml, device):
   assert sim.mj_model.opt.ls_iterations == cfg.mujoco.ls_iterations
   assert sim.mj_model.opt.ccd_iterations == cfg.mujoco.ccd_iterations
   assert tuple(sim.mj_model.opt.gravity) == cfg.mujoco.gravity
-  assert sim.mj_model.opt.enableflags & mujoco.mjtEnableBit.mjENBL_MULTICCD
+  assert sim.mj_model.opt.enableflags & mujoco.mjtEnableBit.mjENBL_ENERGY
 
   # MujocoCfg should be inherited by wp_model via put_model.
   np.testing.assert_almost_equal(
@@ -82,7 +82,7 @@ def test_simulation_config_is_piped(robot_xml, device):
   assert sim.model.opt.integrator == mujoco.mjtIntegrator.mjINT_EULER
   assert sim.model.opt.solver == mujoco.mjtSolver.mjSOL_CG
   assert sim.model.opt.iterations == cfg.mujoco.iterations
-  assert sim.model.opt.enableflags & mujoco.mjtEnableBit.mjENBL_MULTICCD
+  assert sim.model.opt.enableflags & mujoco.mjtEnableBit.mjENBL_ENERGY
 
   # SimulationCfg should be applied to wp_model.
   assert sim.wp_model.opt.contact_sensor_maxmatch == cfg.contact_sensor_maxmatch

--- a/uv.lock
+++ b/uv.lock
@@ -45,7 +45,7 @@ constraints = [
     { name = "gitpython", specifier = ">=3.1.47" },
     { name = "lxml", specifier = ">=6.1.0" },
 ]
-overrides = [{ name = "mujoco", specifier = ">=3.7.0.dev0", index = "https://py.mujoco.org/" }]
+overrides = [{ name = "mujoco", specifier = ">=3.8.0.dev0", index = "https://py.mujoco.org/" }]
 
 [[package]]
 name = "absl-py"
@@ -1716,8 +1716,8 @@ requires-dist = [
     { name = "imageio-ffmpeg" },
     { name = "mediapy", specifier = ">=1.2.6" },
     { name = "mjviser", specifier = ">=0.0.11" },
-    { name = "mujoco", specifier = ">=3.7.0", index = "https://py.mujoco.org/" },
-    { name = "mujoco-warp", git = "https://github.com/google-deepmind/mujoco_warp?rev=ea7f05b" },
+    { name = "mujoco", specifier = ">=3.8.0", index = "https://py.mujoco.org/" },
+    { name = "mujoco-warp", git = "https://github.com/google-deepmind/mujoco_warp?rev=6f235d4" },
     { name = "onnxscript", specifier = ">=0.5.4" },
     { name = "prettytable" },
     { name = "rsl-rl-lib", specifier = "==5.2.0" },
@@ -1931,7 +1931,7 @@ wheels = [
 
 [[package]]
 name = "mujoco"
-version = "3.7.0.dev892927987"
+version = "3.8.1.dev906944517"
 source = { registry = "https://py.mujoco.org/" }
 dependencies = [
     { name = "absl-py" },
@@ -1942,28 +1942,28 @@ dependencies = [
     { name = "pyopengl" },
 ]
 wheels = [
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.7.0.dev892927987-cp310-cp310-macosx_11_0_universal2.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.7.0.dev892927987-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.7.0.dev892927987-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.7.0.dev892927987-cp310-cp310-win_amd64.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.7.0.dev892927987-cp311-cp311-macosx_11_0_universal2.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.7.0.dev892927987-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.7.0.dev892927987-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.7.0.dev892927987-cp311-cp311-win_amd64.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.7.0.dev892927987-cp312-cp312-macosx_11_0_universal2.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.7.0.dev892927987-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.7.0.dev892927987-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.7.0.dev892927987-cp312-cp312-win_amd64.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.7.0.dev892927987-cp313-cp313-macosx_11_0_universal2.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.7.0.dev892927987-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.7.0.dev892927987-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.7.0.dev892927987-cp313-cp313-win_amd64.whl" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.8.1.dev906944517-cp310-cp310-macosx_11_0_universal2.whl" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.8.1.dev906944517-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.8.1.dev906944517-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.8.1.dev906944517-cp310-cp310-win_amd64.whl" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.8.1.dev906944517-cp311-cp311-macosx_11_0_universal2.whl" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.8.1.dev906944517-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.8.1.dev906944517-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.8.1.dev906944517-cp311-cp311-win_amd64.whl" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.8.1.dev906944517-cp312-cp312-macosx_11_0_universal2.whl" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.8.1.dev906944517-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.8.1.dev906944517-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.8.1.dev906944517-cp312-cp312-win_amd64.whl" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.8.1.dev906944517-cp313-cp313-macosx_11_0_universal2.whl" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.8.1.dev906944517-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.8.1.dev906944517-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.8.1.dev906944517-cp313-cp313-win_amd64.whl" },
 ]
 
 [[package]]
 name = "mujoco-warp"
-version = "3.7.0.1"
-source = { git = "https://github.com/google-deepmind/mujoco_warp?rev=ea7f05b#ea7f05baa3e5ea375ed2eeb041fd90eb9b7d6932" }
+version = "3.8.0"
+source = { git = "https://github.com/google-deepmind/mujoco_warp?rev=6f235d4#6f235d46cb2ecf8f37c8f967f8dd9c87d0ca5807" }
 dependencies = [
     { name = "absl-py" },
     { name = "etils", extra = ["epath"] },


### PR DESCRIPTION
The previous mujoco 3.7 nightly was yanked, breaking CI. This bumps both mujoco (to 3.8.1 nightly) and mujoco-warp (to a post-3.8.0 commit that includes the cache_kernel fix from google-deepmind/mujoco_warp#1318, which prevents a 12x CPU slowdown from warp's module="unique" dedup overhead).

The multiccd enable flag was removed in mujoco 3.8 (it became default-on), so the test that exercised it now uses the energy flag instead.

Note: 3 camera segmentation tests will fail until #911 is merged (upstream mujoco_warp changed the segmentation API in google-deepmind/mujoco_warp#1283).

Fixes #948