### PR TITLE
Revert quat_from_matrix decorator from torch.compile to torch.jit.script

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -37,10 +37,6 @@ Changed
   formulation of ``hit_pos_w`` that places misses at the world origin. This
   removes all CUDA syncs from the ray post-process, letting the CPU thread
   proceed while GPU-based sensing runs. Contribution by @bd-pdomanico.
-- Sped up ``quat_from_matrix`` by removing CUDA syncs and aligning the
-  implementation with the latest version in ``pytorch3d``. ~4-5x speedup
-  on a 4090. Output may differ by ~2e-7 vs. the previous implementation.
-  Contribution by @bd-pdomanico.
 - Bumped ``rsl-rl-lib`` from 5.0.1 to 5.2.0. This brings ``torch.compile`` support for
   PPO and Distillation, and optional std clamping and constant std in
   ``GaussianDistribution``. No code changes required on the mjlab side.

--- a/src/mjlab/utils/lab_api/math.py
+++ b/src/mjlab/utils/lab_api/math.py
@@ -314,7 +314,7 @@ def _sqrt_positive_part(x: torch.Tensor) -> torch.Tensor:
     return torch.where(positive_mask, torch.sqrt(safe_x), 0.0)
 
 
-@torch.compile(fullgraph=True)
+@torch.jit.script
 def quat_from_matrix(matrix: torch.Tensor) -> torch.Tensor:
     """Convert rotations given as rotation matrices to quaternions.
 


### PR DESCRIPTION
The @torch.compile(fullgraph=True) decorator added to quat_from_matrix in #948 hits dynamo's recompile_limit (8) when the full test suite runs, causing test_raycast_sensor.py to fail across the board with FailOnRecompileLimitHit. Shape specialization on the leading batch dim exhausts the budget across the many env constructions that happen earlier in the suite, so by the time raycast tests run the cache is poisoned and every test errors out.

Switching back to @torch.jit.script sidesteps dynamo entirely and gets the suite green again. The pytorch3d-style sync-free rewrite from #948 — which is the actual source of the speedup — is preserved untouched; only the decorator changes. The matching changelog entry is dropped since the perf attribution is now muddier.

We can investigate a proper jit → compile switch later (probably with dynamic=True so the batch dim doesn't trigger recompiles, or a per-process dynamo reset in the test harness).

cc @bd-pdomanico