### PR TITLE
Fix extras["log"] entries from reward terms being discarded on reset

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -75,6 +75,12 @@ Changed
 Fixed
 ^^^^^
 
+- Fixed ``extras["log"]`` entries written by reward terms (e.g. ``Metrics/*``
+  values in velocity tasks) being silently discarded on any step where at
+  least one environment resets. ``_reset_idx`` was clearing the dict after
+  ``reward_manager.compute()`` had already populated it. The clear now
+  happens at the top of ``step()`` and ``reset()`` so that all entries
+  survive (:issue:`957`).
 - Fixed ``ManagerBasedRlEnv`` initializing Warp on all visible CUDA devices
   even when constructed with ``device="cpu"``. ``seed_rng`` now accepts a
   ``device`` argument and skips ``wp.rand_init`` on CPU devices, so a

--- a/src/mjlab/envs/manager_based_rl_env.py
+++ b/src/mjlab/envs/manager_based_rl_env.py
@@ -365,6 +365,7 @@ class ManagerBasedRlEnv:
       env_ids = torch.arange(self.num_envs, dtype=torch.int64, device=self.device)
     if seed is not None:
       self.seed(seed)
+    self.extras["log"] = dict()
     self._reset_idx(env_ids)
     self.scene.write_data_to_sim()
     self.sim.forward()
@@ -414,6 +415,7 @@ class ManagerBasedRlEnv:
         "reset(env_ids=...) before calling step() again when auto_reset=False."
       )
 
+    self.extras["log"] = dict()
     self.action_manager.process_action(action.to(self.device))
 
     for _ in range(self.cfg.decimation):
@@ -556,7 +558,6 @@ class ManagerBasedRlEnv:
       )
 
     # NOTE: This is order sensitive.
-    self.extras["log"] = dict()
     # observation manager.
     info = self.observation_manager.reset(env_ids)
     self.extras["log"].update(info)


### PR DESCRIPTION
Reward terms (e.g. velocity task metrics like `Metrics/air_time_mean`, `Metrics/slip_velocity_mean`) write into `extras["log"]` during `reward_manager.compute()`, but `_reset_idx()` was clearing the dict with `self.extras["log"] = dict()` before repopulating it with manager reset data. Since `_reset_idx` runs after `reward_manager.compute()` in `step()`, all reward-term metrics were silently discarded on any step where at least one environment resets — which is nearly every step in practice. This meant rsl_rl's logger never saw these metrics in W&B/Neptune/TensorBoard.

The fix moves the `extras["log"]` clearing from `_reset_idx()` to the top of `step()` and `reset()`, so reward terms write after the clear and `_reset_idx` merges additively via `.update()`. No key collisions are possible since manager resets use `Episode_Reward/`, `Episode_Termination/`, etc. while reward terms use `Metrics/`.

Fixes #957