### PR TITLE
[Bug Fix] Fix contact sensor global frame rotation

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -80,7 +80,7 @@ Fixed
   rotated onto the wrong axis. The contact-frame→world rotation matrix had
   its columns ordered ``[tangent, tangent2, normal]`` instead of
   ``[normal, tangent, tangent2]``, projecting the normal-force component
-  onto a tangent direction.
+  onto a tangent direction. Contribution by @bd-pdomanico.
 - Fixed ``extras["log"]`` entries written by reward terms (e.g. ``Metrics/*``
   values in velocity tasks) being silently discarded on any step where at
   least one environment resets. ``_reset_idx`` was clearing the dict after

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -75,6 +75,12 @@ Changed
 Fixed
 ^^^^^
 
+- Fixed ``ContactSensor`` with ``global_frame=True`` and
+  ``reduce`` ∈ {``"none"``, ``"mindist"``, ``"maxforce"``} producing forces
+  rotated onto the wrong axis. The contact-frame→world rotation matrix had
+  its columns ordered ``[tangent, tangent2, normal]`` instead of
+  ``[normal, tangent, tangent2]``, projecting the normal-force component
+  onto a tangent direction.
 - Fixed ``extras["log"]`` entries written by reward terms (e.g. ``Metrics/*``
   values in velocity tasks) being silently discarded on any step where at
   least one environment resets. ``_reset_idx`` was clearing the dict after

--- a/src/mjlab/sensor/contact_sensor.py
+++ b/src/mjlab/sensor/contact_sensor.py
@@ -428,7 +428,7 @@ class ContactSensor(Sensor[ContactData]):
     normal = data.normal
     tangent = data.tangent
     tangent2 = torch.cross(normal, tangent, dim=-1)
-    R = torch.stack([tangent, tangent2, normal], dim=-1)
+    R = torch.stack([normal, tangent, tangent2], dim=-1)
 
     has_contact = torch.norm(normal, dim=-1, keepdim=True) > 1e-8
 

--- a/tests/test_contact_sensor.py
+++ b/tests/test_contact_sensor.py
@@ -1075,9 +1075,7 @@ def test_history_captures_impact_forces(device):
 
 
 def test_global_frame_maxforce_rotation(device):
-  """
-  A box at rest on a plane has its contact normals all vertical.
-  """
+  """A box at rest on a plane has its contact normals all vertical."""
   cfg = ContactSensorCfg(
     name="box_contact",
     primary=ContactMatch(mode="geom", pattern="box_geom", entity="box"),

--- a/tests/test_contact_sensor.py
+++ b/tests/test_contact_sensor.py
@@ -1072,3 +1072,39 @@ def test_history_captures_impact_forces(device):
   assert torch.all(max_force_seen > steady_state_force * 1.5), (
     f"Peak force {max_force_seen} should be significantly above mg={steady_state_force}"
   )
+
+
+def test_global_frame_maxforce_rotation(device):
+  """
+  A box at rest on a plane has its contact normals all vertical.
+  """
+  cfg = ContactSensorCfg(
+    name="box_contact",
+    primary=ContactMatch(mode="geom", pattern="box_geom", entity="box"),
+    fields=("found", "force", "normal", "tangent"),
+    reduce="maxforce",
+    global_frame=True,
+  )
+  scene, sim = create_scene_with_sensor(FALLING_BOX_XML, "box", cfg, device)
+
+  root_state = torch.zeros((2, 13), device=sim.device)
+  root_state[:, 2] = 0.11
+  root_state[:, 3] = 1.0
+  scene["box"].write_root_state_to_sim(root_state)
+  for _ in range(150):
+    sim.step()
+    scene.update(dt=sim.cfg.mujoco.timestep)
+
+  sensor_force = scene["box_contact"].data.force[:, 0, :]
+
+  # On a flat plane the contact normal is vertical, so a correctly rotated
+  # global-frame force should have its magnitude entirely on the z axis.
+  assert torch.all(sensor_force[:, 0].abs() < 0.05), (
+    f"sensor_force x-component should be ~0, got {sensor_force[:, 0].tolist()}"
+  )
+  assert torch.all(sensor_force[:, 1].abs() < 0.05), (
+    f"sensor_force y-component should be ~0, got {sensor_force[:, 1].tolist()}"
+  )
+  assert torch.all(sensor_force[:, 2].abs() > 1.0), (
+    f"sensor_force z-component should be non-trivial, got {sensor_force[:, 2].tolist()}"
+  )


### PR DESCRIPTION
There exists a bug when `ContactSensor` `global_frame=True` and `reduce != "netforce"`

Contact forces were incorrectly ordered as [tangent, tangent, normal]. From the mujoco [docs](https://mujoco.readthedocs.io/en/stable/computation/index.html#contact):

> The first ( axis of this frame is the contact normal direction, while the remaining y and z axes define the tangent plane. One might have expected the normal to correspond to the z axis, as in MuJoCo’s visualization convention, but we support frictionless contacts where only the normal axis is used, which is why we want to have the normal in first position.

Adds a unit test that prior to fix would fail with the following but is now passing.
```
>     assert torch.all(sensor_force[:, 1].abs() < 0.05), (
        f"sensor_force y-component should be ~0, got {sensor_force[:, 1].tolist()}"
      )
E     AssertionError: sensor_force y-component should be ~0, got [-2.4564199447631836, -2.4564199447631836]
E     assert tensor(False, device='cuda:0')
E      +  where tensor(False, device='cuda:0') = <built-in method all of type object at 0x7240481dcac0>(tensor([2.4564, 2.4564], device='cuda:0') < 0.05)
E      +    where <built-in method all of type object at 0x7240481dcac0> = torch.all
E      +    and   tensor([2.4564, 2.4564], device='cuda:0') = <built-in method abs of Tensor object at 0x723e8d3ccf50>()
E      +      where <built-in method abs of Tensor object at 0x723e8d3ccf50> = tensor([-2.4564, -2.4564], device='cuda:0').abs
```