### PR TITLE
per world material

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -36,6 +36,11 @@ Added
   same kinematic structure (same bodies, joints, joint types); only
   mesh geoms may differ. Assignment is fixed at simulation init. See
   :ref:`heterogeneous_worlds` for usage. With help from @XiangruiJiang.
+- Per-world mesh variants now support per-variant materials and textures.
+  Each variant can reference its own named material, which is automatically
+  prefixed and scattered via ``geom_matid`` alongside the existing
+  ``geom_dataid`` table. Variants without a material get ``matid = -1``.
+  Contribution by @omarrayyann.
 
 Changed
 ^^^^^^^

--- a/src/mjlab/entity/variants.py
+++ b/src/mjlab/entity/variants.py
@@ -47,7 +47,7 @@ import warp as wp
 
 from mjlab.entity.entity import EntityCfg
 from mjlab.utils.mujoco import dof_width, qpos_width
-from mjlab.utils.spec import copy_mesh_data
+from mjlab.utils.spec import copy_material_data, copy_mesh_data, copy_texture_data
 
 # Reserved name prefixes for synthesized template entities. Source variant
 # specs must not create geoms, bodies, meshes, or other named items under
@@ -967,6 +967,38 @@ def build_merged_variant_spec(
       new_mesh.name = f"{prefix}{mesh.name}"
       copy_mesh_data(mesh, new_mesh)
 
+  # Mirror of the mesh treatment above for textures and materials.
+  texture_old_to_new: dict[str, str] = {}
+  for tex in template_spec.textures:
+    new_name = f"{template_prefix}{tex.name}"
+    texture_old_to_new[tex.name] = new_name
+    tex.name = new_name
+  material_old_to_new: dict[str, str] = {}
+  for mat in template_spec.materials:
+    new_name = f"{template_prefix}{mat.name}"
+    material_old_to_new[mat.name] = new_name
+    mat.name = new_name
+    mat.textures = [texture_old_to_new.get(t, t) for t in mat.textures]
+  for _, body in _iter_body_paths(template_body):
+    for g in body.geoms:
+      if g.material in material_old_to_new:
+        g.material = material_old_to_new[g.material]
+
+  # Copy texture/material assets from other variants into the template.
+  for i in range(1, len(variant_specs)):
+    prefix = f"{variant_names[i]}/"
+    src_to_dst_tex: dict[str, str] = {}
+    for tex in variant_specs[i].textures:
+      new_tex = template_spec.add_texture()
+      new_tex.name = f"{prefix}{tex.name}"
+      src_to_dst_tex[tex.name] = new_tex.name
+      copy_texture_data(tex, new_tex)
+    for mat in variant_specs[i].materials:
+      new_mat = template_spec.add_material()
+      new_mat.name = f"{prefix}{mat.name}"
+      copy_material_data(mat, new_mat)
+      new_mat.textures = [src_to_dst_tex.get(t, t) for t in new_mat.textures]
+
   # (2) Slot-driven rename of variant 0's existing mesh geoms. Walk
   # the template body tree; within each (body, role) bucket, the
   # n-th mesh geom (in source order) maps to slot ordinal n.
@@ -1052,6 +1084,18 @@ def _qualified_mesh_name(entity_prefix: str, variant_name: str, mesh_name: str) 
   added (``<entity>/<variant>/<mesh>``).
   """
   return f"{entity_prefix}{variant_name}/{mesh_name}"
+
+
+def _qualified_material_name(
+  entity_prefix: str, variant_name: str, material_name: str
+) -> str:
+  """Material asset name in the merged template's namespace.
+
+  Source materials are prefixed with the variant name during merge
+  (``<variant>/<material>``); after scene attach the entity prefix is
+  added (``<entity>/<variant>/<material>``).
+  """
+  return f"{entity_prefix}{variant_name}/{material_name}"
 
 
 def _qualified_slot_geom_name(entity_prefix: str, template_geom_name: str) -> str:
@@ -1298,6 +1342,10 @@ def build_variant_model(
   base_dataid = model.geom_dataid.copy()
   dataid_table = np.tile(base_dataid, (nworld, 1))
 
+  # Same treatment for matid so each variant can use its own material.
+  base_matid = model.geom_matid.copy()
+  matid_table = np.tile(base_matid, (nworld, 1))
+
   world_to_variant: dict[str, np.ndarray] = {}
 
   for entity_prefix, metadata in variant_info:
@@ -1342,9 +1390,11 @@ def build_variant_model(
         )
       slot_geom_ids[s_idx] = gid
 
-    # Resolve every (variant, slot) -> mesh_id. ``-1`` for slots a
-    # variant doesn't fill.
+    # Resolve every (variant, slot) -> (mesh_id, mat_id). ``-1`` denotes
+    # an unfilled slot (mesh) or a slot rendered without a material
+    # (matid).
     variant_slot_mesh_ids = np.full((nvariants, nslots), -1, dtype=np.int64)
+    variant_slot_matids = np.full((nvariants, nslots), -1, dtype=np.int64)
     for v_idx, slot_specs in enumerate(metadata.variant_slot_specs):
       variant_name = metadata.variant_names[v_idx]
       for s_idx, gspec in enumerate(slot_specs):
@@ -1360,13 +1410,26 @@ def build_variant_model(
             f"slot {slots[s_idx].key}) not found in compiled model."
           )
         variant_slot_mesh_ids[v_idx, s_idx] = mid
+        if gspec.material:
+          full_mat_name = _qualified_material_name(
+            entity_prefix, variant_name, gspec.material
+          )
+          matid = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_MATERIAL, full_mat_name)
+          if matid < 0:
+            raise ValueError(
+              f"Material '{full_mat_name}' (variant '{variant_name}', "
+              f"slot {slots[s_idx].key}) not found in compiled model."
+            )
+          variant_slot_matids[v_idx, s_idx] = matid
 
     # Vectorized scatter: per-world row from variant assignment.
     dataid_table[:, slot_geom_ids] = variant_slot_mesh_ids[w2v]
+    matid_table[:, slot_geom_ids] = variant_slot_matids[w2v]
 
   # Build warp model.
   m = mjwarp.put_model(model)
   m.geom_dataid = wp.array(dataid_table, dtype=int)
+  m.geom_matid = wp.array(matid_table, dtype=int)
 
   # Populate dependent per-world fields.
   _populate_dependent_fields(m, model, nworld, variant_info, world_to_variant)

--- a/src/mjlab/entity/variants.py
+++ b/src/mjlab/entity/variants.py
@@ -433,6 +433,7 @@ def _check_reserved_names(spec: mujoco.MjSpec, variant_name: str) -> None:
     ("geoms", "geom"),
     ("meshes", "mesh"),
     ("materials", "material"),
+    ("textures", "texture"),
     ("joints", "joint"),
     ("actuators", "actuator"),
     ("tendons", "tendon"),

--- a/src/mjlab/sim/sim.py
+++ b/src/mjlab/sim/sim.py
@@ -275,6 +275,7 @@ class Simulation:
     # viewer syncs them per-world.
     self._expanded_fields.update(VARIANT_DEPENDENT_FIELDS)
     self._expanded_fields.add("geom_dataid")
+    self._expanded_fields.add("geom_matid")
 
     # Stash variant assignments as torch tensors keyed by bare entity name
     # (build_variant_model emits "<name>/" prefixes; strip the trailing slash for

--- a/src/mjlab/utils/spec.py
+++ b/src/mjlab/utils/spec.py
@@ -465,3 +465,54 @@ def copy_mesh_data(src: mujoco.MjsMesh, dst: mujoco.MjsMesh) -> None:
   dst.refpos[:] = src.refpos
   dst.refquat[:] = src.refquat
   dst.smoothnormal = src.smoothnormal
+
+
+def copy_texture_data(src: mujoco.MjsTexture, dst: mujoco.MjsTexture) -> None:
+  """Copy texture data from *src* to *dst*.
+
+  Copies the file path or builtin/data fields, format, dimensions, and color
+  settings. The ``name`` field is NOT copied; set it on *dst* before calling.
+  """
+  assert dst.name, "dst.name must be set before copy_texture_data."
+  dst.type = src.type
+  dst.colorspace = src.colorspace
+  dst.builtin = src.builtin
+  dst.mark = src.mark
+  dst.rgb1[:] = src.rgb1
+  dst.rgb2[:] = src.rgb2
+  dst.markrgb[:] = src.markrgb
+  dst.random = src.random
+  dst.gridsize[:] = src.gridsize
+  dst.gridlayout = src.gridlayout
+  dst.width = src.width
+  dst.height = src.height
+  dst.nchannel = src.nchannel
+  dst.hflip = src.hflip
+  dst.vflip = src.vflip
+  if src.file:
+    dst.file = src.file
+  if len(src.cubefiles) > 0:
+    dst.cubefiles = src.cubefiles
+  if len(src.data) > 0:
+    dst.data = src.data
+  if src.content_type:
+    dst.content_type = src.content_type
+
+
+def copy_material_data(src: mujoco.MjsMaterial, dst: mujoco.MjsMaterial) -> None:
+  """Copy material data from *src* to *dst*.
+
+  Copies appearance settings (rgba, specular, shininess, ...) and texture
+  bindings. The ``name`` field is NOT copied; set it on *dst* before calling.
+  """
+  assert dst.name, "dst.name must be set before copy_material_data."
+  dst.rgba[:] = src.rgba
+  dst.emission = src.emission
+  dst.specular = src.specular
+  dst.shininess = src.shininess
+  dst.reflectance = src.reflectance
+  dst.roughness = src.roughness
+  dst.metallic = src.metallic
+  dst.texuniform = src.texuniform
+  dst.texrepeat[:] = src.texrepeat
+  dst.textures = list(src.textures)

--- a/src/mjlab/viewer/model_sync.py
+++ b/src/mjlab/viewer/model_sync.py
@@ -25,6 +25,7 @@ VIEWER_MODEL_FIELDS = frozenset(
   {
     "qpos0",  # Needed for correct mj_forward kinematics (qpos - qpos0).
     "geom_dataid",  # Per-world mesh variants.
+    "geom_matid",  # Per-world material variants.
     "geom_rgba",
     "geom_size",
     "geom_pos",

--- a/tests/test_variants.py
+++ b/tests/test_variants.py
@@ -1036,6 +1036,107 @@ def test_dataid_assigned_per_world():
   assert not np.array_equal(dataid[0], dataid[2])
 
 
+def _sphere_with_material_spec() -> mujoco.MjSpec:
+  """Single-geom sphere whose visual references a named material."""
+  spec = mujoco.MjSpec()
+  m = spec.add_mesh()
+  m.name = "sphere"
+  m.make_sphere(subdivision=2)
+  mat = spec.add_material()
+  mat.name = "red_mat"
+  mat.rgba[:] = (1.0, 0.0, 0.0, 1.0)
+  body = spec.worldbody.add_body()
+  body.name = "prop"
+  body.add_freejoint()
+  g = body.add_geom()
+  g.name = "visual"
+  g.type = mujoco.mjtGeom.mjGEOM_MESH
+  g.meshname = "sphere"
+  g.material = "red_mat"
+  return spec
+
+
+def _cone_with_material_spec() -> mujoco.MjSpec:
+  """Single-geom cone whose visual references a different named material."""
+  spec = mujoco.MjSpec()
+  m = spec.add_mesh()
+  m.name = "cone"
+  m.make_cone(nedge=8, radius=0.05)
+  mat = spec.add_material()
+  mat.name = "blue_mat"
+  mat.rgba[:] = (0.0, 0.0, 1.0, 1.0)
+  body = spec.worldbody.add_body()
+  body.name = "prop"
+  body.add_freejoint()
+  g = body.add_geom()
+  g.name = "visual"
+  g.type = mujoco.mjtGeom.mjGEOM_MESH
+  g.meshname = "cone"
+  g.material = "blue_mat"
+  return spec
+
+
+def test_materials_merged_under_variant_prefix():
+  """Both variants' materials end up in the merged spec, name-prefixed."""
+  scene_spec, vi = _build_scene_with_variants(
+    _sphere_with_material_spec, _cone_with_material_spec
+  )
+  model = scene_spec.compile()
+  mat_names = {model.material(i).name for i in range(model.nmat)}
+  assert "object/a/red_mat" in mat_names
+  assert "object/b/blue_mat" in mat_names
+
+
+def test_matid_assigned_per_world():
+  """Each world's geom_matid points to its variant's material."""
+  scene_spec, vi = _build_scene_with_variants(
+    _sphere_with_material_spec, _cone_with_material_spec
+  )
+  result = build_variant_model(scene_spec, 4, vi)
+
+  matid = result.wp_model.geom_matid.numpy()
+  assert matid.shape == (4, result.mj_model.ngeom)
+
+  w2v = result.world_to_variant["object/"]
+  red_id = mujoco.mj_name2id(
+    result.mj_model, mujoco.mjtObj.mjOBJ_MATERIAL, "object/a/red_mat"
+  )
+  blue_id = mujoco.mj_name2id(
+    result.mj_model, mujoco.mjtObj.mjOBJ_MATERIAL, "object/b/blue_mat"
+  )
+  assert red_id >= 0 and blue_id >= 0 and red_id != blue_id
+
+  # Slot geom is the last mesh geom (single-geom variants -> ordinal 0).
+  slot_gid = next(
+    gid
+    for gid in range(result.mj_model.ngeom - 1, -1, -1)
+    if result.mj_model.geom_type[gid] == mujoco.mjtGeom.mjGEOM_MESH
+  )
+
+  for w in range(4):
+    expected = red_id if w2v[w] == 0 else blue_id
+    assert int(matid[w, slot_gid]) == expected
+
+
+def test_matid_minus_one_when_variant_has_no_material():
+  """A variant slot without a material yields geom_matid == -1 in its worlds."""
+  scene_spec, vi = _build_scene_with_variants(
+    _sphere_with_material_spec,
+    _simple_cone_spec,  # cone has no material
+  )
+  result = build_variant_model(scene_spec, 4, vi)
+
+  matid = result.wp_model.geom_matid.numpy()
+  w2v = result.world_to_variant["object/"]
+  slot_gid = next(
+    gid
+    for gid in range(result.mj_model.ngeom - 1, -1, -1)
+    if result.mj_model.geom_type[gid] == mujoco.mjtGeom.mjGEOM_MESH
+  )
+  cone_world = int(np.where(w2v == 1)[0][0])
+  assert int(matid[cone_world, slot_gid]) == -1
+
+
 def test_padding_slots_get_disabled():
   """Shorter variant's padding geom slots have dataid == -1."""
   scene_spec, vi = _build_scene_with_variants(_sphere_2col_spec, _cone_4col_spec)


### PR DESCRIPTION
Extends per-world variants so each variant can have its own material/texture.  `build_merged_variant_spec` copies them (like the mesh copy), and `build_variant_model` scatters them back per-world. Added tests with/without materials.

| Before | After |
|--------|-------|
| <img  src="https://github.com/user-attachments/assets/afd8eb84-4cb2-4931-b856-e841f39c5877" /> | <img src="https://github.com/user-attachments/assets/8c422d6d-82a0-496c-bdef-0f801c8557ea" /> |
