### PR TITLE
Remove use of deprecated warp-lang symbols

### DIFF
--- a/src/mjlab/sensor/raycast_sensor.py
+++ b/src/mjlab/sensor/raycast_sensor.py
@@ -435,7 +435,7 @@ class RayCastSensor(Sensor[RayCastData]):
     self._model: mjwarp.Model | None = None
     self._mj_model: mujoco.MjModel | None = None
     self._device: str | None = None
-    self._wp_device: wp.context.Device | None = None
+    self._wp_device: wp.Device | None = None
 
     # Per-frame info: list of (frame_type, obj_id, body_id).
     self._frame_infos: list[tuple[Literal["body", "site", "geom"], int, int]] = []

--- a/src/mjlab/sim/sim.py
+++ b/src/mjlab/sim/sim.py
@@ -526,7 +526,7 @@ class Simulation:
     if not self.wp_device.is_cuda:
       return False
 
-    driver_ver = wp.context.runtime.driver_version
+    driver_ver = wp.get_cuda_driver_version()
     has_mempool = wp.is_mempool_enabled(self.wp_device)
 
     if driver_ver is None:


### PR DESCRIPTION
Fixes #967 by switching to the non-deprecated warp API. This should unblock warp-lang 1.13+. 