### PR TITLE
Remove stale commented-out foot collision geoms from G1 XML

### DIFF
--- a/src/mjlab/asset_zoo/robots/unitree_g1/xmls/g1.xml
+++ b/src/mjlab/asset_zoo/robots/unitree_g1/xmls/g1.xml
@@ -102,11 +102,6 @@
                     diaginertia="0.00167218 0.0016161 0.000217621"/>
                   <joint name="left_ankle_roll_joint" axis="1 0 0" range="-0.2618 0.2618"/>
                   <geom class="visual" material="black" mesh="left_ankle_roll_link"/>
-                  <!-- <geom name="left_foot1_collision" class="foot_capsule" fromto="0.1 -0.026 -0.025 0.05 -0.027
-                  -0.025"/>
-                  <geom name="left_foot2_collision" class="foot_capsule" fromto="-0.045 0 -0.015 0.12 0 -0.015"
-                    size="0.02"/>
-                  <geom name="left_foot3_collision" class="foot_capsule" fromto="0.1 0.026 -0.025 0.05 0.026 -0.025"/> -->
                   <geom name="left_foot1_collision" class="foot_capsule" fromto="0.1 -0.026 -0.025 0.05 -0.027 -0.025"/>
                   <geom name="left_foot2_collision" class="foot_capsule"
                     fromto="-0.044 -0.018 -0.025 0.123 -0.018 -0.025"/>
@@ -156,11 +151,6 @@
                     diaginertia="0.00167218 0.0016161 0.000217621"/>
                   <joint name="right_ankle_roll_joint" axis="1 0 0" range="-0.2618 0.2618"/>
                   <geom class="visual" material="black" mesh="right_ankle_roll_link"/>
-                  <!-- <geom name="right_foot1_collision" class="foot_capsule" fromto="0.1 -0.026 -0.025 0.05 -0.026
-                  -0.025"/>
-                  <geom name="right_foot2_collision" class="foot_capsule" fromto="-0.045 0 -0.015 0.12 0 -0.015"
-                    size="0.02"/>
-                  <geom name="right_foot3_collision" class="foot_capsule" fromto="0.1 0.026 -0.025 0.05 0.026 -0.025"/> -->
                   <geom name="right_foot1_collision" class="foot_capsule" fromto="0.1 -0.026 -0.025 0.05 -0.026 -0.025"/>
                   <geom name="right_foot2_collision" class="foot_capsule"
                     fromto="-0.044 -0.018 -0.025 0.123 -0.018 -0.025"/>


### PR DESCRIPTION
The G1 XML had commented-out foot collision geoms for both left and right feet that were superseded when the foot collision geometry was updated to use more capsules. The first geom in each commented block was identical to the active one, and the remaining two had different values. Removing the dead comments to reduce clutter.