### PR TITLE
Fix pd_gains and effort_limits silently ignoring Operation objects

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -80,6 +80,10 @@ Changed
 Fixed
 ^^^^^
 
+- Fixed ``dr.pd_gains`` and ``dr.effort_limits`` silently no-oping when
+  passed an ``Operation`` object (e.g. ``dr.scale``) instead of a string.
+  Both functions now accept ``Operation | str`` like every other DR event
+  and raise ``ValueError`` for unsupported operations (:issue:`971`).
 - Fixed ``ContactSensor`` with ``global_frame=True`` and
   ``reduce`` ∈ {``"none"``, ``"mindist"``, ``"maxforce"``} producing forces
   rotated onto the wrong axis. The contact-frame→world rotation matrix had

--- a/src/mjlab/envs/mdp/dr/actuator.py
+++ b/src/mjlab/envs/mdp/dr/actuator.py
@@ -93,6 +93,7 @@ def pd_gains(
           default_biasprm[ctrl_ids, 2] * kd_samples
         )
       else:
+        assert op.name == "abs"
         env.sim.model.actuator_gainprm[env_ids[:, None], ctrl_ids, 0] = kp_samples
         env.sim.model.actuator_biasprm[env_ids[:, None], ctrl_ids, 1] = -kp_samples
         env.sim.model.actuator_biasprm[env_ids[:, None], ctrl_ids, 2] = -kd_samples
@@ -109,6 +110,7 @@ def pd_gains(
           kd=actuator.default_damping[env_ids] * kd_samples,
         )
       else:
+        assert op.name == "abs"
         actuator.set_gains(env_ids, kp=kp_samples, kd=kd_samples)
 
     else:
@@ -182,6 +184,7 @@ def effort_limits(
           default_forcerange[ctrl_ids, 1] * effort_samples
         )
       else:
+        assert op.name == "abs"
         env.sim.model.actuator_forcerange[
           env_ids[:, None], ctrl_ids, 0
         ] = -effort_samples
@@ -198,6 +201,7 @@ def effort_limits(
           effort_limit=actuator.default_force_limit[env_ids] * effort_samples,
         )
       else:
+        assert op.name == "abs"
         actuator.set_effort_limit(env_ids, effort_limit=effort_samples)
 
     else:

--- a/src/mjlab/envs/mdp/dr/actuator.py
+++ b/src/mjlab/envs/mdp/dr/actuator.py
@@ -13,7 +13,7 @@ from mjlab.managers.event_manager import requires_model_fields
 from mjlab.managers.scene_entity_config import SceneEntityCfg
 
 from ._core import _DEFAULT_ASSET_CFG
-from ._types import resolve_distribution
+from ._types import Operation, resolve_distribution, resolve_operation
 
 if TYPE_CHECKING:
   from mjlab.envs import ManagerBasedRlEnv
@@ -27,7 +27,7 @@ def pd_gains(
   kd_range: tuple[float, float],
   asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
   distribution: Literal["uniform", "log_uniform"] = "uniform",
-  operation: Literal["scale", "abs"] = "scale",
+  operation: Operation | str = "scale",
 ) -> None:
   """Randomize PD stiffness and damping gains.
 
@@ -41,6 +41,11 @@ def pd_gains(
     operation: "scale" multiplies default gains by sampled values, "abs" sets
       absolute values.
   """
+  op = resolve_operation(operation)
+  if op.name not in ("scale", "abs"):
+    raise ValueError(
+      f"pd_gains only supports 'scale' and 'abs' operations, got {op.name!r}"
+    )
   asset: Entity = env.scene[asset_cfg.name]
 
   if env_ids is None:
@@ -75,7 +80,7 @@ def pd_gains(
     if isinstance(actuator, BuiltinPositionActuator) or (
       isinstance(actuator, XmlActuator) and actuator.command_field == "position"
     ):
-      if operation == "scale":
+      if op.name == "scale":
         default_gainprm = env.sim.get_default_field("actuator_gainprm")
         default_biasprm = env.sim.get_default_field("actuator_biasprm")
         env.sim.model.actuator_gainprm[env_ids[:, None], ctrl_ids, 0] = (
@@ -87,7 +92,7 @@ def pd_gains(
         env.sim.model.actuator_biasprm[env_ids[:, None], ctrl_ids, 2] = (
           default_biasprm[ctrl_ids, 2] * kd_samples
         )
-      elif operation == "abs":
+      else:
         env.sim.model.actuator_gainprm[env_ids[:, None], ctrl_ids, 0] = kp_samples
         env.sim.model.actuator_biasprm[env_ids[:, None], ctrl_ids, 1] = -kp_samples
         env.sim.model.actuator_biasprm[env_ids[:, None], ctrl_ids, 2] = -kd_samples
@@ -95,7 +100,7 @@ def pd_gains(
     elif isinstance(actuator, IdealPdActuator):
       assert actuator.stiffness is not None
       assert actuator.damping is not None
-      if operation == "scale":
+      if op.name == "scale":
         assert actuator.default_stiffness is not None
         assert actuator.default_damping is not None
         actuator.set_gains(
@@ -103,7 +108,7 @@ def pd_gains(
           kp=actuator.default_stiffness[env_ids] * kp_samples,
           kd=actuator.default_damping[env_ids] * kd_samples,
         )
-      elif operation == "abs":
+      else:
         actuator.set_gains(env_ids, kp=kp_samples, kd=kd_samples)
 
     else:
@@ -121,7 +126,7 @@ def effort_limits(
   effort_limit_range: tuple[float, float],
   asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
   distribution: Literal["uniform", "log_uniform"] = "uniform",
-  operation: Literal["scale", "abs"] = "scale",
+  operation: Operation | str = "scale",
 ) -> None:
   """Randomize actuator effort limits.
 
@@ -133,6 +138,11 @@ def effort_limits(
     distribution: Distribution type ("uniform" or "log_uniform").
     operation: "scale" multiplies default limits, "abs" sets absolute values.
   """
+  op = resolve_operation(operation)
+  if op.name not in ("scale", "abs"):
+    raise ValueError(
+      f"effort_limits only supports 'scale' and 'abs' operations, got {op.name!r}"
+    )
   asset: Entity = env.scene[asset_cfg.name]
 
   if env_ids is None:
@@ -163,7 +173,7 @@ def effort_limits(
     if isinstance(actuator, BuiltinPositionActuator) or (
       isinstance(actuator, XmlActuator) and actuator.command_field == "position"
     ):
-      if operation == "scale":
+      if op.name == "scale":
         default_forcerange = env.sim.get_default_field("actuator_forcerange")
         env.sim.model.actuator_forcerange[env_ids[:, None], ctrl_ids, 0] = (
           default_forcerange[ctrl_ids, 0] * effort_samples
@@ -171,7 +181,7 @@ def effort_limits(
         env.sim.model.actuator_forcerange[env_ids[:, None], ctrl_ids, 1] = (
           default_forcerange[ctrl_ids, 1] * effort_samples
         )
-      elif operation == "abs":
+      else:
         env.sim.model.actuator_forcerange[
           env_ids[:, None], ctrl_ids, 0
         ] = -effort_samples
@@ -181,13 +191,13 @@ def effort_limits(
 
     elif isinstance(actuator, IdealPdActuator):
       assert actuator.force_limit is not None
-      if operation == "scale":
+      if op.name == "scale":
         assert actuator.default_force_limit is not None
         actuator.set_effort_limit(
           env_ids,
           effort_limit=actuator.default_force_limit[env_ids] * effort_samples,
         )
-      elif operation == "abs":
+      else:
         actuator.set_effort_limit(env_ids, effort_limit=effort_samples)
 
     else:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -418,6 +418,62 @@ def test_effort_limits_scale_no_accumulation(device):
   assert abs(actual_upper - 200.0) < 1e-5
 
 
+def test_pd_gains_accepts_operation_object(device):
+  """dr.scale / dr.abs Operation objects produce the same result as strings."""
+  env_str, ideal_str = _make_pd_env(device)
+  env_obj, ideal_obj = _make_pd_env(device)
+
+  ids = torch.tensor([0], device=device)
+  kwargs = dict(
+    kp_range=(1.5, 1.5), kd_range=(2.0, 2.0), asset_cfg=SceneEntityCfg("robot")
+  )
+
+  torch.manual_seed(0)
+  dr.pd_gains(env_str, ids, operation="scale", **kwargs)
+  torch.manual_seed(0)
+  dr.pd_gains(env_obj, ids, operation=dr.scale, **kwargs)
+
+  assert torch.allclose(
+    env_str.sim.model.actuator_gainprm[0], env_obj.sim.model.actuator_gainprm[0]
+  )
+  assert torch.allclose(ideal_str.stiffness, ideal_obj.stiffness)
+
+
+def test_effort_limits_accepts_operation_object(device):
+  """dr.abs Operation object produces the same result as the string."""
+  env_str, ideal_str = _make_effort_env(device)
+  env_obj, ideal_obj = _make_effort_env(device)
+
+  ids = torch.tensor([0], device=device)
+  kwargs = dict(effort_limit_range=(150.0, 150.0), asset_cfg=SceneEntityCfg("robot"))
+
+  dr.effort_limits(env_str, ids, operation="abs", **kwargs)
+  dr.effort_limits(env_obj, ids, operation=dr.abs, **kwargs)
+
+  assert torch.allclose(
+    env_str.sim.model.actuator_forcerange[0], env_obj.sim.model.actuator_forcerange[0]
+  )
+  assert torch.allclose(ideal_str.force_limit, ideal_obj.force_limit)
+
+
+def test_pd_gains_rejects_unsupported_operation(device):
+  """Operations other than scale/abs raise ValueError."""
+  env, _ = _make_pd_env(device)
+  ids = torch.tensor([0], device=device)
+
+  with pytest.raises(ValueError, match="only supports 'scale' and 'abs'"):
+    dr.pd_gains(env, ids, kp_range=(1.0, 1.0), kd_range=(1.0, 1.0), operation=dr.add)
+
+
+def test_effort_limits_rejects_unsupported_operation(device):
+  """Operations other than scale/abs raise ValueError."""
+  env, _ = _make_effort_env(device)
+  ids = torch.tensor([0], device=device)
+
+  with pytest.raises(ValueError, match="only supports 'scale' and 'abs'"):
+    dr.effort_limits(env, ids, effort_limit_range=(1.0, 1.0), operation=dr.add)
+
+
 # ===========================================================================
 # Section 3: Other events
 # ===========================================================================


### PR DESCRIPTION
`dr.pd_gains` and `dr.effort_limits` accepted only `Literal["scale", "abs"]` strings for their `operation` parameter, unlike every other DR event which accepts `Operation | str`. Passing an `Operation` instance (e.g. `dr.scale` instead of `"scale"`) would silently skip all `if`/`elif` branches and do nothing.

Both functions now resolve the operation via `resolve_operation()`, compare against `op.name`, and raise `ValueError` for unsupported operations (e.g. `dr.add`). The `elif`-abs branches become `else` since the guard at the top already restricts to only scale/abs.

Fixes #971