### PR TITLE
Remove tautological if/else in apply_body_impulse.reset

### DIFF
--- a/src/mjlab/envs/mdp/events.py
+++ b/src/mjlab/envs/mdp/events.py
@@ -553,13 +553,7 @@ class apply_body_impulse:
     if env_ids is None:
       env_ids = slice(None)
 
-    # Clear forces for reset envs.
-    if isinstance(env_ids, slice):
-      reset_ids = env_ids
-    else:
-      reset_ids = env_ids
-
-    if self._active[reset_ids].any():
+    if self._active[env_ids].any():
       if isinstance(env_ids, slice):
         active_ids = self._active.nonzero(as_tuple=False).squeeze(-1)
       else:
@@ -573,6 +567,6 @@ class apply_body_impulse:
           zeros, zeros, env_ids=active_ids, body_ids=self._body_ids
         )
 
-    self._time_remaining[reset_ids] = 0.0
-    self._interval_time_left[reset_ids] = 0.0
-    self._active[reset_ids] = False
+    self._time_remaining[env_ids] = 0.0
+    self._interval_time_left[env_ids] = 0.0
+    self._active[env_ids] = False


### PR DESCRIPTION
The `reset` method on `apply_body_impulse` had an `if isinstance(env_ids, slice)` block whose two branches both assigned `reset_ids = env_ids`, making the alias pure dead code. This drops the branch and uses `env_ids` directly.

Pure refactor — no behavioral change. The existing `apply_body_impulse` tests (including `test_apply_body_impulse_reset_clears`) still pass.

Thanks to @rdeits-bd for catching this in the [#735 review](https://github.com/mujocolab/mjlab/pull/735#discussion_r3198548596).