### PR TITLE
Sample apply_body_impulse cooldown lazily on first step

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -80,6 +80,10 @@ Changed
 Fixed
 ^^^^^
 
+- Fixed ``apply_body_impulse`` firing an impulse on the very first step (and
+  the first step after every reset) instead of starting with a cooldown as
+  documented. The cooldown is now sampled lazily on the first call so impulse
+  timing is decorrelated from episode resets (:issue:`973`).
 - Fixed ``dr.pd_gains`` and ``dr.effort_limits`` silently no-oping when
   passed an ``Operation`` object (e.g. ``dr.scale``) instead of a string.
   Both functions now accept ``Operation | str`` like every other DR event

--- a/src/mjlab/envs/mdp/events.py
+++ b/src/mjlab/envs/mdp/events.py
@@ -425,6 +425,9 @@ class apply_body_impulse:
     self._time_remaining = torch.zeros(self._num_envs, device=self._device)
     self._interval_time_left = torch.zeros(self._num_envs, device=self._device)
     self._active = torch.zeros(self._num_envs, device=self._device, dtype=torch.bool)
+    # Cooldown is sampled lazily on the first call (and after reset), since
+    # cooldown_s is only available at __call__ time.
+    self._needs_init = torch.ones(self._num_envs, device=self._device, dtype=torch.bool)
 
   def __call__(
     self,
@@ -454,6 +457,17 @@ class apply_body_impulse:
     """
     del env, env_ids, asset_cfg  # Unused.
     dt = self._step_dt
+
+    # Sample initial cooldowns for envs starting fresh (first call or after
+    # reset) so the first impulse is preceded by a cooldown rather than firing
+    # immediately at t=0.
+    if self._needs_init.any():
+      init_ids = self._needs_init.nonzero(as_tuple=False).squeeze(-1)
+      int_low, int_high = cooldown_s
+      self._interval_time_left[init_ids] = (
+        torch.rand(len(init_ids), device=self._device) * (int_high - int_low) + int_low
+      )
+      self._needs_init[init_ids] = False
 
     # Decrement timers for active envs.
     self._time_remaining[self._active] -= dt
@@ -570,3 +584,4 @@ class apply_body_impulse:
     self._time_remaining[env_ids] = 0.0
     self._interval_time_left[env_ids] = 0.0
     self._active[env_ids] = False
+    self._needs_init[env_ids] = True

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -590,8 +590,10 @@ def test_apply_body_impulse_basic(device):
     device, num_envs=2, num_bodies=3, body_ids=[1]
   )
 
-  # First call: cooldown_s starts at 0 and gets decremented by dt,
-  # so it becomes <= 0 and triggers.
+  # Skip the initial cooldown so the first call triggers immediately;
+  # the trigger/sustain/expire cycle is what's under test here.
+  impulse._needs_init[:] = False
+
   impulse(
     env,
     None,
@@ -697,6 +699,43 @@ def test_apply_body_impulse_reset_clears(device):
   env_ids_arg = call_args[1]["env_ids"]
   assert len(env_ids_arg) == 1
   assert env_ids_arg[0].item() == 0
+
+
+def test_apply_body_impulse_initial_cooldown(device):
+  """The first call after init/reset enters cooldown, not an immediate impulse.
+
+  Regression test for #973.
+  """
+  env, mock_entity, asset_cfg, impulse = _make_impulse_env(
+    device, num_envs=1, num_bodies=1, body_ids=[0]
+  )
+
+  def step():
+    impulse(
+      env,
+      None,
+      force_range=(10.0, 10.0),
+      torque_range=(0.0, 0.0),
+      duration_s=(1.0, 1.0),
+      cooldown_s=(0.05, 0.05),  # ~2.5 steps at dt=0.02
+      asset_cfg=asset_cfg,
+    )
+
+  # First two steps consume the sampled cooldown; impulse must not fire yet.
+  step()
+  assert not impulse._active.any()
+  step()
+  assert not impulse._active.any()
+
+  # Third step crosses the cooldown boundary and triggers.
+  step()
+  assert impulse._active.all()
+
+  # Reset re-enters cooldown: next step should not immediately re-trigger.
+  impulse.reset(env_ids=torch.tensor([0], device=device))
+  assert not impulse._active.any()
+  step()
+  assert not impulse._active.any()
 
 
 # ===========================================================================


### PR DESCRIPTION
The `apply_body_impulse` docstring describes the lifecycle as starting with a cooldown, but `_interval_time_left` was initialized to zero, so an impulse always fired on the very first step — and on the first step after every reset. That made impulse timing perfectly correlated with episode resets, which is exactly the kind of artifact an RL policy can learn around.

The fix is to sample the initial cooldown lazily on the first `__call__` (and on the first call after each reset), since `cooldown_s` is only available at `__call__` time. A small `_needs_init` bool tensor tracks which envs need a fresh cooldown sample. The rest of the cycle is unchanged.

Updated `test_apply_body_impulse_basic` to skip the initial cooldown explicitly — that test exercises the trigger/sustain/expire cycle, not the cooldown — and added `test_apply_body_impulse_initial_cooldown` as a targeted regression test covering all three properties: no fire on the first calls, fires once cooldown elapses, and reset re-enters cooldown.

Fixes #973.

Thanks to @rdeits-bd for the catch.