### PR TITLE
Clean up apply_body_impulse cooldown handling

### DIFF
--- a/src/mjlab/envs/mdp/events.py
+++ b/src/mjlab/envs/mdp/events.py
@@ -422,12 +422,16 @@ class apply_body_impulse:
       else self._asset.num_bodies
     )
 
+    self._cooldown_s: tuple[float, float] = cfg.params["cooldown_s"]
     self._time_remaining = torch.zeros(self._num_envs, device=self._device)
-    self._interval_time_left = torch.zeros(self._num_envs, device=self._device)
     self._active = torch.zeros(self._num_envs, device=self._device, dtype=torch.bool)
-    # Cooldown is sampled lazily on the first call (and after reset), since
-    # cooldown_s is only available at __call__ time.
-    self._needs_init = torch.ones(self._num_envs, device=self._device, dtype=torch.bool)
+    # Pre-sample the initial cooldown so the first impulse is preceded by a cooldown
+    # rather than firing immediately at t=0.
+    self._interval_time_left = self._sample_cooldown(self._num_envs)
+
+  def _sample_cooldown(self, n: int) -> torch.Tensor:
+    low, high = self._cooldown_s
+    return sample_uniform(low, high, n, self._device)
 
   def __call__(
     self,
@@ -449,25 +453,15 @@ class apply_body_impulse:
       torque_range: ``(min, max)`` uniform range for each torque component (Nm).
       duration_s: ``(min, max)`` uniform range for impulse duration in seconds.
       cooldown_s: ``(min, max)`` uniform range for the cooldown between consecutive
-        impulses in seconds.
+        impulses in seconds. Captured at init so the first impulse can be
+        preceded by a sampled cooldown; the kwarg passed here is unused.
       asset_cfg: Entity and body selection. ``body_ids`` on the config selects which
         bodies receive forces.
       body_point_offset: Optional ``(x, y, z)`` offset in the body frame where the
         force is applied. Generates additional torque via ``cross(offset, force)``.
     """
-    del env, env_ids, asset_cfg  # Unused.
+    del env, env_ids, asset_cfg, cooldown_s  # Unused at call time.
     dt = self._step_dt
-
-    # Sample initial cooldowns for envs starting fresh (first call or after
-    # reset) so the first impulse is preceded by a cooldown rather than firing
-    # immediately at t=0.
-    if self._needs_init.any():
-      init_ids = self._needs_init.nonzero(as_tuple=False).squeeze(-1)
-      int_low, int_high = cooldown_s
-      self._interval_time_left[init_ids] = (
-        torch.rand(len(init_ids), device=self._device) * (int_high - int_low) + int_low
-      )
-      self._needs_init[init_ids] = False
 
     # Decrement timers for active envs.
     self._time_remaining[self._active] -= dt
@@ -482,11 +476,7 @@ class apply_body_impulse:
       )
       self._active[expired_ids] = False
       self._time_remaining[expired_ids] = 0.0
-      int_low, int_high = cooldown_s
-      self._interval_time_left[expired_ids] = (
-        torch.rand(len(expired_ids), device=self._device) * (int_high - int_low)
-        + int_low
-      )
+      self._interval_time_left[expired_ids] = self._sample_cooldown(len(expired_ids))
 
     # Decrement interval timers.
     self._interval_time_left -= dt
@@ -528,10 +518,7 @@ class apply_body_impulse:
     self._active[trigger_ids] = True
 
     # Resample interval timers.
-    int_low, int_high = cooldown_s
-    self._interval_time_left[trigger_ids] = (
-      torch.rand(n, device=self._device) * (int_high - int_low) + int_low
-    )
+    self._interval_time_left[trigger_ids] = self._sample_cooldown(n)
 
   def debug_vis(self, visualizer: DebugVisualizer) -> None:
     """Draw arrows for active impulse forces."""
@@ -581,7 +568,7 @@ class apply_body_impulse:
           zeros, zeros, env_ids=active_ids, body_ids=self._body_ids
         )
 
+    n = self._num_envs if isinstance(env_ids, slice) else len(env_ids)
     self._time_remaining[env_ids] = 0.0
-    self._interval_time_left[env_ids] = 0.0
+    self._interval_time_left[env_ids] = self._sample_cooldown(n)
     self._active[env_ids] = False
-    self._needs_init[env_ids] = True

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -559,7 +559,9 @@ def test_step_mode_fires_every_call(device):
   assert call_count[0] == 5
 
 
-def _make_impulse_env(device, num_envs=2, num_bodies=1, body_ids=None):
+def _make_impulse_env(
+  device, num_envs=2, num_bodies=1, body_ids=None, cooldown_s=(0.0, 0.0)
+):
   """Create a mock env for apply_body_impulse tests."""
   if body_ids is None:
     body_ids = [0]
@@ -579,7 +581,7 @@ def _make_impulse_env(device, num_envs=2, num_bodies=1, body_ids=None):
 
   asset_cfg = SceneEntityCfg("robot", body_ids=body_ids)
   term_cfg = Mock()
-  term_cfg.params = {"asset_cfg": asset_cfg}
+  term_cfg.params = {"asset_cfg": asset_cfg, "cooldown_s": cooldown_s}
   impulse = events.apply_body_impulse(cfg=term_cfg, env=env)
   return env, mock_entity, asset_cfg, impulse
 
@@ -587,12 +589,12 @@ def _make_impulse_env(device, num_envs=2, num_bodies=1, body_ids=None):
 def test_apply_body_impulse_basic(device):
   """Impulse is applied and cleared after duration expires."""
   env, mock_entity, asset_cfg, impulse = _make_impulse_env(
-    device, num_envs=2, num_bodies=3, body_ids=[1]
+    device, num_envs=2, num_bodies=3, body_ids=[1], cooldown_s=(10.0, 10.0)
   )
 
   # Skip the initial cooldown so the first call triggers immediately;
   # the trigger/sustain/expire cycle is what's under test here.
-  impulse._needs_init[:] = False
+  impulse._interval_time_left[:] = 0.0
 
   impulse(
     env,
@@ -707,7 +709,7 @@ def test_apply_body_impulse_initial_cooldown(device):
   Regression test for #973.
   """
   env, mock_entity, asset_cfg, impulse = _make_impulse_env(
-    device, num_envs=1, num_bodies=1, body_ids=[0]
+    device, num_envs=1, num_bodies=1, body_ids=[0], cooldown_s=(0.05, 0.05)
   )
 
   def step():


### PR DESCRIPTION
A few minor nits and fixes around `apply_body_impulse` cooldown handling.

`cooldown_s` is now captured from `cfg.params` at `__init__` and used to pre-sample the initial `_interval_time_left` directly, which lets us drop the `_needs_init` flag and the lazy-init block at the top of `__call__`. All four cooldown sampling sites (init, post-expiry, post-trigger, reset) now share a single `_sample_cooldown` helper backed by the existing `sample_uniform` utility, so there is one source of truth for the cooldown range and no duplicated sampling math.

Behavior is unchanged. Tests updated accordingly.