### PR TITLE
Fix make sync by selecting one torch extra

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 .PHONY: sync
 sync:
-	uv sync --all-extras --all-packages --group dev
+	uv sync --all-packages --extra cu128 --group dev
+
+.PHONY: sync-cpu
+sync-cpu:
+	uv sync --all-packages --extra cpu --group dev
 
 .PHONY: format
 format:


### PR DESCRIPTION
The cpu and cu128 extras are declared as conflicting in pyproject.toml, so make sync was failing under --all-extras. Default to cu128 and add a sync-cpu target for CPU-only setups.