### PR TITLE
Bump GitPython to >=3.1.49 to fix security vulnerabilities

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ conflicts = [
 # reject them. This override loosens the constraint for uv resolution only.
 override-dependencies = ["mujoco>=3.8.0.dev0"]
 constraint-dependencies = [
-  "GitPython>=3.1.47",
+  "GitPython>=3.1.49",
   "lxml>=6.1.0",
 ]
 required-environments = [

--- a/uv.lock
+++ b/uv.lock
@@ -42,7 +42,7 @@ conflicts = [[
 
 [manifest]
 constraints = [
-    { name = "gitpython", specifier = ">=3.1.47" },
+    { name = "gitpython", specifier = ">=3.1.49" },
     { name = "lxml", specifier = ">=6.1.0" },
 ]
 overrides = [{ name = "mujoco", specifier = ">=3.8.0.dev0", index = "https://py.mujoco.org/" }]
@@ -823,14 +823,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.47"
+version = "3.1.50"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c1/bd/50db468e9b1310529a19fce651b3b0e753b5c07954d486cba31bbee9a5d5/gitpython-3.1.47.tar.gz", hash = "sha256:dba27f922bd2b42cb54c87a8ab3cb6beb6bf07f3d564e21ac848913a05a8a3cd", size = 216978, upload-time = "2026-04-22T02:44:44.059Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/f6/354ae6491228b5eb40e10d89c4d13c651fe1cf7556e35ebdded50cff57ce/gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc", size = 219798, upload-time = "2026-05-06T04:01:26.571Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f2/c5/a1bc0996af85757903cf2bf444a7824e68e0035ce63fb41d6f76f9def68b/gitpython-3.1.47-py3-none-any.whl", hash = "sha256:489f590edfd6d20571b2c0e72c6a6ac6915ee8b8cd04572330e3842207a78905", size = 209547, upload-time = "2026-04-22T02:44:41.271Z" },
+    { url = "https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl", hash = "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9", size = 212507, upload-time = "2026-05-06T04:01:23.799Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Two high-severity Dependabot alerts were open against GitPython. This bumps the constraint from >=3.1.47 to >=3.1.49, which resolves both:

Alert #25: A path traversal vulnerability in reference APIs allowed arbitrary file writes and deletes outside the repository boundary (patched in 3.1.48).

Alert #26: A newline injection in `config_writer().set_value()` could be exploited to set `core.hooksPath` to an attacker-controlled path, enabling remote code execution (patched in 3.1.49).

The lock file resolves to 3.1.50, the latest release.