### PR TITLE
Add get_observations() to ManagerBasedRlEnv to satisfy EnvProtocol

### DIFF
--- a/src/mjlab/envs/manager_based_rl_env.py
+++ b/src/mjlab/envs/manager_based_rl_env.py
@@ -478,6 +478,9 @@ class ManagerBasedRlEnv:
       self.extras,
     )
 
+  def get_observations(self) -> dict:
+    return self.observation_manager.compute()
+
   def render(self) -> np.ndarray | None:
     if self.render_mode == "human" or self.render_mode is None:
       return None


### PR DESCRIPTION
EnvProtocol in viewer/base.py requires a get_observations() method, but ManagerBasedRlEnv never implemented it, causing a runtime failure when the viewer tries to call env.get_observations(). This adds the missing method, delegating to observation_manager.compute().

Fixes #986