### PR TITLE
Fix multi-node distributed training using duplicate seeds across nodes

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -80,6 +80,9 @@ Changed
 Fixed
 ^^^^^
 
+- Fixed duplicate random seeds across nodes in multi-node training. The
+  per-process seed offset in ``scripts/train.py`` now uses the global
+  ``RANK`` instead of ``LOCAL_RANK``. Contribution by @bd-pdomanico.
 - Fixed ``apply_body_impulse`` firing an impulse on the very first step (and
   the first step after every reset) instead of starting with a cooldown as
   documented. The cooldown is now sampled lazily on the first call so impulse

--- a/src/mjlab/scripts/train.py
+++ b/src/mjlab/scripts/train.py
@@ -59,7 +59,7 @@ def run_train(task_id: str, cfg: TrainConfig, log_dir: Path) -> None:
     os.environ["MUJOCO_EGL_DEVICE_ID"] = str(local_rank)
     device = f"cuda:{local_rank}"
     # Set seed to have diversity in different processes.
-    seed = cfg.agent.seed + local_rank
+    seed = cfg.agent.seed + rank
 
   configure_torch_backends()
 


### PR DESCRIPTION
The per-process seed offset in `scripts/train.py` is derived from `LOCAL_RANK`, which is each process's rank within its node and only matches the global `RANK` on single-node runs. In any multi-node configuration the same `LOCAL_RANK` repeats on every node, so the seed offset collides and processes end up training with duplicate seeds. Concretely, training across two nodes with one GPU each gives both nodes `local_rank=0`, producing identical seeds on both nodes — defeating the "diversity in different processes" intent of the offset. Switching the offset to the global `RANK` makes every process across every node receive a unique seed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)