### PR TITLE
Enforce @abstractmethod on ActionTerm and CommandTerm

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -80,6 +80,10 @@ Changed
 Fixed
 ^^^^^
 
+- Fixed ``@abc.abstractmethod`` decorators being silently ignored on
+  ``ActionTerm`` and ``CommandTerm``. Subclasses that omit a required
+  override now raise ``TypeError`` on instantiation (previously they
+  silently constructed and failed later). Contribution by @bd-pdomanico.
 - Fixed duplicate random seeds across nodes in multi-node training. The
   per-process seed offset in ``scripts/train.py`` now uses the global
   ``RANK`` instead of ``LOCAL_RANK``. Contribution by @bd-pdomanico.

--- a/src/mjlab/managers/action_manager.py
+++ b/src/mjlab/managers/action_manager.py
@@ -37,7 +37,7 @@ class ActionTermCfg(abc.ABC):
     raise NotImplementedError
 
 
-class ActionTerm(ManagerTermBase):
+class ActionTerm(ManagerTermBase, abc.ABC):
   """Base class for action terms.
 
   The action term is responsible for processing the raw actions sent to the environment

--- a/src/mjlab/managers/command_manager.py
+++ b/src/mjlab/managers/command_manager.py
@@ -44,7 +44,7 @@ class CommandTermCfg(abc.ABC):
     raise NotImplementedError
 
 
-class CommandTerm(ManagerTermBase):
+class CommandTerm(ManagerTermBase, abc.ABC):
   """Base class for command terms."""
 
   def __init__(self, cfg: CommandTermCfg, env: ManagerBasedRlEnv):


### PR DESCRIPTION
The `@abc.abstractmethod` decorators on `ActionTerm` and `CommandTerm` were silently ignored because they did not inherit from `abc.ABC`, so the `ABCMeta` metaclass that makes the decorator effective was never installed. Subclasses that omitted a required override would construct successfully and only fail later at the call site with `NotImplementedError`.

Adding `abc.ABC` as a mixin on each class restores the intended behavior: incomplete subclasses now raise `TypeError` on instantiation, surfacing the mistake immediately. This is technically a behavior change — any subclass that was relying on the silent acceptance will now fail to construct.
