### PR TITLE
Add add_box primitive to DebugVisualizer

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,6 +8,9 @@ Upcoming version (not yet released)
 Added
 ^^^^^
 
+- Added ``DebugVisualizer.add_box`` for drawing an axis-oriented box
+  primitive, mirroring ``add_ellipsoid``. Supported by both the native
+  and Viser viewers. ``size`` is the box half-extents (:issue:`992`).
 - Added ``--log-root`` CLI option to ``train``, ``play``, and ``evaluate``
   scripts for choosing where training logs are stored. Defaults to
   ``logs/rsl_rl`` (unchanged behavior). Useful for directing outputs to a

--- a/src/mjlab/viewer/debug_visualizer.py
+++ b/src/mjlab/viewer/debug_visualizer.py
@@ -180,6 +180,26 @@ class DebugVisualizer(ABC):
     ...
 
   @abstractmethod
+  def add_box(
+    self,
+    center: np.ndarray,
+    size: np.ndarray,
+    mat: np.ndarray,
+    color: tuple[float, float, float, float],
+    label: str | None = None,
+  ) -> None:
+    """Add an axis-oriented box visualization.
+
+    Args:
+      center: Center position (3D vector).
+      size: Half-extents along each local axis (3D vector: a, b, c).
+      mat: 3x3 rotation matrix (or flattened 9-element array).
+      color: RGBA color (values 0-1).
+      label: Optional label for this box.
+    """
+    ...
+
+  @abstractmethod
   def clear(self) -> None:
     """Clear all debug visualizations."""
     ...
@@ -240,6 +260,9 @@ class NullDebugVisualizer:
     pass
 
   def add_ellipsoid(self, center, size, mat, color, label=None) -> None:
+    pass
+
+  def add_box(self, center, size, mat, color, label=None) -> None:
     pass
 
   def clear(self) -> None:

--- a/src/mjlab/viewer/native/visualizer.py
+++ b/src/mjlab/viewer/native/visualizer.py
@@ -239,6 +239,31 @@ class MujocoNativeDebugVisualizer(DebugVisualizer):
     )
 
   @override
+  def add_box(
+    self,
+    center: np.ndarray,
+    size: np.ndarray,
+    mat: np.ndarray,
+    color: tuple[float, float, float, float],
+    label: str | None = None,
+  ) -> None:
+    """Add a box visualization using MuJoCo's box geometry."""
+    del label  # Unused.
+
+    self.scn.ngeom += 1
+    geom = self.scn.geoms[self.scn.ngeom - 1]
+    geom.category = mujoco.mjtCatBit.mjCAT_DECOR
+
+    mujoco.mjv_initGeom(
+      geom=geom,
+      type=mujoco.mjtGeom.mjGEOM_BOX.value,
+      size=np.asarray(size, dtype=np.float64),
+      pos=np.asarray(center, dtype=np.float64),
+      mat=np.asarray(mat, dtype=np.float64).flatten(),
+      rgba=np.asarray(color, dtype=np.float32),
+    )
+
+  @override
   def clear(self) -> None:
     """Clear debug visualizations by resetting geom count."""
     self.scn.ngeom = self._initial_geom_count

--- a/src/mjlab/viewer/viser/scene.py
+++ b/src/mjlab/viewer/viser/scene.py
@@ -263,6 +263,7 @@ class MjlabViserScene(ViserMujocoScene, DebugVisualizer):
     self._queued_spheres: list = []
     self._queued_cylinders: list = []
     self._queued_ellipsoids: list = []
+    self._queued_boxes: list = []
 
     # Batched mesh handles for simple primitives.
     def _shaft_mesh() -> trimesh.Trimesh:
@@ -287,12 +288,19 @@ class MjlabViserScene(ViserMujocoScene, DebugVisualizer):
       "ellipsoids",
       lambda: trimesh.creation.icosphere(subdivisions=2, radius=1.0),
     )
+    # Unit half-extents so that scaling by the box size yields the requested
+    # half-extents (extents=2 spans -1 to 1 along each axis).
+    self._boxes = _BatchedPrimitive(
+      "boxes",
+      lambda: trimesh.creation.box(extents=(2.0, 2.0, 2.0)),
+    )
     self._all_primitives = [
       self._arrow_shafts,
       self._arrow_heads,
       self._spheres,
       self._cylinders,
       self._ellipsoids,
+      self._boxes,
     ]
 
     # Ghost mesh state.
@@ -956,12 +964,34 @@ class MjlabViserScene(ViserMujocoScene, DebugVisualizer):
     )
 
   @override
+  def add_box(
+    self,
+    center: np.ndarray | torch.Tensor,
+    size: np.ndarray | torch.Tensor,
+    mat: np.ndarray | torch.Tensor,
+    color: tuple[float, float, float, float],
+    label: str | None = None,
+  ) -> None:
+    if not self.debug_visualization_enabled:
+      return
+    del label
+    self._queued_boxes.append(
+      (
+        np.asarray(_to_numpy(center), dtype=np.float32).copy(),
+        np.asarray(_to_numpy(size), dtype=np.float32).copy(),
+        np.asarray(_to_numpy(mat), dtype=np.float32).reshape(3, 3).copy(),
+        color,
+      )
+    )
+
+  @override
   def clear(self) -> None:
     """Clear all debug visualization queues."""
     self._queued_arrows.clear()
     self._queued_spheres.clear()
     self._queued_cylinders.clear()
     self._queued_ellipsoids.clear()
+    self._queued_boxes.clear()
     self._queued_ghosts.clear()
 
   def clear_debug_all(self) -> None:
@@ -1039,6 +1069,7 @@ class MjlabViserScene(ViserMujocoScene, DebugVisualizer):
     self._sync_spheres()
     self._sync_cylinders()
     self._sync_ellipsoids()
+    self._sync_boxes()
 
   def _sync_spheres(self) -> None:
     if not self._queued_spheres:
@@ -1116,6 +1147,32 @@ class MjlabViserScene(ViserMujocoScene, DebugVisualizer):
       colors[i] = _color_uint8(color)
       opacity = color[3]
     self._ellipsoids.sync(
+      self.server,
+      self.env_idx,
+      positions,
+      wxyzs,
+      scales,
+      colors,
+      opacity,
+    )
+
+  def _sync_boxes(self) -> None:
+    if not self._queued_boxes:
+      self._boxes.remove()
+      return
+    n = len(self._queued_boxes)
+    positions = np.zeros((n, 3), dtype=np.float32)
+    wxyzs = np.zeros((n, 4), dtype=np.float32)
+    scales = np.zeros((n, 3), dtype=np.float32)
+    colors = np.zeros((n, 3), dtype=np.uint8)
+    opacity = 1.0
+    for i, (center, size, mat, color) in enumerate(self._queued_boxes):
+      positions[i] = center + self._scene_offset
+      wxyzs[i] = vtf.SO3.from_matrix(mat).wxyz
+      scales[i] = size
+      colors[i] = _color_uint8(color)
+      opacity = color[3]
+    self._boxes.sync(
       self.server,
       self.env_idx,
       positions,


### PR DESCRIPTION
Adds an axis-oriented box primitive to the debug visualizer, mirroring the existing add_ellipsoid signature. Both backends already support it (mjGEOM_BOX natively and scene.add_box in viser), so this just wires up the wrapper across the abstract interface, the native viewer, and the Viser scene. size is interpreted as half-extents, consistent with add_ellipsoid and MuJoCo's box size convention.

Fixes #992