### PR TITLE
Fix rough-terrain video flicker from mutating env origins

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -83,6 +83,11 @@ Changed
 Fixed
 ^^^^^
 
+- Fixed heavy flicker in offscreen training videos on rough-terrain tasks.
+  The renderer recomputed its context "neighbor" robots every frame from
+  ``env_origins``, which the terrain curriculum mutates on reset, so the
+  neighbor set kept changing and robots popped in and out. The neighbor
+  set is now computed once and cached (:issue:`979`).
 - Fixed duplicate random seeds across nodes in multi-node training. The
   per-process seed offset in ``scripts/train.py`` now uses the global
   ``RANK`` instead of ``LOCAL_RANK``. Contribution by @bd-pdomanico.

--- a/src/mjlab/viewer/offscreen_renderer.py
+++ b/src/mjlab/viewer/offscreen_renderer.py
@@ -57,6 +57,7 @@ class OffscreenRenderer:
     self._opt = mujoco.MjvOption()
     self._pert = mujoco.MjvPerturb()
     self._catmask = mujoco.mjtCatBit.mjCAT_DYNAMIC
+    self._extra_env_ids: list[int] | None = None
 
   @property
   def renderer(self) -> mujoco.Renderer:
@@ -134,9 +135,17 @@ class OffscreenRenderer:
 
     We render a small local neighborhood around ``env_idx`` instead of the first
     N environments, so videos stay focused on the tracked robot and nearby peers.
+
+    The neighbor set is computed once and cached. ``env_origins`` can mutate during
+    training (e.g. the terrain curriculum reassigns origins on reset), so recomputing
+    every frame would make the context robots pop in and out, causing video flicker.
     """
+    if self._extra_env_ids is not None:
+      return self._extra_env_ids
+
     if self._cfg.max_extra_envs <= 0 or nworld <= 1:
-      return []
+      self._extra_env_ids = []
+      return self._extra_env_ids
 
     k = min(self._cfg.max_extra_envs, nworld - 1)
     origins = self._scene.env_origins[:nworld].cpu().numpy()
@@ -146,7 +155,8 @@ class OffscreenRenderer:
 
     nearest = np.argpartition(dist2, kth=k - 1)[:k]
     nearest = nearest[np.argsort(dist2[nearest])]
-    return [int(i) for i in nearest]
+    self._extra_env_ids = [int(i) for i in nearest]
+    return self._extra_env_ids
 
   def _sync_model_fields(self, env_idx: int) -> None:
     """Sync visually relevant per-world model fields into the host MjModel."""


### PR DESCRIPTION
Offscreen training videos flicker heavily on rough-terrain tasks (#979). The renderer draws a few `env_origins`-nearest "neighbor" robots around the tracked env for context, but it recomputed that set every frame. On rough terrain the `terrain_levels` curriculum reassigns `env_origins` on reset, so the nearest set kept changing and the context robots popped in and out. Flat tasks looked fine because they disable the terrain curriculum, leaving origins static.

The fix computes the neighbor set once and caches it. `env_idx` and `nworld` are fixed for a recording session, so the context robots stay stable across the whole video. One tradeoff: under an active curriculum the cached neighbors are picked from the origins at the first rendered frame and may drift to other tiles over a long run, but a stable set is the right call for a focused tracking video.

Fixes #979