### PR TITLE
Fix delayed actuators only delaying a single command field

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -102,6 +102,10 @@ Fixed
   ``env_origins``, which the terrain curriculum mutates on reset, so the
   neighbor set kept changing and robots popped in and out. The neighbor
   set is now computed once and cached (:issue:`979`).
+- Fixed command delay only applying to an actuator's position target.
+  ``IdealPdActuator`` and ``DcMotorActuator`` also use velocity and effort, which
+  arrived undelayed and out of sync; all command targets now share one delay.
+  Zero-reference setups are unaffected.
 - Fixed duplicate random seeds across nodes in multi-node training. The
   per-process seed offset in ``scripts/train.py`` now uses the global
   ``RANK`` instead of ``LOCAL_RANK``. Contribution by @bd-pdomanico.

--- a/src/mjlab/actuator/actuator.py
+++ b/src/mjlab/actuator/actuator.py
@@ -175,15 +175,6 @@ class Actuator(ABC, Generic[ActuatorCfgT]):
     return self.cfg.delay_max_lag > 0
 
   @property
-  def command_field(self) -> CommandField | None:
-    """The primary command field this actuator consumes.
-
-    Returns None by default. Subclasses should override to return the
-    appropriate field.
-    """
-    return None
-
-  @property
   def target_ids(self) -> torch.Tensor:
     """Local indices of targets controlled by this actuator."""
     assert self._target_ids is not None
@@ -271,11 +262,6 @@ class Actuator(ABC, Generic[ActuatorCfgT]):
     """Create delay buffer. Called during initialize()."""
     if not self.has_delay:
       return
-    if self.command_field is None:
-      raise ValueError(
-        f"{self.__class__.__name__}: delay is configured (delay_max_lag="
-        f"{self.cfg.delay_max_lag}) but command_field is not defined."
-      )
     self._delay_buffer = DelayBuffer(
       min_lag=self.cfg.delay_min_lag,
       max_lag=self.cfg.delay_max_lag,
@@ -287,19 +273,25 @@ class Actuator(ABC, Generic[ActuatorCfgT]):
     )
 
   def apply_delay(self, cmd: ActuatorCmd) -> ActuatorCmd:
-    """Apply delay to the command_field target. No-op without delay."""
+    """Delay all command targets with one shared lag. No-op without delay.
+
+    Every target the policy issues (position, velocity, effort) travels the same
+    command channel and experiences the same latency, so they are stacked and
+    delayed together. Feedback fields (``pos``, ``vel``) are never delayed.
+    """
     if self._delay_buffer is None:
       return cmd
-    cf = self.command_field
-    if cf == "position":
-      self._delay_buffer.append(cmd.position_target)
-      return dataclasses.replace(cmd, position_target=self._delay_buffer.compute())
-    elif cf == "velocity":
-      self._delay_buffer.append(cmd.velocity_target)
-      return dataclasses.replace(cmd, velocity_target=self._delay_buffer.compute())
-    else:
-      self._delay_buffer.append(cmd.effort_target)
-      return dataclasses.replace(cmd, effort_target=self._delay_buffer.compute())
+    targets = torch.stack(
+      (cmd.position_target, cmd.velocity_target, cmd.effort_target), dim=-1
+    )
+    self._delay_buffer.append(targets)
+    delayed = self._delay_buffer.compute()
+    return dataclasses.replace(
+      cmd,
+      position_target=delayed[..., 0],
+      velocity_target=delayed[..., 1],
+      effort_target=delayed[..., 2],
+    )
 
   def set_lags(
     self,

--- a/src/mjlab/actuator/builtin_actuator.py
+++ b/src/mjlab/actuator/builtin_actuator.py
@@ -16,7 +16,6 @@ from mjlab.actuator.actuator import (
   Actuator,
   ActuatorCfg,
   ActuatorCmd,
-  CommandField,
   TransmissionType,
 )
 from mjlab.utils.spec import (
@@ -62,10 +61,6 @@ class BuiltinPositionActuatorCfg(ActuatorCfg):
 
 class BuiltinPositionActuator(Actuator[BuiltinPositionActuatorCfg]):
   """MuJoCo built-in position actuator."""
-
-  @property
-  def command_field(self) -> CommandField:
-    return "position"
 
   def __init__(
     self,
@@ -118,10 +113,6 @@ class BuiltinMotorActuatorCfg(ActuatorCfg):
 
 class BuiltinMotorActuator(Actuator[BuiltinMotorActuatorCfg]):
   """MuJoCo built-in motor actuator."""
-
-  @property
-  def command_field(self) -> CommandField:
-    return "effort"
 
   def __init__(
     self,
@@ -181,10 +172,6 @@ class BuiltinVelocityActuatorCfg(ActuatorCfg):
 
 class BuiltinVelocityActuator(Actuator[BuiltinVelocityActuatorCfg]):
   """MuJoCo built-in velocity actuator."""
-
-  @property
-  def command_field(self) -> CommandField:
-    return "velocity"
 
   def __init__(
     self,
@@ -259,10 +246,6 @@ class BuiltinMuscleActuatorCfg(ActuatorCfg):
 
 class BuiltinMuscleActuator(Actuator[BuiltinMuscleActuatorCfg]):
   """MuJoCo built-in muscle actuator."""
-
-  @property
-  def command_field(self) -> CommandField:
-    return "effort"
 
   def __init__(
     self,

--- a/src/mjlab/actuator/pd_actuator.py
+++ b/src/mjlab/actuator/pd_actuator.py
@@ -9,7 +9,7 @@ import mujoco
 import mujoco_warp as mjwarp
 import torch
 
-from mjlab.actuator.actuator import Actuator, ActuatorCfg, ActuatorCmd, CommandField
+from mjlab.actuator.actuator import Actuator, ActuatorCfg, ActuatorCmd
 from mjlab.utils.spec import create_motor_actuator
 
 if TYPE_CHECKING:
@@ -37,10 +37,6 @@ class IdealPdActuatorCfg(ActuatorCfg):
 
 class IdealPdActuator(Actuator, Generic[IdealPdCfgT]):
   """Ideal PD control actuator."""
-
-  @property
-  def command_field(self) -> CommandField:
-    return "position"
 
   def __init__(
     self,

--- a/tests/test_delayed_actuator.py
+++ b/tests/test_delayed_actuator.py
@@ -125,6 +125,72 @@ def test_delayed_ideal_applies_delay(device):
   assert torch.allclose(qfrc, expected_torque, atol=1e-4)
 
 
+def test_delayed_ideal_delays_velocity(device):
+  """Velocity targets share the same delay as position targets.
+
+  Regression test: the velocity reference used to bypass the delay buffer, so
+  the damping term consumed the latest target instead of the delayed one.
+  """
+  entity = create_entity_with_delayed_ideal(delay_min_lag=2, delay_max_lag=2)
+  entity, sim = initialize_entity(entity, device)
+
+  joint_pos = torch.zeros(1, 2, device=device)
+  joint_vel = torch.zeros(1, 2, device=device)
+  entity.write_joint_state_to_sim(joint_pos, joint_vel)
+
+  # Only the velocity target varies; position and effort stay zero.
+  vel_targets = [
+    torch.tensor([[0.1, 0.2]], device=device),
+    torch.tensor([[0.3, 0.4]], device=device),
+    torch.tensor([[0.5, 0.6]], device=device),
+  ]
+
+  for vel_target in vel_targets:
+    entity.set_joint_position_target(joint_pos)
+    entity.set_joint_velocity_target(vel_target)
+    entity.set_joint_effort_target(torch.zeros(1, 2, device=device))
+    entity.write_data_to_sim()
+    sim.forward()
+
+  joint_v_adr = entity.indexing.joint_v_adr
+  qfrc = sim.data.qfrc_actuator[0, joint_v_adr]
+
+  # With lag=2, the damping term uses the velocity target from step 0:
+  # kd * (delayed_vel_target - 0) = 10.0 * [0.1, 0.2].
+  expected_torque = 10.0 * vel_targets[0][0]
+  assert torch.allclose(qfrc, expected_torque, atol=1e-4)
+
+
+def test_delayed_ideal_delays_effort(device):
+  """Feedforward effort targets share the same delay as position targets."""
+  entity = create_entity_with_delayed_ideal(delay_min_lag=2, delay_max_lag=2)
+  entity, sim = initialize_entity(entity, device)
+
+  joint_pos = torch.zeros(1, 2, device=device)
+  joint_vel = torch.zeros(1, 2, device=device)
+  entity.write_joint_state_to_sim(joint_pos, joint_vel)
+
+  effort_targets = [
+    torch.tensor([[1.0, 2.0]], device=device),
+    torch.tensor([[3.0, 4.0]], device=device),
+    torch.tensor([[5.0, 6.0]], device=device),
+  ]
+
+  for effort_target in effort_targets:
+    entity.set_joint_position_target(joint_pos)
+    entity.set_joint_velocity_target(joint_vel)
+    entity.set_joint_effort_target(effort_target)
+    entity.write_data_to_sim()
+    sim.forward()
+
+  joint_v_adr = entity.indexing.joint_v_adr
+  qfrc = sim.data.qfrc_actuator[0, joint_v_adr]
+
+  # With lag=2, the feedforward term uses the effort target from step 0.
+  expected_torque = effort_targets[0][0]
+  assert torch.allclose(qfrc, expected_torque, atol=1e-4)
+
+
 def test_delayed_actuator_reset(device):
   """Test that reset clears the delay buffer."""
   entity = create_entity_with_delayed_builtin(delay_min_lag=1, delay_max_lag=3)

--- a/tests/test_xml_actuator.py
+++ b/tests/test_xml_actuator.py
@@ -4,7 +4,7 @@ import mujoco
 import pytest
 from conftest import get_test_device
 
-from mjlab.actuator import XmlActuatorCfg
+from mjlab.actuator import XmlActuator, XmlActuatorCfg
 from mjlab.entity import Entity, EntityArticulationInfoCfg, EntityCfg
 from mjlab.envs import ManagerBasedRlEnv, ManagerBasedRlEnvCfg, mdp
 from mjlab.managers.observation_manager import ObservationGroupCfg, ObservationTermCfg
@@ -160,6 +160,7 @@ def test_xml_actuator_explicit_command_field_bypasses_detection():
   entity.compile()
 
   actuator = entity._actuators[0]
+  assert isinstance(actuator, XmlActuator)
   assert actuator.command_field == "effort"
   assert actuator._target_names == ["joint1"]
 


### PR DESCRIPTION
`IdealPdActuator` and `DcMotorActuator` derive torque from position, velocity, and effort, but command delay only buffers position. Nonzero velocity or feedforward effort references therefore reach the control law undelayed, out of sync with the delayed position by up to `delay_max_lag` steps. The bug is invisible when those references are zero, which is the common case.

This delays the full command vector through one shared buffer so the three targets stay aligned, and removes the now-unused `command_field` delay overrides. Effort is delayed too now, so command-delay runs with nonzero velocity or effort references shift slightly and won't reproduce old checkpoints bit-for-bit; zero-reference setups are unchanged.