### PR TITLE
Deduplicate env_ids handling in events and harden reset path

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -79,6 +79,14 @@ Changed
   air-time fields (``current_air_time``, ``last_air_time``,
   ``current_contact_time``, ``last_contact_time``) have shape ``[B, P]``,
   where ``P`` is the number of resolved primaries (:issue:`914`).
+- Event functions now share a single ``resolve_env_ids`` helper to expand
+  ``env_ids=None`` to all environments, replacing five copies of the same
+  guard. ``push_by_setting_velocity`` and ``apply_external_force_torque``
+  accept ``env_ids=None`` too, so they work as global-time interval terms.
+  Documented when to use ``apply_external_force_torque`` (a constant,
+  self-managed wrench) versus ``apply_body_impulse`` (transient, automatic
+  impulses) versus ``push_by_setting_velocity`` (an instantaneous velocity
+  kick).
 
 Fixed
 ^^^^^

--- a/src/mjlab/envs/mdp/events.py
+++ b/src/mjlab/envs/mdp/events.py
@@ -21,6 +21,24 @@ if TYPE_CHECKING:
   from mjlab.viewer.debug_visualizer import DebugVisualizer
 
 _DEFAULT_ASSET_CFG = SceneEntityCfg("robot")
+_SE3_KEYS = ("x", "y", "z", "roll", "pitch", "yaw")
+
+
+def _sample_se3_range(
+  range_dict: dict[str, tuple[float, float]] | None,
+  shape: tuple[int, ...],
+  device: str,
+) -> torch.Tensor:
+  """Sample uniform ``[x, y, z, roll, pitch, yaw]`` offsets.
+
+  ``range_dict`` maps any subset of those keys to ``(min, max)`` ranges; missing
+  keys default to ``(0.0, 0.0)`` (no offset). ``None`` is treated as empty. The
+  returned tensor has the requested ``shape`` whose last dimension must be 6.
+  """
+  range_dict = range_dict or {}
+  range_list = [range_dict.get(key, (0.0, 0.0)) for key in _SE3_KEYS]
+  ranges = torch.tensor(range_list, device=device)
+  return sample_uniform(ranges[:, 0], ranges[:, 1], shape, device=device)
 
 
 def resolve_env_ids(
@@ -122,13 +140,7 @@ def reset_root_state_uniform(
   asset: Entity = env.scene[asset_cfg.name]
 
   # Pose.
-  range_list = [
-    pose_range.get(key, (0.0, 0.0)) for key in ["x", "y", "z", "roll", "pitch", "yaw"]
-  ]
-  ranges = torch.tensor(range_list, device=env.device)
-  pose_samples = sample_uniform(
-    ranges[:, 0], ranges[:, 1], (len(env_ids), 6), device=env.device
-  )
+  pose_samples = _sample_se3_range(pose_range, (len(env_ids), 6), env.device)
 
   # Fixed-based entities with mocap=True.
   if asset.is_fixed_base:
@@ -168,16 +180,7 @@ def reset_root_state_uniform(
   orientations = quat_mul(root_states[:, 3:7], orientations_delta)
 
   # Velocities.
-  if velocity_range is None:
-    velocity_range = {}
-  range_list = [
-    velocity_range.get(key, (0.0, 0.0))
-    for key in ["x", "y", "z", "roll", "pitch", "yaw"]
-  ]
-  ranges = torch.tensor(range_list, device=env.device)
-  vel_samples = sample_uniform(
-    ranges[:, 0], ranges[:, 1], (len(env_ids), 6), device=env.device
-  )
+  vel_samples = _sample_se3_range(velocity_range, (len(env_ids), 6), env.device)
   velocities = root_states[:, 7:13] + vel_samples
 
   asset.write_root_link_pose_to_sim(
@@ -240,15 +243,7 @@ def reset_root_state_from_flat_patches(
   root_states = default_root_state[env_ids].clone()
 
   # Apply optional pose range offset.
-  if pose_range is None:
-    pose_range = {}
-  range_list = [
-    pose_range.get(key, (0.0, 0.0)) for key in ["x", "y", "z", "roll", "pitch", "yaw"]
-  ]
-  ranges = torch.tensor(range_list, device=env.device)
-  pose_samples = sample_uniform(
-    ranges[:, 0], ranges[:, 1], (len(env_ids), 6), device=env.device
-  )
+  pose_samples = _sample_se3_range(pose_range, (len(env_ids), 6), env.device)
 
   # Position: flat patch position + optional offset. Use patch z instead of default.
   final_positions = positions.clone()
@@ -272,16 +267,7 @@ def reset_root_state_from_flat_patches(
     return
 
   # Velocities.
-  if velocity_range is None:
-    velocity_range = {}
-  vel_range_list = [
-    velocity_range.get(key, (0.0, 0.0))
-    for key in ["x", "y", "z", "roll", "pitch", "yaw"]
-  ]
-  vel_ranges = torch.tensor(vel_range_list, device=env.device)
-  vel_samples = sample_uniform(
-    vel_ranges[:, 0], vel_ranges[:, 1], (len(env_ids), 6), device=env.device
-  )
+  vel_samples = _sample_se3_range(velocity_range, (len(env_ids), 6), env.device)
   velocities = root_states[:, 7:13] + vel_samples
 
   asset.write_root_link_pose_to_sim(
@@ -347,12 +333,7 @@ def push_by_setting_velocity(
   env_ids = resolve_env_ids(env, env_ids)
   asset: Entity = env.scene[asset_cfg.name]
   vel_w = asset.data.root_link_vel_w[env_ids]
-  range_list = [
-    velocity_range.get(key, (0.0, 0.0))
-    for key in ["x", "y", "z", "roll", "pitch", "yaw"]
-  ]
-  ranges = torch.tensor(range_list, device=env.device)
-  vel_w += sample_uniform(ranges[:, 0], ranges[:, 1], vel_w.shape, device=env.device)
+  vel_w += _sample_se3_range(velocity_range, vel_w.shape, env.device)
   asset.write_root_link_velocity_to_sim(vel_w, env_ids=env_ids)
 
 

--- a/src/mjlab/envs/mdp/events.py
+++ b/src/mjlab/envs/mdp/events.py
@@ -23,14 +23,27 @@ if TYPE_CHECKING:
 _DEFAULT_ASSET_CFG = SceneEntityCfg("robot")
 
 
+def resolve_env_ids(
+  env: ManagerBasedRlEnv, env_ids: torch.Tensor | None
+) -> torch.Tensor:
+  """Return ``env_ids`` unchanged, or all environment indices if ``None``.
+
+  Event functions receive ``env_ids=None`` to mean "all environments" (a full
+  reset, or a global-time interval term). This normalizes that sentinel to a
+  concrete index tensor so the function body can assume a real ``torch.Tensor``.
+  """
+  if env_ids is None:
+    return torch.arange(env.num_envs, device=env.device, dtype=torch.int)
+  return env_ids
+
+
 def randomize_terrain(env: ManagerBasedRlEnv, env_ids: torch.Tensor | None) -> None:
   """Randomize the sub-terrain for each environment on reset.
 
   This picks a random terrain type (column) and difficulty level (row) for each
   environment. Useful for play/evaluation mode to test on varied terrains.
   """
-  if env_ids is None:
-    env_ids = torch.arange(env.num_envs, device=env.device, dtype=torch.int)
+  env_ids = resolve_env_ids(env, env_ids)
 
   terrain = env.scene.terrain
   if terrain is not None:
@@ -48,8 +61,7 @@ def reset_scene_to_default(
 
   Automatically applies env_origins offset to position all entities correctly.
   """
-  if env_ids is None:
-    env_ids = torch.arange(env.num_envs, device=env.device, dtype=torch.int)
+  env_ids = resolve_env_ids(env, env_ids)
 
   for entity in env.scene.entities.values():
     if not isinstance(entity, Entity):
@@ -105,8 +117,7 @@ def reset_root_state_uniform(
     velocity_range: Velocity range (only used for floating-base entities).
     asset_cfg: Asset configuration.
   """
-  if env_ids is None:
-    env_ids = torch.arange(env.num_envs, device=env.device, dtype=torch.int)
+  env_ids = resolve_env_ids(env, env_ids)
 
   asset: Entity = env.scene[asset_cfg.name]
 
@@ -199,8 +210,7 @@ def reset_root_state_from_flat_patches(
     velocity_range: Optional velocity range (floating-base only).
     asset_cfg: Asset configuration.
   """
-  if env_ids is None:
-    env_ids = torch.arange(env.num_envs, device=env.device, dtype=torch.int)
+  env_ids = resolve_env_ids(env, env_ids)
 
   terrain = env.scene.terrain
   if terrain is None or patch_name not in terrain.flat_patches:
@@ -287,8 +297,7 @@ def reset_joints_by_offset(
   velocity_range: tuple[float, float],
   asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
 ) -> None:
-  if env_ids is None:
-    env_ids = torch.arange(env.num_envs, device=env.device, dtype=torch.int)
+  env_ids = resolve_env_ids(env, env_ids)
 
   asset: Entity = env.scene[asset_cfg.name]
   default_joint_pos = asset.data.default_joint_pos
@@ -320,10 +329,22 @@ def reset_joints_by_offset(
 
 def push_by_setting_velocity(
   env: ManagerBasedRlEnv,
-  env_ids: torch.Tensor,
+  env_ids: torch.Tensor | None,
   velocity_range: dict[str, tuple[float, float]],
   asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
 ) -> None:
+  """Push an entity by overwriting its root velocity with a sampled offset.
+
+  This is an *instantaneous, mass-independent* kick: it adds a uniformly sampled
+  delta directly to the root velocity, ignoring inertia and contact dynamics. It
+  is the cheapest disturbance and the standard locomotion "push the robot" term.
+  Use with ``mode="interval"``.
+
+  For force-based disturbances that respect the entity's dynamics, see
+  :func:`apply_external_force_torque` (a constant wrench you manage yourself) or
+  :class:`apply_body_impulse` (transient, self-managing impulses).
+  """
+  env_ids = resolve_env_ids(env, env_ids)
   asset: Entity = env.scene[asset_cfg.name]
   vel_w = asset.data.root_link_vel_w[env_ids]
   range_list = [
@@ -337,11 +358,36 @@ def push_by_setting_velocity(
 
 def apply_external_force_torque(
   env: ManagerBasedRlEnv,
-  env_ids: torch.Tensor,
+  env_ids: torch.Tensor | None,
   force_range: tuple[float, float],
   torque_range: tuple[float, float],
   asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
 ) -> None:
+  """Apply a single *constant* external wrench to bodies.
+
+  Samples a force and torque once and writes them to ``xfrc_applied``. The wrench
+  is **stateless and never expires**: MuJoCo holds it constant on every physics
+  step until something overwrites or zeroes it. There is no duration, cooldown,
+  or auto-clear.
+
+  **When to use this vs.** :class:`apply_body_impulse`:
+
+  - Use ``apply_external_force_torque`` for a *steady, episode-long* disturbance
+    such as a fixed payload, a constant wind, or a sustained load. The intended
+    pattern is ``mode="reset"``: re-randomize the wrench each episode so it holds
+    for that episode's duration. Because it never turns itself off, **you are
+    responsible for clearing or overwriting it** (e.g. via the next reset). It is
+    *not* suited to transient bumps on its own.
+
+  - Use :class:`apply_body_impulse` for *transient, repeated, randomized*
+    disturbances during an episode (bumps, gusts, collisions). It runs a full
+    cooldown -> trigger -> sustain -> expire lifecycle per environment, zeroing
+    the wrench automatically when each impulse ends, and ticks on ``mode="step"``.
+
+  For an instantaneous, mass-independent kick instead of a force, see
+  :func:`push_by_setting_velocity`.
+  """
+  env_ids = resolve_env_ids(env, env_ids)
   asset: Entity = env.scene[asset_cfg.name]
   num_bodies = (
     len(asset_cfg.body_ids)
@@ -385,6 +431,10 @@ class apply_body_impulse:
   applied.
 
   Use with ``mode="step"``.
+
+  For a *constant* episode-long wrench instead of transient impulses, see
+  :func:`apply_external_force_torque`. For an instantaneous, mass-independent
+  velocity kick, see :func:`push_by_setting_velocity`.
   """
 
   @dataclass

--- a/src/mjlab/managers/event_manager.py
+++ b/src/mjlab/managers/event_manager.py
@@ -290,9 +290,12 @@ class EventManager(ManagerBase):
         fired = True
       elif mode == "reset":
         assert global_env_step_count is not None
+        # Reset events require concrete indices: callers (e.g. ManagerBasedRlEnv)
+        # resolve None to all environments upstream. Enforce that here so a future
+        # caller passing None fails loudly instead of leaking a slice into event
+        # functions, which only understand None or a tensor.
+        assert env_ids is not None, "reset events require concrete env_ids, got None"
         min_step_count = term_cfg.min_step_count_between_reset
-        if env_ids is None:
-          env_ids = slice(None)
         if min_step_count == 0:
           self._reset_term_last_triggered_step_id[index][env_ids] = (
             global_env_step_count


### PR DESCRIPTION
The five reset event functions in events.py each repeated the same four-line guard to expand env_ids=None to all environments. This factors that into a single resolve_env_ids helper. It also applies the helper to push_by_setting_velocity and apply_external_force_torque, which were typed as taking a bare tensor and had no guard at all; widening them to accept None means they now work correctly as global-time interval terms, where the manager passes None to mean "all envs" (previously that None would have silently inserted a tensor dimension).

The event manager's reset branch had a None-to-slice(None) conversion that is effectively dead code: every caller resolves env_ids to a concrete tensor before reaching it, so None never actually arrives. The risk was latent rather than live, but if a future caller ever did pass None, the slice would be forwarded into an event function that only understands None or a tensor and crash on len() far from the cause. I replaced the conversion with an assert that encodes the existing invariant, so a violation fails loudly at the boundary with a clear message.

Finally, the docstrings now spell out when to reach for each disturbance term, since the difference is easy to get wrong: apply_external_force_torque is a constant wrench you manage yourself (typically re-randomized on reset), apply_body_impulse runs a self-managing cooldown/sustain/expire lifecycle for transient impulses, and push_by_setting_velocity is an instantaneous, mass-independent velocity kick. No behavior change for existing task configs. Full test suite passes.