### PR TITLE
Fix tracking MPKPE metric to use the global reference

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -97,6 +97,12 @@ Changed
 Fixed
 ^^^^^
 
+- Fixed the tracking MPKPE metric (``compute_mpkpe``) using the reward's
+  drift-cancelled reference ``body_pos_relative_w`` instead of the true
+  global reference ``body_pos_w``. It is documented to measure global-frame
+  keypoint error but previously never captured global drift and nearly
+  duplicated the root-relative metric. It now uses ``body_pos_w``
+  (:issue:`1006`).
 - Fixed heavy flicker in offscreen training videos on rough-terrain tasks.
   The renderer recomputed its context "neighbor" robots every frame from
   ``env_origins``, which the terrain curriculum mutates on reset, so the

--- a/src/mjlab/tasks/tracking/mdp/metrics.py
+++ b/src/mjlab/tasks/tracking/mdp/metrics.py
@@ -14,9 +14,10 @@ def compute_mpkpe(command: MotionCommand) -> torch.Tensor:
   """Compute Mean Per-Keybody Position Error (MPKPE).
 
   MPKPE measures the average Euclidean distance between the reference and
-  actual positions of all key bodies in world frame.
+  actual key body positions in the global world frame. It captures all
+  tracking error, including global translation and heading drift.
   """
-  pos_error = command.body_pos_relative_w - command.robot_body_pos_w
+  pos_error = command.body_pos_w - command.robot_body_pos_w
   per_body_error = torch.norm(pos_error, dim=-1)  # (num_envs, num_bodies)
   return per_body_error.mean(dim=-1)  # (num_envs,)
 

--- a/tests/test_tracking_metrics.py
+++ b/tests/test_tracking_metrics.py
@@ -34,11 +34,11 @@ def mock_command():
 
 
 def test_mpkpe_zero_when_positions_match(mock_command):
-  """Test MPKPE is zero when positions are identical."""
+  """Test MPKPE is zero when global positions are identical."""
   num_bodies = len(mock_command.cfg.body_names)
   positions = torch.rand(mock_command.num_envs, num_bodies, 3)
 
-  mock_command.body_pos_relative_w = positions.clone()
+  mock_command.body_pos_w = positions.clone()
   mock_command.robot_body_pos_w = positions.clone()
 
   mpkpe = compute_mpkpe(mock_command)
@@ -48,12 +48,31 @@ def test_mpkpe_zero_when_positions_match(mock_command):
 
 
 def test_mpkpe_correct_error(mock_command):
-  """Test MPKPE computes correct mean error."""
+  """Test MPKPE computes the correct mean global error."""
   num_bodies = len(mock_command.cfg.body_names)
 
-  mock_command.body_pos_relative_w = torch.zeros(mock_command.num_envs, num_bodies, 3)
+  mock_command.body_pos_w = torch.zeros(mock_command.num_envs, num_bodies, 3)
   mock_command.robot_body_pos_w = torch.zeros(mock_command.num_envs, num_bodies, 3)
   mock_command.robot_body_pos_w[:, :, 0] = 1.0  # 1 unit offset in x
+
+  mpkpe = compute_mpkpe(mock_command)
+
+  assert torch.allclose(mpkpe, torch.ones(mock_command.num_envs), atol=1e-6)
+
+
+def test_mpkpe_uses_global_reference(mock_command):
+  """MPKPE must read the global reference, not the drift-cancelled one.
+
+  Pins issue #1006: setting body_pos_relative_w to match the robot exactly
+  would yield zero error if it were (incorrectly) used; the metric must
+  instead follow body_pos_w.
+  """
+  num_bodies = len(mock_command.cfg.body_names)
+  robot_pos = torch.rand(mock_command.num_envs, num_bodies, 3)
+  mock_command.robot_body_pos_w = robot_pos.clone()
+  mock_command.body_pos_relative_w = robot_pos.clone()  # zero error if misused
+  mock_command.body_pos_w = robot_pos.clone()
+  mock_command.body_pos_w[:, :, 0] += 1.0  # 1 unit of global drift
 
   mpkpe = compute_mpkpe(mock_command)
 


### PR DESCRIPTION
compute_mpkpe compared the robot against body_pos_relative_w, which is the reference re-anchored to the robot's root every step (the quantity the tracking reward optimizes). That cancels global drift, so the metric never measured the global-frame error it documents and nearly duplicated compute_root_relative_mpkpe. It now uses the true global reference body_pos_w. Adds a test pinning this.

Thanks to @zhuoqun-chen for reporting.

Fixes #1006.