### PR TITLE
Improve tracking metrics and fix evaluation frame alignment

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -54,6 +54,16 @@ Added
 Changed
 ^^^^^^^
 
+- Changed the tracking task's root-relative MPKPE metric
+  (``compute_root_relative_mpkpe``) to use ``body_pos_relative_w``, the
+  reference re-anchored to the robot's root position and heading each step.
+  It previously removed only the anchor translation, so heading drift still
+  leaked into the score; it now removes both translation and yaw drift and
+  measures intrinsic body pose error, matching the tracking reward.
+- Changed the tracking task's joint velocity metric
+  (``compute_joint_velocity_error``) from a raw L2 norm to a per-joint RMS,
+  so the value no longer scales with the number of joints and is comparable
+  across robots.
 - Bumped ``mujoco`` to 3.8 and ``mujoco-warp`` to 3.8.0. The ``multiccd``
   enable flag was removed in mujoco 3.8 (it became default-on), so configs
   that listed ``"multiccd"`` in ``MujocoCfg.enableflags`` need to drop it.
@@ -97,6 +107,11 @@ Changed
 Fixed
 ^^^^^
 
+- Fixed the tracking task's end-effector metrics silently returning a zero
+  error when an end-effector body name was not in the tracked body list.
+  ``compute_ee_position_error`` and ``compute_ee_orientation_error`` now
+  raise a clear ``ValueError`` for unknown names instead of masking the
+  misconfiguration.
 - Fixed the tracking MPKPE metric (``compute_mpkpe``) using the reward's
   drift-cancelled reference ``body_pos_relative_w`` instead of the true
   global reference ``body_pos_w``. It is documented to measure global-frame

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -107,6 +107,13 @@ Changed
 Fixed
 ^^^^^
 
+- Fixed the tracking evaluation script (``evaluate``) computing its metrics
+  one motion frame out of sync. It advanced the command an extra frame
+  before the rollout and read the reference after ``env.step`` had already
+  advanced it, so the robot was scored against the next frame rather than
+  the one it was rewarded against. The reference is now snapshotted before
+  each step, and per-step averaging counts active steps explicitly instead
+  of inferring them from a nonzero MPKPE.
 - Fixed the tracking task's end-effector metrics silently returning a zero
   error when an end-effector body name was not in the tracked body list.
   ``compute_ee_position_error`` and ``compute_ee_orientation_error`` now

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -54,16 +54,11 @@ Added
 Changed
 ^^^^^^^
 
-- Changed the tracking task's root-relative MPKPE metric
-  (``compute_root_relative_mpkpe``) to use ``body_pos_relative_w``, the
-  reference re-anchored to the robot's root position and heading each step.
-  It previously removed only the anchor translation, so heading drift still
-  leaked into the score; it now removes both translation and yaw drift and
-  measures intrinsic body pose error, matching the tracking reward.
-- Changed the tracking task's joint velocity metric
-  (``compute_joint_velocity_error``) from a raw L2 norm to a per-joint RMS,
-  so the value no longer scales with the number of joints and is comparable
-  across robots.
+- Changed ``compute_root_relative_mpkpe`` to re-anchor the reference to the
+  robot's root each step, removing yaw drift as well as translation so it
+  measures intrinsic body pose error.
+- Changed ``compute_joint_velocity_error`` from an L2 norm to a per-joint
+  RMS, so it no longer scales with the number of joints.
 - Bumped ``mujoco`` to 3.8 and ``mujoco-warp`` to 3.8.0. The ``multiccd``
   enable flag was removed in mujoco 3.8 (it became default-on), so configs
   that listed ``"multiccd"`` in ``MujocoCfg.enableflags`` need to drop it.
@@ -107,24 +102,13 @@ Changed
 Fixed
 ^^^^^
 
-- Fixed the tracking evaluation script (``evaluate``) computing its metrics
-  one motion frame out of sync. It advanced the command an extra frame
-  before the rollout and read the reference after ``env.step`` had already
-  advanced it, so the robot was scored against the next frame rather than
-  the one it was rewarded against. The reference is now snapshotted before
-  each step, and per-step averaging counts active steps explicitly instead
-  of inferring them from a nonzero MPKPE.
-- Fixed the tracking task's end-effector metrics silently returning a zero
-  error when an end-effector body name was not in the tracked body list.
-  ``compute_ee_position_error`` and ``compute_ee_orientation_error`` now
-  raise a clear ``ValueError`` for unknown names instead of masking the
-  misconfiguration.
-- Fixed the tracking MPKPE metric (``compute_mpkpe``) using the reward's
-  drift-cancelled reference ``body_pos_relative_w`` instead of the true
-  global reference ``body_pos_w``. It is documented to measure global-frame
-  keypoint error but previously never captured global drift and nearly
-  duplicated the root-relative metric. It now uses ``body_pos_w``
-  (:issue:`1006`).
+- Fixed the tracking ``evaluate`` script scoring each metric against the
+  next motion frame; the reference is now snapshotted before each step to
+  match the reward.
+- Fixed the tracking end-effector metrics silently scoring zero for an
+  unknown body name; they now raise ``ValueError``.
+- Fixed ``compute_mpkpe`` measuring root-relative instead of global error;
+  it now uses the global reference ``body_pos_w`` (:issue:`1006`).
 - Fixed heavy flicker in offscreen training videos on rough-terrain tasks.
   The renderer recomputed its context "neighbor" robots every frame from
   ``env_origins``, which the terrain curriculum mutates on reset, so the

--- a/src/mjlab/tasks/tracking/mdp/metrics.py
+++ b/src/mjlab/tasks/tracking/mdp/metrics.py
@@ -25,29 +25,25 @@ def compute_mpkpe(command: MotionCommand) -> torch.Tensor:
 def compute_root_relative_mpkpe(command: MotionCommand) -> torch.Tensor:
   """Compute Root-relative Mean Per-Keybody Position Error (R-MPKPE).
 
-  R-MPKPE measures pose error independent of global drift by computing
-  positions relative to the root/anchor body.
+  R-MPKPE measures intrinsic pose error independent of global drift. It
+  uses ``body_pos_relative_w``, the reference re-anchored to the robot's
+  current root position and heading each step (the same quantity the
+  tracking reward optimizes), so both global translation and yaw drift are
+  removed and only the local body pose error remains.
   """
-  # Compute reference positions relative to reference anchor.
-  ref_anchor_pos = command.anchor_pos_w.unsqueeze(1)  # (num_envs, 1, 3)
-  ref_rel_pos = command.body_pos_w - ref_anchor_pos  # (num_envs, num_bodies, 3)
-
-  # Compute robot positions relative to robot anchor.
-  robot_anchor_pos = command.robot_anchor_pos_w.unsqueeze(1)  # (num_envs, 1, 3)
-  robot_rel_pos = (
-    command.robot_body_pos_w - robot_anchor_pos
-  )  # (num_envs, num_bodies, 3)
-
-  # Compute error between relative positions.
-  pos_error = ref_rel_pos - robot_rel_pos
+  pos_error = command.body_pos_relative_w - command.robot_body_pos_w
   per_body_error = torch.norm(pos_error, dim=-1)  # (num_envs, num_bodies)
   return per_body_error.mean(dim=-1)  # (num_envs,)
 
 
 def compute_joint_velocity_error(command: MotionCommand) -> torch.Tensor:
-  """Compute average joint velocity error."""
+  """Compute root-mean-square joint velocity error.
+
+  Uses an RMS over joints (rather than a raw L2 norm) so the value is a
+  per-joint quantity, comparable across robots with different DOF counts.
+  """
   vel_error = command.joint_vel - command.robot_joint_vel
-  return torch.norm(vel_error, dim=-1)  # (num_envs,)
+  return torch.sqrt(torch.mean(vel_error**2, dim=-1))  # (num_envs,)
 
 
 def compute_ee_position_error(
@@ -94,6 +90,18 @@ def _get_body_indices(
     body_names: Names of bodies to find.
 
   Returns:
-    List of indices into command.cfg.body_names.
+    List of indices into command.cfg.body_names, in the order requested.
+
+  Raises:
+    ValueError: If any requested body name is not tracked by the command.
+      Silently dropping unknown names would otherwise report a spurious
+      zero error for misconfigured end-effector lists.
   """
-  return [i for i, name in enumerate(command.cfg.body_names) if name in body_names]
+  name_to_index = {name: i for i, name in enumerate(command.cfg.body_names)}
+  missing = [name for name in body_names if name not in name_to_index]
+  if missing:
+    raise ValueError(
+      f"Body names {missing} are not tracked by the command. "
+      f"Available bodies: {tuple(command.cfg.body_names)}."
+    )
+  return [name_to_index[name] for name in body_names]

--- a/src/mjlab/tasks/tracking/scripts/evaluate.py
+++ b/src/mjlab/tasks/tracking/scripts/evaluate.py
@@ -6,6 +6,7 @@ import json
 import sys
 from dataclasses import asdict, dataclass
 from pathlib import Path
+from types import SimpleNamespace
 from typing import cast
 
 import torch
@@ -97,35 +98,61 @@ def run_evaluate(task_id: str, cfg: EvaluateConfig) -> dict[str, float]:
   all_joint_vel_error: list[torch.Tensor] = []
   all_ee_pos_error: list[torch.Tensor] = []
   all_ee_ori_error: list[torch.Tensor] = []
+  all_active: list[torch.Tensor] = []
 
   done_envs = torch.zeros(cfg.num_envs, dtype=torch.bool, device=device)
   success = torch.zeros(cfg.num_envs, dtype=torch.bool, device=device)
 
   obs = env.get_observations()
-  env.unwrapped.command_manager.compute(dt=env.unwrapped.step_dt)
 
   print(f"[INFO] Running {cfg.num_envs} evaluation episodes...")
 
   step = 0
   while not done_envs.all():
+    # Snapshot the reference frame the upcoming step will be scored against.
+    # env.step computes the reward (against the current reference) and only
+    # afterwards advances the command's motion frame, so reading the
+    # reference after stepping would pair the robot with the *next* frame.
+    # We snapshot here and pair it with the post-step robot state below,
+    # matching how the reward is computed.
+    ref = SimpleNamespace(
+      num_envs=command.num_envs,
+      device=command.device,
+      cfg=command.cfg,
+      body_pos_w=command.body_pos_w.clone(),
+      body_pos_relative_w=command.body_pos_relative_w.clone(),
+      body_quat_relative_w=command.body_quat_relative_w.clone(),
+      joint_vel=command.joint_vel.clone(),
+    )
+
     with torch.no_grad():
       actions = policy(obs)
     obs, _, dones, _ = env.step(actions)
 
-    # Compute metrics for active envs.
+    # Pair the snapshotted reference with the post-step robot state.
+    ref.robot_body_pos_w = command.robot_body_pos_w
+    ref.robot_body_quat_w = command.robot_body_quat_w
+    ref.robot_joint_vel = command.robot_joint_vel
+    ref_command = cast(MotionCommand, ref)
+
+    # Accumulate metrics for envs still running this step. active.any() is
+    # always true here: the loop runs only while some env is not done, and
+    # done_envs is updated below after this point.
     active = ~done_envs
-    if active.any():
-      all_mpkpe.append(torch.where(active, compute_mpkpe(command), 0.0))
-      all_r_mpkpe.append(torch.where(active, compute_root_relative_mpkpe(command), 0.0))
-      all_joint_vel_error.append(
-        torch.where(active, compute_joint_velocity_error(command), 0.0)
-      )
-      all_ee_pos_error.append(
-        torch.where(active, compute_ee_position_error(command, ee_body_names), 0.0)
-      )
-      all_ee_ori_error.append(
-        torch.where(active, compute_ee_orientation_error(command, ee_body_names), 0.0)
-      )
+    all_active.append(active.float())
+    all_mpkpe.append(torch.where(active, compute_mpkpe(ref_command), 0.0))
+    all_r_mpkpe.append(
+      torch.where(active, compute_root_relative_mpkpe(ref_command), 0.0)
+    )
+    all_joint_vel_error.append(
+      torch.where(active, compute_joint_velocity_error(ref_command), 0.0)
+    )
+    all_ee_pos_error.append(
+      torch.where(active, compute_ee_position_error(ref_command, ee_body_names), 0.0)
+    )
+    all_ee_ori_error.append(
+      torch.where(active, compute_ee_orientation_error(ref_command, ee_body_names), 0.0)
+    )
 
     # Track completions.
     terminated = env.unwrapped.termination_manager.terminated
@@ -142,7 +169,7 @@ def run_evaluate(task_id: str, cfg: EvaluateConfig) -> dict[str, float]:
       )
     step += 1
 
-  # Compute mean metrics.
+  # Compute mean metrics over the steps each env was active.
   stacks = [
     all_mpkpe,
     all_r_mpkpe,
@@ -151,7 +178,7 @@ def run_evaluate(task_id: str, cfg: EvaluateConfig) -> dict[str, float]:
     all_ee_ori_error,
   ]
   stacks = [torch.stack(s, dim=0) for s in stacks]
-  active_steps = (stacks[0] != 0).sum(dim=0).float().clamp(min=1)
+  active_steps = torch.stack(all_active, dim=0).sum(dim=0).clamp(min=1)
   means = [s.sum(dim=0) / active_steps for s in stacks]
 
   metrics = {

--- a/tests/test_tracking_metrics.py
+++ b/tests/test_tracking_metrics.py
@@ -1,5 +1,6 @@
 """Tests for motion tracking evaluation metrics."""
 
+import math
 from unittest.mock import Mock
 
 import pytest
@@ -79,58 +80,52 @@ def test_mpkpe_uses_global_reference(mock_command):
   assert torch.allclose(mpkpe, torch.ones(mock_command.num_envs), atol=1e-6)
 
 
-def test_r_mpkpe_invariant_to_global_translation(mock_command):
-  """Test R-MPKPE is invariant to global translation."""
+def test_r_mpkpe_zero_when_relative_positions_match(mock_command):
+  """R-MPKPE is zero when re-anchored positions are identical."""
   num_bodies = len(mock_command.cfg.body_names)
+  positions = torch.rand(mock_command.num_envs, num_bodies, 3)
 
-  mock_command.anchor_pos_w = torch.zeros(mock_command.num_envs, 3)
-  mock_command.body_pos_w = torch.rand(mock_command.num_envs, num_bodies, 3)
-  mock_command.robot_anchor_pos_w = torch.zeros(mock_command.num_envs, 3)
-  mock_command.robot_body_pos_w = mock_command.body_pos_w.clone()
+  mock_command.body_pos_relative_w = positions.clone()
+  mock_command.robot_body_pos_w = positions.clone()
 
-  r_mpkpe_1 = compute_root_relative_mpkpe(mock_command)
+  r_mpkpe = compute_root_relative_mpkpe(mock_command)
 
-  # Translate everything by large offset.
-  offset = torch.tensor([100.0, 200.0, 300.0])
-  mock_command.anchor_pos_w = offset.expand(mock_command.num_envs, 3).clone()
-  mock_command.body_pos_w = mock_command.body_pos_w + offset
-  mock_command.robot_anchor_pos_w = offset.expand(mock_command.num_envs, 3).clone()
-  mock_command.robot_body_pos_w = mock_command.robot_body_pos_w + offset
-
-  r_mpkpe_2 = compute_root_relative_mpkpe(mock_command)
-
-  assert torch.allclose(r_mpkpe_1, r_mpkpe_2, atol=1e-5)
+  assert r_mpkpe.shape == (mock_command.num_envs,)
+  assert torch.allclose(r_mpkpe, torch.zeros(mock_command.num_envs), atol=1e-6)
 
 
-def test_r_mpkpe_detects_relative_error(mock_command):
-  """Test R-MPKPE detects errors in relative positions."""
+def test_r_mpkpe_uses_relative_reference(mock_command):
+  """R-MPKPE reads the re-anchored reference, not the global one.
+
+  Setting body_pos_w to match the robot exactly would yield zero error if
+  it were (incorrectly) used; the metric must instead follow
+  body_pos_relative_w.
+  """
   num_bodies = len(mock_command.cfg.body_names)
-
-  mock_command.anchor_pos_w = torch.zeros(mock_command.num_envs, 3)
-  mock_command.body_pos_w = torch.zeros(mock_command.num_envs, num_bodies, 3)
-  mock_command.body_pos_w[:, :, 0] = 1.0  # Bodies 1 unit from anchor
-
-  mock_command.robot_anchor_pos_w = torch.zeros(mock_command.num_envs, 3)
-  mock_command.robot_body_pos_w = torch.zeros(mock_command.num_envs, num_bodies, 3)
-  mock_command.robot_body_pos_w[:, :, 0] = 2.0  # Bodies 2 units from anchor
+  robot_pos = torch.rand(mock_command.num_envs, num_bodies, 3)
+  mock_command.robot_body_pos_w = robot_pos.clone()
+  mock_command.body_pos_w = robot_pos.clone()  # zero error if misused
+  mock_command.body_pos_relative_w = robot_pos.clone()
+  mock_command.body_pos_relative_w[:, :, 0] += 1.0  # 1 unit of local pose error
 
   r_mpkpe = compute_root_relative_mpkpe(mock_command)
 
   assert torch.allclose(r_mpkpe, torch.ones(mock_command.num_envs), atol=1e-6)
 
 
-def test_joint_velocity_error(mock_command):
-  """Test joint velocity error computes correct L2 norm."""
+def test_joint_velocity_error_rms(mock_command):
+  """Joint velocity error is the per-joint RMS of the velocity error."""
   num_joints = 3
 
   mock_command.joint_vel = torch.zeros(mock_command.num_envs, num_joints)
   mock_command.robot_joint_vel = torch.zeros(mock_command.num_envs, num_joints)
   mock_command.robot_joint_vel[:, 0] = 3.0
-  mock_command.robot_joint_vel[:, 1] = 4.0  # Error [3, 4, 0] has norm 5
+  mock_command.robot_joint_vel[:, 1] = 4.0  # Error [3, 4, 0]
 
   error = compute_joint_velocity_error(mock_command)
 
-  assert torch.allclose(error, torch.ones(mock_command.num_envs) * 5.0, atol=1e-6)
+  expected = math.sqrt((3.0**2 + 4.0**2 + 0.0**2) / num_joints)
+  assert torch.allclose(error, torch.ones(mock_command.num_envs) * expected, atol=1e-6)
 
 
 def test_ee_position_error_only_uses_specified_bodies(mock_command):
@@ -172,3 +167,13 @@ def test_ee_orientation_error_detects_rotation(mock_command):
   # Error should be approximately pi/2 radians.
   expected = torch.ones(mock_command.num_envs) * (3.14159 / 2)
   assert torch.allclose(error, expected, atol=0.01)
+
+
+def test_ee_metrics_raise_on_unknown_body(mock_command):
+  """Unknown end-effector names raise instead of silently scoring zero."""
+  num_bodies = len(mock_command.cfg.body_names)
+  mock_command.body_pos_relative_w = torch.zeros(mock_command.num_envs, num_bodies, 3)
+  mock_command.robot_body_pos_w = torch.zeros(mock_command.num_envs, num_bodies, 3)
+
+  with pytest.raises(ValueError, match="not tracked"):
+    compute_ee_position_error(mock_command, ("nonexistent_body",))


### PR DESCRIPTION
Follow-up cleanup to #1007 for the tracking task's evaluation metrics.

compute_root_relative_mpkpe now uses body_pos_relative_w, the reference re-anchored to the robot's root position and heading each step (the same quantity the tracking reward optimizes). It previously subtracted only the anchor translation, so heading drift still leaked into the score; it now removes both translation and yaw drift and measures intrinsic body pose error.

compute_joint_velocity_error now returns a per-joint RMS instead of a raw L2 norm, so the value no longer scales with the number of joints and is comparable across robots.

The end-effector metrics (compute_ee_position_error and compute_ee_orientation_error) now raise a ValueError when given a body name that is not tracked, instead of silently returning a zero error and hiding the misconfiguration. The re-anchored frame they use is intentional and unchanged.

The evaluation script also computed its metrics one motion frame out of sync. It advanced the command an extra frame before the rollout and read the reference after env.step had already advanced it, so each metric paired the robot with the next reference frame rather than the one it was rewarded against. The reference is now snapshotted before each step and paired with the post-step robot state, and per-step averaging counts active steps explicitly instead of inferring them from a nonzero MPKPE.

Verified by running the full evaluation on a real nightly checkpoint (run xfxrbq3v, 512 envs): joint_vel_error drops by a factor of sqrt(29) as expected for the 29-DOF G1, the end-effector metrics are numerically unchanged, and r_mpkpe stays below mpkpe. The published nightly numbers should be backfilled once this merges, since these changes alter the cached r_mpkpe and joint_vel_error values.