### PR TITLE
Nightly page: throughput range filter, regression flags, and zoom

### DIFF
--- a/scripts/benchmarks/generate_report.py
+++ b/scripts/benchmarks/generate_report.py
@@ -102,6 +102,7 @@ def generate_dashboard_html(runs: list[dict], throughput_data: list[dict]) -> st
     <title>mjlab Nightly Benchmark</title>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-zoom@2"></script>
     <style>
         :root {{
             --bg: #ffffff;
@@ -336,6 +337,12 @@ def generate_dashboard_html(runs: list[dict], throughput_data: list[dict]) -> st
     <div id="throughput" class="tab-content">
         <p class="tab-description">Physics simulation throughput across tasks (4096 parallel envs, NVIDIA RTX 5090).</p>
         <div class="task-grid" id="task-grid"></div>
+        <div class="range-selector" id="range-selector-tp">
+            <button class="range-btn" data-days="30">30d</button>
+            <button class="range-btn active" data-days="90">90d</button>
+            <button class="range-btn" data-days="180">180d</button>
+            <button class="range-btn" data-days="0">All</button>
+        </div>
         <div id="task-chart-panels"></div>
     </div>
 
@@ -421,6 +428,7 @@ def generate_dashboard_html(runs: list[dict], throughput_data: list[dict]) -> st
 
         let charts = [];
         let trackingCharts = [];
+        let throughputCharts = [];
 
         function updateChartColors() {{
             const style = getComputedStyle(root);
@@ -450,6 +458,27 @@ def generate_dashboard_html(runs: list[dict], throughput_data: list[dict]) -> st
         }}
 
         const AVG_WINDOW = 7;
+        const REG_THRESHOLD = 0.1;  // Flag points >10% worse than trailing avg.
+        const REG_COLOR = '#f85149';
+
+        // Flag each point that is worse than the trailing average of the prior
+        // AVG_WINDOW points by more than REG_THRESHOLD (direction-aware).
+        function regressionFlags(data, higherIsBetter) {{
+            return data.map((d, i) => {{
+                if (i < AVG_WINDOW) return false;
+                const prior = data.slice(i - AVG_WINDOW, i);
+                const avg = prior.reduce((s, p) => s + p.y, 0) / prior.length;
+                if (!avg) return false;
+                const rel = (d.y - avg) / Math.abs(avg);
+                return higherIsBetter ? rel < -REG_THRESHOLD : rel > REG_THRESHOLD;
+            }});
+        }}
+
+        // Shared zoom/pan config: wheel to zoom, drag to pan, x-axis only.
+        const ZOOM = {{
+            zoom: {{ wheel: {{ enabled: true }}, pinch: {{ enabled: true }}, mode: 'x' }},
+            pan: {{ enabled: true, mode: 'x' }}
+        }};
 
         METRICS.forEach(([key, label, unit, scale, higherIsBetter]) => {{
             const data = runs.map(r => ({{
@@ -460,18 +489,22 @@ def generate_dashboard_html(runs: list[dict], throughput_data: list[dict]) -> st
             }}));
 
             const avgData = rollingAvg(data, AVG_WINDOW);
+            const flags = regressionFlags(data, higherIsBetter);
             const color = colors[key] || '#58a6ff';
 
             const latestVal = data[data.length - 1]?.y;
+            const latestRegressed = flags[flags.length - 1];
             const arrow = higherIsBetter ? '\u2191' : '\u2193';
             const tooltip = higherIsBetter ? 'Higher is better' : 'Lower is better';
+            const valStyle = latestRegressed ? ` style="color:${{REG_COLOR}}"` : '';
+            const warn = latestRegressed ? ' \u26a0' : '';
 
             const card = document.createElement('div');
             card.className = 'chart-card';
             card.innerHTML = `
                 <div class="chart-title">
                     <span>${{label}} <span title="${{tooltip}}" style="cursor:help;opacity:0.6">${{arrow}}</span></span>
-                    <span class="chart-value">${{latestVal?.toFixed(3)}} ${{unit}}</span>
+                    <span class="chart-value"${{valStyle}}>${{latestVal?.toFixed(3)}} ${{unit}}${{warn}}</span>
                 </div>
                 <div class="chart-container"><canvas></canvas></div>
             `;
@@ -487,8 +520,10 @@ def generate_dashboard_html(runs: list[dict], throughput_data: list[dict]) -> st
                             borderColor: color,
                             backgroundColor: color + '20',
                             borderWidth: 2,
-                            pointRadius: 2,
+                            pointRadius: data.map((d, i) => flags[i] ? 5 : 2),
                             pointHoverRadius: 5,
+                            pointBackgroundColor: data.map((d, i) => flags[i] ? REG_COLOR : color),
+                            pointBorderColor: data.map((d, i) => flags[i] ? REG_COLOR : color),
                             tension: 0.1,
                             fill: true
                         }},
@@ -516,6 +551,7 @@ def generate_dashboard_html(runs: list[dict], throughput_data: list[dict]) -> st
                         }}
                     }},
                     plugins: {{
+                        zoom: ZOOM,
                         legend: {{
                             display: true,
                             position: 'bottom',
@@ -564,23 +600,6 @@ def generate_dashboard_html(runs: list[dict], throughput_data: list[dict]) -> st
             charts.push(chart);
             trackingCharts.push(chart);
         }});
-
-        // Date-range windowing across all tracking charts.
-        function setRange(days) {{
-            const min = days > 0 ? Date.now() - days * 86400000 : undefined;
-            trackingCharts.forEach(c => {{
-                c.options.scales.x.min = min;
-                c.update();
-            }});
-        }}
-        document.querySelectorAll('.range-btn').forEach(btn => {{
-            btn.addEventListener('click', () => {{
-                document.querySelectorAll('.range-btn').forEach(b => b.classList.remove('active'));
-                btn.classList.add('active');
-                setRange(parseInt(btn.dataset.days));
-            }});
-        }});
-        setRange(90);
 
         // Tab switching
         document.querySelectorAll('.tab').forEach(tab => {{
@@ -659,6 +678,9 @@ def generate_dashboard_html(runs: list[dict], throughput_data: list[dict]) -> st
                     physicsData.push({{ ...point, y: result.physics_sps / 1000 }});
                 }});
 
+                const envFlags = regressionFlags(envData, true);
+                const physFlags = regressionFlags(physicsData, true);
+
                 const chart = new Chart(panel.querySelector('canvas'), {{
                     type: 'line',
                     data: {{
@@ -669,7 +691,10 @@ def generate_dashboard_html(runs: list[dict], throughput_data: list[dict]) -> st
                                 borderColor: '#58a6ff',
                                 backgroundColor: '#58a6ff20',
                                 borderWidth: 2,
-                                pointRadius: 4,
+                                pointRadius: envData.map((d, i) => envFlags[i] ? 5 : 2),
+                                pointHoverRadius: 5,
+                                pointBackgroundColor: envData.map((d, i) => envFlags[i] ? REG_COLOR : '#58a6ff'),
+                                pointBorderColor: envData.map((d, i) => envFlags[i] ? REG_COLOR : '#58a6ff'),
                                 tension: 0.1,
                                 fill: true
                             }},
@@ -679,7 +704,10 @@ def generate_dashboard_html(runs: list[dict], throughput_data: list[dict]) -> st
                                 borderColor: '#3fb950',
                                 backgroundColor: '#3fb95020',
                                 borderWidth: 2,
-                                pointRadius: 4,
+                                pointRadius: physicsData.map((d, i) => physFlags[i] ? 5 : 2),
+                                pointHoverRadius: 5,
+                                pointBackgroundColor: physicsData.map((d, i) => physFlags[i] ? REG_COLOR : '#3fb950'),
+                                pointBorderColor: physicsData.map((d, i) => physFlags[i] ? REG_COLOR : '#3fb950'),
                                 tension: 0.1,
                                 fill: true
                             }}
@@ -699,6 +727,7 @@ def generate_dashboard_html(runs: list[dict], throughput_data: list[dict]) -> st
                             }}
                         }},
                         plugins: {{
+                            zoom: ZOOM,
                             legend: {{ display: true, position: 'bottom' }},
                             tooltip: {{
                                 mode: 'index',
@@ -745,6 +774,7 @@ def generate_dashboard_html(runs: list[dict], throughput_data: list[dict]) -> st
                     }}
                 }});
                 charts.push(chart);
+                throughputCharts.push(chart);
                 throughputChartInstances[task] = {{ chart, panelId: `task-panel-${{i}}` }};
 
                 // Card click handler
@@ -760,6 +790,23 @@ def generate_dashboard_html(runs: list[dict], throughput_data: list[dict]) -> st
         }} else {{
             taskGrid.innerHTML = '<p style="color: var(--text-dim)">No throughput data available. Run measure_throughput.py to generate data.</p>';
         }}
+
+        // Date-range windowing across both tracking and throughput charts.
+        // Setting min and clearing max also resets any zoom/pan.
+        function setRange(days) {{
+            const min = days > 0 ? Date.now() - days * 86400000 : undefined;
+            [...trackingCharts, ...throughputCharts].forEach(c => {{
+                c.options.scales.x.min = min;
+                c.options.scales.x.max = undefined;
+                c.update();
+            }});
+            document.querySelectorAll('.range-btn').forEach(b =>
+                b.classList.toggle('active', parseInt(b.dataset.days) === days));
+        }}
+        document.querySelectorAll('.range-btn').forEach(btn => {{
+            btn.addEventListener('click', () => setRange(parseInt(btn.dataset.days)));
+        }});
+        setRange(90);
     </script>
 </body>
 </html>


### PR DESCRIPTION
Three readability/usefulness improvements to the nightly benchmark page, following the date-range filter added in #1009.

The throughput tab had the same crowding as the tracking tab (112 points, full-size markers) and wasn't covered by the tracking range filter. It now has its own 30d/90d/180d/All selector, and a single setRange windows both tabs at once while keeping the two selectors in sync.

Both tabs now flag regressions. Any point worse than the trailing 7-run average by more than 10 percent (direction-aware, so lower-is-better and higher-is-better metrics are handled correctly) is drawn enlarged in red, and a tracking metric card shows its latest value in red with a warning glyph when the most recent run regressed.

All charts get wheel-zoom and drag-pan on the x-axis via chartjs-plugin-zoom; picking a range preset also resets the zoom. Header freshness (last-updated/commit) is left for a later change.

Template-only. Verified by regenerating the page from the live backfilled data and syntax-checking the generated script. I can regenerate and republish to gh-pages once this merges.