### PR TITLE
Reject entity specs with multiple freejoints

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -54,6 +54,12 @@ Added
 Changed
 ^^^^^^^
 
+- ``Entity`` now raises a clear error at construction when its spec contains
+  more than one freejoint. An entity models a single system rooted at one
+  body, so it has at most one freejoint; a second one was previously accepted
+  silently and only surfaced later as a cryptic shape mismatch when writing
+  root state. Model each detached floating body as its own entry in
+  ``SceneCfg.entities`` instead.
 - Changed ``compute_root_relative_mpkpe`` to re-anchor the reference to the
   robot's root each step, removing yaw drift as well as translation so it
   measures intrinsic body pose error.

--- a/src/mjlab/entity/entity.py
+++ b/src/mjlab/entity/entity.py
@@ -169,6 +169,16 @@ class Entity:
     self._all_joints = self._spec.joints
     self._free_joint = None
     self._non_free_joints = tuple(self._all_joints)
+
+    free_joints = [j for j in self._all_joints if j.type == mujoco.mjtJoint.mjJNT_FREE]
+    if len(free_joints) > 1:
+      raise ValueError(
+        f"Entity spec has {len(free_joints)} freejoints. An Entity models a "
+        "single rigid- or articulated-body system with at most one freejoint, "
+        "which serves as its root. Model each detached floating body as its own "
+        "entry in SceneCfg.entities instead."
+      )
+
     if self._all_joints and self._all_joints[0].type == mujoco.mjtJoint.mjJNT_FREE:
       self._free_joint = self._all_joints[0]
       if not self._free_joint.name:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -106,17 +106,25 @@ def initialize_entity(entity: Entity, device: str, num_envs: int = 1):
 
 def make_scene_and_sim(
   device: str,
-  xml: str,
+  xml: str | dict[str, str],
   sensors: tuple,
   num_envs: int = 1,
   sim_cfg: SimulationCfg | None = None,
 ) -> tuple[Scene, Simulation]:
-  """Create a scene and simulation from inline XML with sensors wired up."""
-  entity_cfg = EntityCfg(spec_fn=lambda: mujoco.MjSpec.from_string(xml))
+  """Create a scene and simulation from inline XML with sensors wired up.
+
+  ``xml`` may be a single XML string (registered as the ``robot`` entity) or a
+  mapping of entity name to XML string for multi-entity scenes.
+  """
+  xml_by_entity = {"robot": xml} if isinstance(xml, str) else xml
+  entities = {
+    name: EntityCfg(spec_fn=lambda s=s: mujoco.MjSpec.from_string(s))
+    for name, s in xml_by_entity.items()
+  }
   scene_cfg = SceneCfg(
     num_envs=num_envs,
     env_spacing=5.0,
-    entities={"robot": entity_cfg},
+    entities=entities,
     sensors=sensors,
   )
   scene = Scene(scene_cfg, device)

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -243,6 +243,27 @@ def test_unnamed_freejoint_gets_default_name():
   assert "floating_base_joint" in entity.all_joint_names
 
 
+def test_multiple_freejoints_raises():
+  """An entity with more than one freejoint is rejected at construction."""
+  xml = """
+  <mujoco>
+    <worldbody>
+      <body name="object_a" pos="0 0 1">
+        <freejoint/>
+        <geom type="box" size="0.1 0.1 0.1" mass="0.1"/>
+      </body>
+      <body name="object_b" pos="1 0 1">
+        <freejoint/>
+        <geom type="box" size="0.1 0.1 0.1" mass="0.1"/>
+      </body>
+    </worldbody>
+  </mujoco>
+  """
+  cfg = EntityCfg(spec_fn=lambda: mujoco.MjSpec.from_string(xml))
+  with pytest.raises(ValueError, match="2 freejoints"):
+    Entity(cfg)
+
+
 def test_find_methods():
   """Test find methods with exact and regex matches."""
   entity = create_floating_articulated_entity()

--- a/tests/test_raycast_sensor.py
+++ b/tests/test_raycast_sensor.py
@@ -936,7 +936,7 @@ def test_multi_frame_body_exclusion(device):
   should skip body_b's own geom but HIT body_a's platform. Frame A's
   rays should skip body_a and hit the floor.
   """
-  xml = """
+  body_a_xml = """
     <mujoco>
       <worldbody>
         <geom name="floor" type="plane" size="10 10 0.1" pos="0 0 0"/>
@@ -945,6 +945,12 @@ def test_multi_frame_body_exclusion(device):
           <geom name="geom_a" type="box" size="2 2 0.1" mass="5.0"/>
           <site name="site_a" pos="0 0 0"/>
         </body>
+      </worldbody>
+    </mujoco>
+  """
+  body_b_xml = """
+    <mujoco>
+      <worldbody>
         <body name="body_b" pos="0 0 3">
           <freejoint name="free_b"/>
           <geom name="geom_b" type="box" size="0.5 0.5 0.5" mass="5.0"/>
@@ -957,15 +963,17 @@ def test_multi_frame_body_exclusion(device):
   cfg = RayCastSensorCfg(
     name="multi",
     frame=(
-      ObjRef(type="site", name="site_a", entity="robot"),
-      ObjRef(type="site", name="site_b", entity="robot"),
+      ObjRef(type="site", name="site_a", entity="body_a"),
+      ObjRef(type="site", name="site_b", entity="body_b"),
     ),
     pattern=GridPatternCfg(size=(0.0, 0.0), resolution=0.1),
     max_distance=10.0,
     exclude_parent_body=True,
   )
 
-  scene, sim = make_scene_and_sim(device, xml, (cfg,))
+  scene, sim = make_scene_and_sim(
+    device, {"body_a": body_a_xml, "body_b": body_b_xml}, (cfg,)
+  )
   sim.step()
   sim.sense()
 


### PR DESCRIPTION
An Entity has at most one freejoint (its root). A second freejoint was previously accepted silently and only surfaced later as a cryptic shape mismatch when writing root state. This raises a clear error at construction instead, pointing users to model each detached floating body as its own `SceneCfg.entities` entry.