### PR TITLE
Add BuiltinPdActuator: implicit-integration PD with position and velocity references

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,6 +8,17 @@ Upcoming version (not yet released)
 Added
 ^^^^^
 
+- Added ``BuiltinPdActuator``, the implicit-integration version of
+  ``IdealPdActuator``. Same interface (position + velocity targets,
+  kp/kd gains), but expresses the PD as native MuJoCo ``<position>``
+  and ``<velocity>`` elements so the ``implicit`` / ``implicitfast``
+  integrators include the kp/kd derivatives in their velocity update.
+  The actuator stays stable at gain/timestep combinations where
+  explicit Python PD would diverge, which matters when you want to
+  run a real motor's stiff on-board PD gains in sim. ``effort_limit``
+  is enforced as a sum-clamp on the two PD terms via
+  ``jnt_actfrcrange`` (or ``tendon_actfrcrange``). Supported by
+  ``dr.pd_gains`` and ``dr.effort_limits``.
 - Added ``mdp.projected_gravity_from_sensor``, an observation that derives
   projected gravity from a ``framezaxis`` up-vector sensor (negated) rather
   than from the root body orientation. Unlike ``mdp.projected_gravity``, it

--- a/src/mjlab/actuator/__init__.py
+++ b/src/mjlab/actuator/__init__.py
@@ -17,6 +17,12 @@ from mjlab.actuator.builtin_actuator import (
   BuiltinMuscleActuatorCfg as BuiltinMuscleActuatorCfg,
 )
 from mjlab.actuator.builtin_actuator import (
+  BuiltinPdActuator as BuiltinPdActuator,
+)
+from mjlab.actuator.builtin_actuator import (
+  BuiltinPdActuatorCfg as BuiltinPdActuatorCfg,
+)
+from mjlab.actuator.builtin_actuator import (
   BuiltinPositionActuator as BuiltinPositionActuator,
 )
 from mjlab.actuator.builtin_actuator import (

--- a/src/mjlab/actuator/builtin_actuator.py
+++ b/src/mjlab/actuator/builtin_actuator.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import mujoco
+import numpy as np
 import torch
 
 from mjlab.actuator.actuator import (
@@ -89,6 +90,102 @@ class BuiltinPositionActuator(Actuator[BuiltinPositionActuatorCfg]):
 
   def compute(self, cmd: ActuatorCmd) -> torch.Tensor:
     return cmd.position_target
+
+
+@dataclass(kw_only=True)
+class BuiltinPdActuatorCfg(ActuatorCfg):
+  """Implicit-integration version of ``IdealPdActuator``.
+
+  Both consume a position target and a velocity target with kp/kd gains.
+  The difference is in how the PD is delivered to MuJoCo: ``IdealPdActuator`` computes
+  the PD force in Python and feeds it to a ``<motor>`` element, which MuJoCo sees as an
+  opaque external force. This actuator expresses the PD as native MuJoCo elements (a
+  ``<position>`` carrying kp, a ``<velocity>`` carrying kd), so the ``implicit`` and
+  ``implicitfast`` integrators include the kp/kd derivatives in their velocity update.
+  That makes the actuator numerically stable at gain/timestep combinations where
+  explicit Python PD would diverge, which matters when you want to run a real motor's
+  stiff on-board PD gains in sim.
+  """
+
+  stiffness: float
+  """Proportional gain (kp)."""
+  damping: float
+  """Derivative gain (kd)."""
+  effort_limit: float | None = None
+  """Maximum total torque applied to the joint or tendon. Enforced as a
+  sum-clamp on the two PD terms via jnt_actfrcrange (JOINT) or
+  tendon_actfrcrange (TENDON). None leaves the limit unset."""
+
+  def __post_init__(self) -> None:
+    super().__post_init__()
+    if self.transmission_type == TransmissionType.SITE:
+      raise ValueError(
+        "BuiltinPdActuatorCfg does not support SITE transmission. "
+        "Use BuiltinMotorActuatorCfg for site transmission."
+      )
+
+  def build(
+    self, entity: Entity, target_ids: list[int], target_names: list[str]
+  ) -> BuiltinPdActuator:
+    return BuiltinPdActuator(self, entity, target_ids, target_names)
+
+
+class BuiltinPdActuator(Actuator[BuiltinPdActuatorCfg]):
+  """MuJoCo native PD: paired <position> + <velocity> elements per target."""
+
+  def __init__(
+    self,
+    cfg: BuiltinPdActuatorCfg,
+    entity: Entity,
+    target_ids: list[int],
+    target_names: list[str],
+  ) -> None:
+    super().__init__(cfg, entity, target_ids, target_names)
+
+  @property
+  def num_targets(self) -> int:
+    """Number of targets. ``ctrl_ids`` is laid out as ``[pos..., vel...]``,
+    each block of length ``num_targets``."""
+    return len(self._target_ids_list)
+
+  def edit_spec(self, spec: mujoco.MjSpec, target_names: list[str]) -> None:
+    # Position elements first, then velocity elements, so ctrl_ids is laid out
+    # as [pos_0..pos_{N-1}, vel_0..vel_{N-1}].
+    for target_name in target_names:
+      pos_act = create_position_actuator(
+        spec,
+        target_name,
+        actuator_name=f"{target_name}_pd_pos",
+        stiffness=self.cfg.stiffness,
+        damping=0.0,  # damping lives on the <velocity> element.
+        armature=self.cfg.armature,
+        frictionloss=self.cfg.frictionloss,
+        viscous_damping=self.cfg.viscous_damping,
+        transmission_type=self.cfg.transmission_type,
+      )
+      self._mjs_actuators.append(pos_act)
+    for target_name in target_names:
+      vel_act = create_velocity_actuator(
+        spec,
+        target_name,
+        actuator_name=f"{target_name}_pd_vel",
+        damping=self.cfg.damping,
+        transmission_type=self.cfg.transmission_type,
+      )
+      self._mjs_actuators.append(vel_act)
+    # Effort limit: sum-clamp on the joint/tendon, not on each element.
+    if self.cfg.effort_limit is not None:
+      lim = self.cfg.effort_limit
+      for target_name in target_names:
+        if self.cfg.transmission_type == TransmissionType.JOINT:
+          target = spec.joint(target_name)
+        else:
+          target = spec.tendon(target_name)
+        target.actfrclimited = mujoco.mjtLimited.mjLIMITED_TRUE
+        target.actfrcrange[:] = np.array([-lim, lim])
+
+  def compute(self, cmd: ActuatorCmd) -> torch.Tensor:
+    return torch.cat((cmd.position_target, cmd.velocity_target), dim=1)
 
 
 @dataclass(kw_only=True)

--- a/src/mjlab/envs/mdp/dr/actuator.py
+++ b/src/mjlab/envs/mdp/dr/actuator.py
@@ -6,7 +6,8 @@ from typing import TYPE_CHECKING, Literal
 
 import torch
 
-from mjlab.actuator import BuiltinPositionActuator, IdealPdActuator
+from mjlab.actuator import BuiltinPdActuator, BuiltinPositionActuator, IdealPdActuator
+from mjlab.actuator.actuator import TransmissionType
 from mjlab.actuator.xml_actuator import XmlActuator
 from mjlab.entity import Entity
 from mjlab.managers.event_manager import requires_model_fields
@@ -62,18 +63,25 @@ def pd_gains(
 
   for actuator in actuators:
     ctrl_ids = actuator.global_ctrl_ids
+    # Each target needs one kp draw and one kd draw. For single-element
+    # actuators that's len(ctrl_ids) of each; for BuiltinPd the ctrl tensor
+    # has 2*N entries but only N independent kp/kd values, so we sample
+    # num_targets to avoid throwing the other half away.
+    n_gains = (
+      actuator.num_targets if isinstance(actuator, BuiltinPdActuator) else len(ctrl_ids)
+    )
 
     dist = resolve_distribution(distribution)
     kp_samples = dist.sample(
       torch.tensor(kp_range[0], device=env.device),
       torch.tensor(kp_range[1], device=env.device),
-      (len(env_ids), len(ctrl_ids)),
+      (len(env_ids), n_gains),
       env.device,
     )
     kd_samples = dist.sample(
       torch.tensor(kd_range[0], device=env.device),
       torch.tensor(kd_range[1], device=env.device),
-      (len(env_ids), len(ctrl_ids)),
+      (len(env_ids), n_gains),
       env.device,
     )
 
@@ -98,6 +106,37 @@ def pd_gains(
         env.sim.model.actuator_biasprm[env_ids[:, None], ctrl_ids, 1] = -kp_samples
         env.sim.model.actuator_biasprm[env_ids[:, None], ctrl_ids, 2] = -kd_samples
 
+    elif isinstance(actuator, BuiltinPdActuator):
+      # ctrl_ids is laid out as [pos_0..pos_{N-1}, vel_0..vel_{N-1}], so the
+      # first N rows carry kp and the next N carry kd.
+      n = actuator.num_targets
+      pos_ids = ctrl_ids[:n]
+      vel_ids = ctrl_ids[n:]
+      if op.name == "scale":
+        default_gainprm = env.sim.get_default_field("actuator_gainprm")
+        default_biasprm = env.sim.get_default_field("actuator_biasprm")
+        env.sim.model.actuator_gainprm[env_ids[:, None], pos_ids, 0] = (
+          default_gainprm[pos_ids, 0] * kp_samples
+        )
+        env.sim.model.actuator_biasprm[env_ids[:, None], pos_ids, 1] = (
+          default_biasprm[pos_ids, 1] * kp_samples
+        )
+        env.sim.model.actuator_gainprm[env_ids[:, None], vel_ids, 0] = (
+          default_gainprm[vel_ids, 0] * kd_samples
+        )
+        env.sim.model.actuator_biasprm[env_ids[:, None], vel_ids, 2] = (
+          default_biasprm[vel_ids, 2] * kd_samples
+        )
+      else:
+        assert op.name == "abs"
+        env.sim.model.actuator_gainprm[env_ids[:, None], pos_ids, 0] = kp_samples
+        env.sim.model.actuator_biasprm[env_ids[:, None], pos_ids, 1] = -kp_samples
+        env.sim.model.actuator_gainprm[env_ids[:, None], vel_ids, 0] = kd_samples
+        env.sim.model.actuator_biasprm[env_ids[:, None], vel_ids, 2] = -kd_samples
+      # biasprm[2] on the position half stays zero by construction. Writing
+      # anything else here would inject damping into the position element on
+      # top of the velocity element, silently double-counting kd.
+
     elif isinstance(actuator, IdealPdActuator):
       assert actuator.stiffness is not None
       assert actuator.damping is not None
@@ -115,13 +154,13 @@ def pd_gains(
 
     else:
       raise TypeError(
-        f"pd_gains only supports BuiltinPositionActuator, "
+        f"pd_gains only supports BuiltinPositionActuator, BuiltinPdActuator, "
         f"XmlActuator (position), and IdealPdActuator, "
         f"got {type(actuator).__name__}"
       )
 
 
-@requires_model_fields("actuator_forcerange")
+@requires_model_fields("actuator_forcerange", "jnt_actfrcrange", "tendon_actfrcrange")
 def effort_limits(
   env: ManagerBasedRlEnv,
   env_ids: torch.Tensor | None,
@@ -162,13 +201,18 @@ def effort_limits(
 
   for actuator in actuators:
     ctrl_ids = actuator.global_ctrl_ids
-    num_actuators = len(ctrl_ids)
+    # One effort sample per target. For single-element actuators this matches
+    # ctrl_ids; for BuiltinPd the limit lives on the joint/tendon, so one
+    # sample per target is sufficient regardless of the two-element ctrl.
+    n_samples = (
+      actuator.num_targets if isinstance(actuator, BuiltinPdActuator) else len(ctrl_ids)
+    )
 
     dist = resolve_distribution(distribution)
     effort_samples = dist.sample(
       torch.tensor(effort_limit_range[0], device=env.device),
       torch.tensor(effort_limit_range[1], device=env.device),
-      (len(env_ids), num_actuators),
+      (len(env_ids), n_samples),
       env.device,
     )
 
@@ -204,9 +248,32 @@ def effort_limits(
         assert op.name == "abs"
         actuator.set_effort_limit(env_ids, effort_limit=effort_samples)
 
+    elif isinstance(actuator, BuiltinPdActuator):
+      # BuiltinPd's effort_limit lives on the joint/tendon as a sum-clamp
+      # (jnt_actfrcrange / tendon_actfrcrange), not on per-element forcerange.
+      if actuator.transmission_type == TransmissionType.JOINT:
+        field = "jnt_actfrcrange"
+        target_global_ids = asset.indexing.joint_ids[actuator.target_ids]
+      else:
+        field = "tendon_actfrcrange"
+        target_global_ids = asset.indexing.tendon_ids[actuator.target_ids]
+      arr = getattr(env.sim.model, field)
+      if op.name == "scale":
+        default = env.sim.get_default_field(field)
+        arr[env_ids[:, None], target_global_ids, 0] = (
+          default[target_global_ids, 0] * effort_samples
+        )
+        arr[env_ids[:, None], target_global_ids, 1] = (
+          default[target_global_ids, 1] * effort_samples
+        )
+      else:
+        assert op.name == "abs"
+        arr[env_ids[:, None], target_global_ids, 0] = -effort_samples
+        arr[env_ids[:, None], target_global_ids, 1] = effort_samples
+
     else:
       raise TypeError(
-        f"effort_limits only supports BuiltinPositionActuator, "
+        f"effort_limits only supports BuiltinPositionActuator, BuiltinPdActuator, "
         f"XmlActuator (position), and IdealPdActuator, "
         f"got {type(actuator).__name__}"
       )

--- a/src/mjlab/utils/spec.py
+++ b/src/mjlab/utils/spec.py
@@ -265,14 +265,21 @@ def create_position_actuator(
   frictionloss: float | None = None,
   viscous_damping: float | None = None,
   transmission_type: TransmissionType = TransmissionType.JOINT,
+  actuator_name: str | None = None,
 ) -> mujoco.MjsActuator:
   """Creates a <position> actuator.
 
   An important note about this actuator is that we set `ctrllimited` to False. This is
   because we want to allow the policy to output setpoints that are outside the kinematic
   limits of the joint.
+
+  ``actuator_name`` defaults to ``joint_name``; pass a distinct value when multiple
+  actuators target the same joint (e.g. paired position+velocity elements).
   """
-  actuator = spec.add_actuator(name=joint_name, target=joint_name)
+  actuator = spec.add_actuator(
+    name=actuator_name if actuator_name is not None else joint_name,
+    target=joint_name,
+  )
 
   actuator.trntype = _TRANSMISSION_TYPE_MAP[transmission_type]
   actuator.dyntype = mujoco.mjtDyn.mjDYN_NONE
@@ -343,14 +350,21 @@ def create_velocity_actuator(
   frictionloss: float | None = None,
   viscous_damping: float | None = None,
   transmission_type: TransmissionType = TransmissionType.JOINT,
+  actuator_name: str | None = None,
 ) -> mujoco.MjsActuator:
   """Creates a <velocity> actuator.
 
   Control inputs are not clamped so that velocity commands work for any joint,
   including continuous joints that have no range defined. Force output is still
   bounded when effort_limit is set.
+
+  ``actuator_name`` defaults to ``joint_name``; pass a distinct value when multiple
+  actuators target the same joint (e.g. paired position+velocity elements).
   """
-  actuator = spec.add_actuator(name=joint_name, target=joint_name)
+  actuator = spec.add_actuator(
+    name=actuator_name if actuator_name is not None else joint_name,
+    target=joint_name,
+  )
 
   actuator.trntype = _TRANSMISSION_TYPE_MAP[transmission_type]
   actuator.dyntype = mujoco.mjtDyn.mjDYN_NONE

--- a/tests/test_builtin_pd_actuator.py
+++ b/tests/test_builtin_pd_actuator.py
@@ -1,0 +1,468 @@
+"""Tests for BuiltinPdActuator.
+
+Covers the unique surface of the actuator: paired <position>/<velocity>
+elements per target, joint/tendon-level actfrcrange sum-clamp, DR for both
+gains and effort limits, delay synchronization, and the ordering invariant
+that DR depends on.
+"""
+
+from unittest.mock import Mock
+
+import mujoco
+import pytest
+import torch
+from conftest import (
+  create_entity_with_actuator,
+  get_test_device,
+  initialize_entity,
+  load_fixture_xml,
+)
+
+from mjlab.actuator import BuiltinPdActuator, BuiltinPdActuatorCfg
+from mjlab.actuator.actuator import TransmissionType
+from mjlab.entity import Entity, EntityArticulationInfoCfg, EntityCfg
+from mjlab.envs.mdp import dr
+from mjlab.managers.scene_entity_config import SceneEntityCfg
+from mjlab.scene import Scene, SceneCfg
+from mjlab.sim.sim import Simulation, SimulationCfg
+
+ROBOT_XML = load_fixture_xml("floating_base_articulated")
+KP = 100.0
+KD = 10.0
+
+
+@pytest.fixture(scope="module")
+def device():
+  return get_test_device()
+
+
+def _make_entity(
+  *,
+  effort_limit: float | None = 50.0,
+  armature: float | None = None,
+  delay_max_lag: int = 0,
+  delay_min_lag: int = 0,
+  delay_hold_prob: float = 0.0,
+) -> Entity:
+  cfg = BuiltinPdActuatorCfg(
+    target_names_expr=("joint.*",),
+    stiffness=KP,
+    damping=KD,
+    effort_limit=effort_limit,
+    armature=armature,
+    delay_min_lag=delay_min_lag,
+    delay_max_lag=delay_max_lag,
+    delay_hold_prob=delay_hold_prob,
+  )
+  return create_entity_with_actuator(ROBOT_XML, cfg)
+
+
+def _at_rest_with_targets(
+  entity: Entity,
+  sim,
+  device: str,
+  pos_target: torch.Tensor,
+  vel_target: torch.Tensor,
+) -> None:
+  entity.write_joint_state_to_sim(
+    position=torch.zeros(1, 2, device=device),
+    velocity=torch.zeros(1, 2, device=device),
+  )
+  entity.set_joint_position_target(pos_target)
+  entity.set_joint_velocity_target(vel_target)
+  entity.set_joint_effort_target(torch.zeros(1, 2, device=device))
+  entity.write_data_to_sim()
+  sim.forward()
+
+
+# ---------------------------------------------------------------------------
+# Structural invariants
+# ---------------------------------------------------------------------------
+
+
+def test_two_ctrls_per_target_with_pos_then_vel_layout(device):
+  """Each target gets one <position> + one <velocity>, in halves."""
+  entity, sim = initialize_entity(_make_entity(), device)
+  act = entity.actuators[0]
+  assert isinstance(act, BuiltinPdActuator)
+
+  n = act.num_targets
+  assert n == len(act.target_names) == 2
+  assert len(act.ctrl_ids) == 2 * n
+  assert len(act.global_ctrl_ids) == 2 * n
+
+  names = [sim.mj_model.actuator(i).name for i in act.global_ctrl_ids.tolist()]
+  assert names[:n] == [f"{name}_pd_pos" for name in act.target_names]
+  assert names[n:] == [f"{name}_pd_vel" for name in act.target_names]
+
+
+def test_site_transmission_rejected():
+  with pytest.raises(ValueError, match="SITE"):
+    BuiltinPdActuatorCfg(
+      target_names_expr=("x",),
+      stiffness=1.0,
+      damping=1.0,
+      transmission_type=TransmissionType.SITE,
+    )
+
+
+def test_armature_applied_once(device):
+  """Joint armature must come from the position element only; double-applying
+  would silently double dof_armature."""
+  _, sim = initialize_entity(_make_entity(armature=0.7), device)
+  m = sim.mj_model
+  for jname in ("joint1", "joint2"):
+    dof_id = m.jnt_dofadr[m.joint(jname).id]
+    assert m.dof_armature[dof_id] == pytest.approx(0.7)
+
+
+# ---------------------------------------------------------------------------
+# Force computation
+# ---------------------------------------------------------------------------
+
+
+def test_position_only(device):
+  """Zero vel target: qfrc = kp * pos_target."""
+  entity, sim = initialize_entity(_make_entity(effort_limit=None), device)
+  pos = torch.tensor([[0.1, -0.05]], device=device)
+  _at_rest_with_targets(entity, sim, device, pos, torch.zeros(1, 2, device=device))
+  v_adr = entity.indexing.joint_v_adr
+  assert torch.allclose(sim.data.qfrc_actuator[0, v_adr], KP * pos[0], atol=1e-4)
+
+
+def test_velocity_only(device):
+  """Zero pos target, joint at rest: qfrc = kd * vel_target."""
+  entity, sim = initialize_entity(_make_entity(effort_limit=None), device)
+  vel = torch.tensor([[0.3, -0.2]], device=device)
+  _at_rest_with_targets(entity, sim, device, torch.zeros(1, 2, device=device), vel)
+  v_adr = entity.indexing.joint_v_adr
+  assert torch.allclose(sim.data.qfrc_actuator[0, v_adr], KD * vel[0], atol=1e-4)
+
+
+def test_pd_superposition(device):
+  """Both targets nonzero: qfrc = kp * pos_target + kd * vel_target."""
+  entity, sim = initialize_entity(_make_entity(effort_limit=None), device)
+  pos = torch.tensor([[0.1, -0.05]], device=device)
+  vel = torch.tensor([[0.2, -0.1]], device=device)
+  _at_rest_with_targets(entity, sim, device, pos, vel)
+  v_adr = entity.indexing.joint_v_adr
+  expected = KP * pos[0] + KD * vel[0]
+  assert torch.allclose(sim.data.qfrc_actuator[0, v_adr], expected, atol=1e-4)
+
+
+def test_actfrcrange_sum_clamp(device):
+  """A pos error big enough to make kp*err exceed effort_limit must be
+  clamped at the joint, not allowed to ride through the unbounded element."""
+  entity, sim = initialize_entity(_make_entity(effort_limit=5.0), device)
+  # kp * 10.0 = 1000, well over the 5.0 clamp.
+  pos = torch.tensor([[10.0, 0.0]], device=device)
+  _at_rest_with_targets(entity, sim, device, pos, torch.zeros(1, 2, device=device))
+  v_adr = entity.indexing.joint_v_adr
+  qfrc = sim.data.qfrc_actuator[0, v_adr]
+  assert qfrc[0].item() == pytest.approx(5.0, abs=1e-4)
+  assert qfrc[1].item() == pytest.approx(0.0, abs=1e-4)
+
+
+def test_effort_limit_none_leaves_joint_unlimited(device):
+  """effort_limit=None: jnt_actfrclimited stays 0 on the targeted joints."""
+  _, sim = initialize_entity(_make_entity(effort_limit=None), device)
+  m = sim.mj_model
+  for jname in ("joint1", "joint2"):
+    jid = m.joint(jname).id
+    assert m.jnt_actfrclimited[jid] == 0
+
+
+def test_actuator_forcerange_not_set(device):
+  """We deliberately leave per-element forcerange unset; the limit lives on
+  the joint. Inspection of actuator_force[i] thus shows the unclamped value."""
+  entity, sim = initialize_entity(_make_entity(effort_limit=5.0), device)
+  m = sim.mj_model
+  for ctrl_id in entity.actuators[0].global_ctrl_ids.tolist():
+    assert m.actuator_forcelimited[ctrl_id] == 0
+
+
+# ---------------------------------------------------------------------------
+# Delay synchronization
+# ---------------------------------------------------------------------------
+
+
+def test_delay_syncs_pos_and_vel(device):
+  """The shared delay buffer must lag pos and vel together."""
+  entity, sim = initialize_entity(
+    _make_entity(effort_limit=None, delay_min_lag=2, delay_max_lag=2),
+    device,
+  )
+  pos_targets = [
+    torch.tensor([[0.1, 0.0]], device=device),
+    torch.tensor([[0.3, 0.0]], device=device),
+    torch.tensor([[0.5, 0.0]], device=device),
+  ]
+  vel_targets = [
+    torch.tensor([[1.0, 0.0]], device=device),
+    torch.tensor([[2.0, 0.0]], device=device),
+    torch.tensor([[3.0, 0.0]], device=device),
+  ]
+  entity.write_joint_state_to_sim(
+    position=torch.zeros(1, 2, device=device),
+    velocity=torch.zeros(1, 2, device=device),
+  )
+  for p, v in zip(pos_targets, vel_targets, strict=True):
+    entity.set_joint_position_target(p)
+    entity.set_joint_velocity_target(v)
+    entity.set_joint_effort_target(torch.zeros(1, 2, device=device))
+    entity.write_data_to_sim()
+    sim.forward()
+
+  v_adr = entity.indexing.joint_v_adr
+  # With lag=2, both halves should reference step-0 values.
+  expected = KP * pos_targets[0][0] + KD * vel_targets[0][0]
+  assert torch.allclose(sim.data.qfrc_actuator[0, v_adr], expected, atol=1e-4)
+
+
+def test_reset_clears_delay_buffer(device):
+  entity, _ = initialize_entity(_make_entity(delay_min_lag=1, delay_max_lag=3), device)
+  act = entity.actuators[0]
+  assert act._delay_buffer is not None
+  entity.set_joint_position_target(torch.full((1, 2), 0.5, device=device))
+  entity.set_joint_velocity_target(torch.zeros(1, 2, device=device))
+  entity.write_data_to_sim()
+
+  entity.reset(torch.tensor([0], device=device))
+  assert act._delay_buffer.current_lags[0] == 0
+
+
+# ---------------------------------------------------------------------------
+# Domain randomization
+# ---------------------------------------------------------------------------
+
+
+def _scene_env(device, transmission=TransmissionType.JOINT, num_envs=2):
+  """Build a real scene/sim with one BuiltinPd-driven entity for DR tests."""
+  if transmission == TransmissionType.JOINT:
+    xml = ROBOT_XML
+    targets = ("joint.*",)
+  else:
+    xml = load_fixture_xml("tendon_finger")
+    # tendon_finger ships with motor/position/velocity actuators; we need a
+    # bare spec so BuiltinPd can attach to the tendon without name clashes.
+    targets = ("finger_tendon",)
+
+  def spec_fn():
+    spec = mujoco.MjSpec.from_string(xml)
+    # Strip any pre-existing actuators so BuiltinPd's added elements own ctrl.
+    for a in list(spec.actuators):
+      spec.delete(a)
+    return spec
+
+  entity_cfg = EntityCfg(
+    spec_fn=spec_fn,
+    articulation=EntityArticulationInfoCfg(
+      actuators=(
+        BuiltinPdActuatorCfg(
+          target_names_expr=targets,
+          stiffness=KP,
+          damping=KD,
+          effort_limit=50.0,
+          transmission_type=transmission,
+        ),
+      )
+    ),
+  )
+  scene_cfg = SceneCfg(num_envs=num_envs, entities={"robot": entity_cfg})
+  scene = Scene(scene_cfg, device)
+  model = scene.compile()
+  sim = Simulation(num_envs=num_envs, cfg=SimulationCfg(), model=model, device=device)
+  scene.initialize(model, sim.model, sim.data)
+
+  env = Mock()
+  env.num_envs = num_envs
+  env.device = device
+  env.scene = {"robot": scene["robot"]}
+  env.sim = sim
+  return env
+
+
+def test_dr_pd_gains_scales_halves_independently(device):
+  env = _scene_env(device)
+  robot = env.scene["robot"]
+  act = robot.actuators[0]
+  assert isinstance(act, BuiltinPdActuator)
+  n = act.num_targets
+  pos_ids = act.global_ctrl_ids[:n]
+  vel_ids = act.global_ctrl_ids[n:]
+
+  # Expand fields so DR can write per-env.
+  env.sim.expand_model_fields(("actuator_gainprm", "actuator_biasprm"))
+
+  dr.pd_gains(
+    env,
+    env_ids=torch.tensor([0], device=device),
+    kp_range=(2.0, 2.0),
+    kd_range=(3.0, 3.0),
+    asset_cfg=SceneEntityCfg("robot"),
+    operation="scale",
+  )
+
+  m = env.sim.model
+  # Position half: gainprm[0] and biasprm[1] both scaled by kp=2, biasprm[2]
+  # must stay zero (no kd injection).
+  assert torch.allclose(
+    m.actuator_gainprm[0, pos_ids, 0],
+    torch.full((n,), 2.0 * KP, device=device),
+  )
+  assert torch.allclose(
+    m.actuator_biasprm[0, pos_ids, 1],
+    torch.full((n,), -2.0 * KP, device=device),
+  )
+  assert torch.allclose(
+    m.actuator_biasprm[0, pos_ids, 2], torch.zeros(n, device=device)
+  )
+  # Velocity half: gainprm[0] and biasprm[2] both scaled by kd=3, biasprm[1]
+  # stays zero (no kp injection).
+  assert torch.allclose(
+    m.actuator_gainprm[0, vel_ids, 0],
+    torch.full((n,), 3.0 * KD, device=device),
+  )
+  assert torch.allclose(
+    m.actuator_biasprm[0, vel_ids, 2],
+    torch.full((n,), -3.0 * KD, device=device),
+  )
+  assert torch.allclose(
+    m.actuator_biasprm[0, vel_ids, 1], torch.zeros(n, device=device)
+  )
+  # The other env must be untouched.
+  assert torch.allclose(m.actuator_gainprm[1, pos_ids, 0], torch.tensor(KP))
+  assert torch.allclose(m.actuator_gainprm[1, vel_ids, 0], torch.tensor(KD))
+
+
+def test_dr_pd_gains_abs_writes_correct_columns(device):
+  env = _scene_env(device)
+  robot = env.scene["robot"]
+  act = robot.actuators[0]
+  assert isinstance(act, BuiltinPdActuator)
+  n = act.num_targets
+  pos_ids = act.global_ctrl_ids[:n]
+  vel_ids = act.global_ctrl_ids[n:]
+  env.sim.expand_model_fields(("actuator_gainprm", "actuator_biasprm"))
+
+  dr.pd_gains(
+    env,
+    env_ids=torch.tensor([0, 1], device=device),
+    kp_range=(200.0, 200.0),
+    kd_range=(25.0, 25.0),
+    asset_cfg=SceneEntityCfg("robot"),
+    operation="abs",
+  )
+
+  m = env.sim.model
+  assert torch.allclose(
+    m.actuator_gainprm[:, pos_ids, 0],
+    torch.full((env.num_envs, n), 200.0, device=device),
+  )
+  assert torch.allclose(
+    m.actuator_biasprm[:, pos_ids, 1],
+    torch.full((env.num_envs, n), -200.0, device=device),
+  )
+  assert torch.allclose(
+    m.actuator_biasprm[:, pos_ids, 2],
+    torch.zeros(env.num_envs, n, device=device),
+  )
+  assert torch.allclose(
+    m.actuator_gainprm[:, vel_ids, 0],
+    torch.full((env.num_envs, n), 25.0, device=device),
+  )
+  assert torch.allclose(
+    m.actuator_biasprm[:, vel_ids, 2],
+    torch.full((env.num_envs, n), -25.0, device=device),
+  )
+
+
+def test_dr_effort_limits_writes_jnt_actfrcrange(device):
+  env = _scene_env(device, transmission=TransmissionType.JOINT)
+  robot = env.scene["robot"]
+  act = robot.actuators[0]
+  assert isinstance(act, BuiltinPdActuator)
+  env.sim.expand_model_fields(
+    ("actuator_forcerange", "jnt_actfrcrange", "tendon_actfrcrange")
+  )
+
+  joint_ids = robot.indexing.joint_ids[act.target_ids]
+  pre_forcerange = env.sim.model.actuator_forcerange.clone()
+
+  dr.effort_limits(
+    env,
+    env_ids=torch.tensor([0], device=device),
+    effort_limit_range=(123.0, 123.0),
+    asset_cfg=SceneEntityCfg("robot"),
+    operation="abs",
+  )
+
+  m = env.sim.model
+  # The joint sum-clamp was rewritten on env 0 only.
+  assert torch.allclose(
+    m.jnt_actfrcrange[0, joint_ids],
+    torch.tensor([[-123.0, 123.0]] * len(joint_ids), device=device),
+  )
+  assert torch.allclose(
+    m.jnt_actfrcrange[1, joint_ids],
+    torch.tensor([[-50.0, 50.0]] * len(joint_ids), device=device),
+  )
+  # Per-element actuator_forcerange must be untouched for BuiltinPd: that
+  # field belongs to the existing single-element actuator semantic.
+  assert torch.allclose(m.actuator_forcerange, pre_forcerange)
+
+
+def test_dr_effort_limits_scale_multiplies_default(device):
+  """``scale`` multiplies the configured ``effort_limit`` (50.0) by the sample."""
+  env = _scene_env(device, transmission=TransmissionType.JOINT)
+  robot = env.scene["robot"]
+  act = robot.actuators[0]
+  assert isinstance(act, BuiltinPdActuator)
+  env.sim.expand_model_fields(
+    ("actuator_forcerange", "jnt_actfrcrange", "tendon_actfrcrange")
+  )
+  joint_ids = robot.indexing.joint_ids[act.target_ids]
+
+  dr.effort_limits(
+    env,
+    env_ids=torch.tensor([0], device=device),
+    effort_limit_range=(2.0, 2.0),
+    asset_cfg=SceneEntityCfg("robot"),
+    operation="scale",
+  )
+
+  m = env.sim.model
+  # Default is [-50, 50], scaled by 2 -> [-100, 100].
+  assert torch.allclose(
+    m.jnt_actfrcrange[0, joint_ids],
+    torch.tensor([[-100.0, 100.0]] * len(joint_ids), device=device),
+  )
+
+
+def test_dr_effort_limits_writes_tendon_actfrcrange(device):
+  env = _scene_env(device, transmission=TransmissionType.TENDON)
+  robot = env.scene["robot"]
+  act = robot.actuators[0]
+  assert isinstance(act, BuiltinPdActuator)
+  env.sim.expand_model_fields(
+    ("actuator_forcerange", "jnt_actfrcrange", "tendon_actfrcrange")
+  )
+  tendon_ids = robot.indexing.tendon_ids[act.target_ids]
+
+  dr.effort_limits(
+    env,
+    env_ids=torch.tensor([0], device=device),
+    effort_limit_range=(77.0, 77.0),
+    asset_cfg=SceneEntityCfg("robot"),
+    operation="abs",
+  )
+
+  m = env.sim.model
+  assert torch.allclose(
+    m.tendon_actfrcrange[0, tendon_ids],
+    torch.tensor([[-77.0, 77.0]] * len(tendon_ids), device=device),
+  )
+  assert torch.allclose(
+    m.tendon_actfrcrange[1, tendon_ids],
+    torch.tensor([[-50.0, 50.0]] * len(tendon_ids), device=device),
+  )

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -125,7 +125,9 @@ def test_dr_fields_registered_in_event_manager(device):
   assert "actuator_gainprm" in manager.domain_randomization_fields
   assert "actuator_biasprm" in manager.domain_randomization_fields
   assert "actuator_forcerange" in manager.domain_randomization_fields
-  assert len(manager.domain_randomization_fields) == 5
+  assert "jnt_actfrcrange" in manager.domain_randomization_fields
+  assert "tendon_actfrcrange" in manager.domain_randomization_fields
+  assert len(manager.domain_randomization_fields) == 7
 
 
 def test_recompute_level_ordering():


### PR DESCRIPTION
Adds `BuiltinPdActuator`: the implicit-integration counterpart to `IdealPdActuator`. Same interface (position + velocity targets, kp/kd), but the PD is expressed as native MuJoCo `<position>` and `<velocity>` elements instead of a Python-computed force on a `<motor>`. The `implicit` / `implicitfast` integrators then include the kp/kd derivatives in their velocity update, so the actuator stays stable at gain/timestep combinations where explicit Python PD would diverge. Useful when you want to run a real motor's stiff on-board PD gains in sim.

`effort_limit` is a sum-clamp on `kp*err + kd*verr` via `jnt_actuatorfrcrange` (or `tendon_actuatorfrcrange`), matching the single torque limit a real motor controller has. `dr.pd_gains` and `dr.effort_limits` both branch on the new actuator.
