### PR TITLE
Add BuiltinDcMotorActuator: native MuJoCo <dcmotor> wrapper

### DIFF
--- a/docs/source/actuators.rst
+++ b/docs/source/actuators.rst
@@ -61,6 +61,7 @@ MuJoCo's integrator handles velocity-dependent forces.
 
 **Built-in actuators** (``BuiltinPositionActuator``,
 ``BuiltinVelocityActuator``, ``BuiltinMotorActuator``,
+``BuiltinPdActuator``, ``BuiltinDcMotorActuator``,
 ``BuiltinMuscleActuator``) create native MuJoCo actuator elements in the
 MjSpec. The physics engine computes the control law and integrates
 velocity-dependent damping forces implicitly. This provides the best
@@ -118,6 +119,31 @@ control.
 
 **BuiltinMotorActuator**: Creates ``<motor>`` actuators for direct torque
 control.
+
+**BuiltinPdActuator**: Native PD that closes on both a position and a
+velocity target, implemented as paired ``<position>`` + ``<velocity>``
+actuators summing to ``kp * (p_target - q) + kd * (v_target - qdot)``.
+``BuiltinPositionActuator`` puts kd on the ``<position>`` element and
+implicitly assumes a zero velocity reference; use this when the policy
+emits a non-zero velocity target. Native delivery lets
+``implicit`` / ``implicitfast`` see the kd term in their velocity update,
+unlike ``IdealPdActuator`` which forwards Python-computed torque through
+an opaque ``<motor>``.
+
+**BuiltinDcMotorActuator**: Wraps MuJoCo's native
+`<dcmotor> <https://mujoco.readthedocs.io/en/stable/XMLreference.html#actuator-dcmotor>`_
+element. Torque is ``tau = K * (V - K * omega) / R``; the back-EMF runs
+through the native bias path, so ``implicit`` / ``implicitfast`` pick up
+its velocity derivative as effective damping. Three input modes pick what
+``ctrl`` carries: VOLTAGE drives the motor directly; POSITION / VELOCITY
+close an internal PID (with anti-windup and slew limiting) against a
+single setpoint, whose Vmax-clamped output becomes torque. POSITION mode
+pins v_target = 0 (the kd term acts on raw velocity). Optional physics:
+inductance,
+thermal model with I^2R heating, cogging ripple, LuGre friction.
+``DcMotorActuator`` (the explicit version) is a software PD with a
+velocity-dependent torque clamp on top of a ``<motor>``; this is the real
+electrical model.
 
 **BuiltinMuscleActuator**: Creates ``<muscle>`` actuators for
 biologically-inspired muscle dynamics with force-length-velocity

--- a/docs/source/api/actuator.rst
+++ b/docs/source/api/actuator.rst
@@ -18,6 +18,13 @@ mjlab.actuator
   - :class:`BuiltinPositionActuatorCfg`
   - :class:`BuiltinVelocityActuator`
   - :class:`BuiltinVelocityActuatorCfg`
+  - :class:`BuiltinPdActuator`
+  - :class:`BuiltinPdActuatorCfg`
+  - :class:`BuiltinDcMotorActuator`
+  - :class:`BuiltinDcMotorActuatorCfg`
+  - :class:`DcMotorInputMode`
+  - :class:`DcMotorDatasheetParams`
+  - :class:`DcMotorPhysicalParams`
   - :class:`BuiltinMuscleActuator`
   - :class:`BuiltinMuscleActuatorCfg`
   - :class:`XmlActuator`
@@ -79,6 +86,40 @@ Builtin Actuators
   :show-inheritance:
 
 .. autoclass:: BuiltinVelocityActuatorCfg
+  :members:
+  :exclude-members: __init__
+  :undoc-members:
+
+
+.. autoclass:: BuiltinPdActuator
+  :members:
+  :show-inheritance:
+
+.. autoclass:: BuiltinPdActuatorCfg
+  :members:
+  :exclude-members: __init__
+  :undoc-members:
+
+
+.. autoclass:: BuiltinDcMotorActuator
+  :members:
+  :show-inheritance:
+
+.. autoclass:: BuiltinDcMotorActuatorCfg
+  :members:
+  :exclude-members: __init__
+  :undoc-members:
+
+.. autoclass:: DcMotorInputMode
+  :members:
+  :show-inheritance:
+
+.. autoclass:: DcMotorDatasheetParams
+  :members:
+  :exclude-members: __init__
+  :undoc-members:
+
+.. autoclass:: DcMotorPhysicalParams
   :members:
   :exclude-members: __init__
   :undoc-members:

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -2,6 +2,17 @@
 Changelog
 =========
 
+Upcoming version (not yet released)
+-----------------------------------
+
+Added
+^^^^^
+
+- Added ``BuiltinDcMotorActuator``, a native MuJoCo ``<dcmotor>`` wrapper.
+  Supports voltage / position / velocity input modes with back-EMF,
+  configurable motor constants, and optional integral, slew, inductance,
+  thermal, LuGre, and cogging extensions.
+
 Version 1.4.0 (May 26, 2026)
 ----------------------------
 

--- a/src/mjlab/actuator/__init__.py
+++ b/src/mjlab/actuator/__init__.py
@@ -5,6 +5,12 @@ from mjlab.actuator.actuator import ActuatorCfg as ActuatorCfg
 from mjlab.actuator.actuator import ActuatorCmd as ActuatorCmd
 from mjlab.actuator.actuator import CommandField as CommandField
 from mjlab.actuator.builtin_actuator import (
+  BuiltinDcMotorActuator as BuiltinDcMotorActuator,
+)
+from mjlab.actuator.builtin_actuator import (
+  BuiltinDcMotorActuatorCfg as BuiltinDcMotorActuatorCfg,
+)
+from mjlab.actuator.builtin_actuator import (
   BuiltinMotorActuator as BuiltinMotorActuator,
 )
 from mjlab.actuator.builtin_actuator import (

--- a/src/mjlab/actuator/__init__.py
+++ b/src/mjlab/actuator/__init__.py
@@ -40,6 +40,15 @@ from mjlab.actuator.builtin_actuator import (
 from mjlab.actuator.builtin_actuator import (
   BuiltinVelocityActuatorCfg as BuiltinVelocityActuatorCfg,
 )
+from mjlab.actuator.builtin_actuator import (
+  DcMotorDatasheetParams as DcMotorDatasheetParams,
+)
+from mjlab.actuator.builtin_actuator import (
+  DcMotorInputMode as DcMotorInputMode,
+)
+from mjlab.actuator.builtin_actuator import (
+  DcMotorPhysicalParams as DcMotorPhysicalParams,
+)
 from mjlab.actuator.builtin_group import BuiltinActuatorGroup as BuiltinActuatorGroup
 from mjlab.actuator.dc_actuator import DcMotorActuator as DcMotorActuator
 from mjlab.actuator.dc_actuator import DcMotorActuatorCfg as DcMotorActuatorCfg

--- a/src/mjlab/actuator/builtin_actuator.py
+++ b/src/mjlab/actuator/builtin_actuator.py
@@ -7,7 +7,8 @@ created programmatically via the MjSpec API.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Literal
+from enum import IntEnum
+from typing import TYPE_CHECKING
 
 import mujoco
 import numpy as np
@@ -95,17 +96,17 @@ class BuiltinPositionActuator(Actuator[BuiltinPositionActuatorCfg]):
 
 @dataclass(kw_only=True)
 class BuiltinPdActuatorCfg(ActuatorCfg):
-  """Implicit-integration version of ``IdealPdActuator``.
+  """Implicit-integration version of IdealPdActuator.
 
-  Both consume a position target and a velocity target with kp/kd gains.
-  The difference is in how the PD is delivered to MuJoCo: ``IdealPdActuator`` computes
-  the PD force in Python and feeds it to a ``<motor>`` element, which MuJoCo sees as an
-  opaque external force. This actuator expresses the PD as native MuJoCo elements (a
-  ``<position>`` carrying kp, a ``<velocity>`` carrying kd), so the ``implicit`` and
-  ``implicitfast`` integrators include the kp/kd derivatives in their velocity update.
-  That makes the actuator numerically stable at gain/timestep combinations where
-  explicit Python PD would diverge, which matters when you want to run a real motor's
-  stiff on-board PD gains in sim.
+  Both consume a position target and a velocity target with kp/kd gains. The
+  difference is in how the PD is delivered to MuJoCo: IdealPdActuator computes
+  the PD force in Python and feeds it to a ``<motor>`` element, which MuJoCo
+  sees as an opaque external force. This actuator expresses the PD as native
+  MuJoCo elements (a ``<position>`` carrying kp, a ``<velocity>`` carrying kd),
+  so the implicit and implicitfast integrators include the kp/kd derivatives
+  in their velocity update. That makes the actuator numerically stable at
+  gain/timestep combinations where explicit Python PD would diverge, which
+  matters when you want to run a real motor's stiff on-board PD gains in sim.
   """
 
   stiffness: float
@@ -240,131 +241,151 @@ class BuiltinMotorActuator(Actuator[BuiltinMotorActuatorCfg]):
     return cmd.effort_target
 
 
-DcMotorInputMode = Literal["voltage", "position", "velocity"]
-# Values match MuJoCo's <dcmotor input=...> enum, consumed by mjs_setToDCMotor
-# and read as gainprm[8] (see mujoco/src/xml/xml_native_reader.cc dcmotorinput_map).
-_DCMOTOR_INPUT_MODE: dict[DcMotorInputMode, int] = {
-  "voltage": 0,
-  "position": 1,
-  "velocity": 2,
-}
+def _or_zeros(t: tuple[float, ...] | None, n: int) -> list[float]:
+  return list(t) if t is not None else [0.0] * n
+
+
+class DcMotorInputMode(IntEnum):
+  """What the ``ctrl`` signal of a ``<dcmotor>`` represents.
+
+  Values match MuJoCo's enum, consumed by mjs_setToDCMotor and read as gainprm[8].
+  """
+
+  VOLTAGE = 0
+  POSITION = 1
+  VELOCITY = 2
+
+
+@dataclass(frozen=True)
+class DcMotorDatasheetParams:
+  """Datasheet characterization of a DC motor."""
+
+  nominal_voltage: float
+  """Nominal (rated) voltage V_n [V]."""
+  stall_torque: float
+  """Stall torque tau_stall at V_n [N*m]."""
+  no_load_speed: float
+  """No-load angular velocity omega_no_load at V_n [rad/s]."""
+
+  def _pack(self) -> tuple[list[float], float, list[float]]:
+    """Returns (motorconst, resistance, nominal) for set_to_dcmotor."""
+    return (
+      [0.0, 0.0],
+      0.0,
+      [self.nominal_voltage, self.stall_torque, self.no_load_speed],
+    )
+
+
+@dataclass(frozen=True)
+class DcMotorPhysicalParams:
+  """Physical characterization of a DC motor."""
+
+  kt: float
+  """Torque constant [N*m/A]."""
+  ke: float
+  """Back-EMF constant [V*s/rad]."""
+  resistance: float
+  """Terminal resistance R [Ohm]."""
+
+  def _pack(self) -> tuple[list[float], float, list[float]]:
+    """Returns (motorconst, resistance, nominal) for set_to_dcmotor."""
+    return [self.kt, self.ke], self.resistance, [0.0, 0.0, 0.0]
 
 
 @dataclass(kw_only=True)
 class BuiltinDcMotorActuatorCfg(ActuatorCfg):
   """Native MuJoCo ``<dcmotor>`` wrapper.
 
-  Models a DC motor: torque is derived from voltage via the motor constant
-  ``K`` and back-EMF, ``tau = K * (V - K * omega) / R``. The back-EMF term
-  lives in ``biasprm``, so MuJoCo's ``implicit`` / ``implicitfast``
-  integrators pick up its velocity derivative as effective damping.
+  Models a DC motor: torque is derived from voltage via the motor constant K and
+  back-EMF, tau = K * (V - K * omega) / R. The back-EMF term lives in biasprm, so
+  MuJoCo's implicit / implicitfast integrators pick up its velocity derivative as
+  effective damping.
 
-  Three input modes select what ``ctrl`` carries:
+  Three input modes select what ctrl carries:
 
-  * "voltage": ``ctrl`` is the drive voltage. ``cmd.effort_target`` carries
-    volts, not torque.
-  * "position" / "velocity": an internal PID closes on the setpoint and
-    the motor produces torque from its (Vmax-clamped) voltage output.
+  * VOLTAGE: ctrl is the drive voltage. cmd.effort_target carries volts, not torque.
+  * POSITION / VELOCITY: an internal PID closes on the setpoint and the motor produces
+    torque from its (Vmax-clamped) voltage output.
 
-  Motor characterization: specify exactly one of
+  Motor characterization: pass either DcMotorDatasheetParams or DcMotorPhysicalParams
+  as motor_params. mjs_setToDCMotor derives K and R (including the viscous-damping
+  correction) and packs the generic gainprm / biasprm / dynprm slots.
 
-  * ``nominal=(V_n, tau_stall, omega_no_load)``: datasheet form.
-  * ``motor_const=(Kt, Ke)`` + ``resistance=R``: physical form.
+  Optional extensions, off by default: integral_gain / integral_limit, slew_rate,
+  inductance / electrical_time_constant, thermal, lugre, cogging.
 
-  ``mjs_setToDCMotor`` derives ``K`` and ``R`` (including the viscous-damping
-  correction) and packs the generic ``gainprm`` / ``biasprm`` / ``dynprm``
-  slots.
-
-  Optional extensions, off by default: ``integral_gain`` / ``integral_limit``,
-  ``slew_rate``, ``inductance`` / ``electrical_time_constant``, ``thermal``,
-  ``lugre``, ``cogging``. ``dr.pd_gains`` randomizes only kp and kd; for DR
-  over the extensions, write directly to ``actuator_gainprm`` /
-  ``actuator_dynprm``.
-
-  Different from ``DcMotorActuator``: that class is a software PD with a
-  velocity-dependent torque clamp on top of a ``<motor>`` element; this one
-  is the real motor model with back-EMF and an optional native PID.
+  dr.pd_gains randomizes only kp and kd; for DR over the extensions, write directly to
+  actuator_gainprm or actuator_dynprm.
   """
 
-  mode: DcMotorInputMode = "position"
-  """``ctrl`` input semantics. See class docstring."""
+  motor_params: DcMotorDatasheetParams | DcMotorPhysicalParams
+  """Motor characterization. Datasheet form: (V_n, tau_stall, omega_no_load).
+  Physical form: (Kt, Ke, R)."""
 
-  nominal: tuple[float, float, float] | None = None
-  """Datasheet characterization: ``(nominal_voltage, stall_torque,
-  no_load_speed)``. Provide this XOR ``motor_const`` + ``resistance``."""
-
-  motor_const: tuple[float, float] | None = None
-  """Physical characterization: ``(Kt, Ke)`` (torque and back-EMF constants).
-  Provide this and ``resistance`` XOR ``nominal``."""
-
-  resistance: float | None = None
-  """Terminal resistance R [Ohm]. Required when using ``motor_const``."""
+  mode: DcMotorInputMode = DcMotorInputMode.POSITION
+  """ctrl input semantics. See class docstring."""
 
   stiffness: float = 0.0
-  """PID proportional gain ``kp``. Required when ``mode`` is "position" /
-  "velocity". Must be 0 in "voltage" mode."""
+  """PID proportional gain kp. Required in POSITION / VELOCITY mode; must be
+  0 in VOLTAGE mode."""
 
   damping: float = 0.0
-  """PID derivative gain ``kd``. Used when ``mode`` is "position" /
-  "velocity". Must be 0 in "voltage" mode."""
+  """PID derivative gain kd. Used in POSITION / VELOCITY mode; must be 0 in
+  VOLTAGE mode."""
 
   voltage_limit: float = 0.0
-  """Max drive voltage ``Vmax``. Required when ``mode`` is "position" /
-  "velocity" (clamps the PID output). In "voltage" mode it is an
-  optional clamp on the user's ``ctrl``; 0 disables clamping."""
+  """Max drive voltage Vmax. Required in POSITION / VELOCITY mode (clamps the
+  PID output). In VOLTAGE mode it is an optional clamp on ctrl; 0 disables."""
+
+  integral_gain: float = 0.0
+  """PID integral gain ki. In position mode the integrator tracks
+  ki * integral(target - q); in velocity mode, ki * (integral(target) - q).
+  Must be 0 in VOLTAGE mode."""
+
+  integral_limit: float = 0.0
+  """Anti-windup clamp Imax on the integrator state. 0 disables (the
+  integrator can run away)."""
+
+  slew_rate: float = 0.0
+  """Max rate of change of ctrl per second. 0 disables."""
 
   effort_limit: float | None = None
-  """Continuous torque cap [N*m]. Sets ``actuator_forcerange``. None leaves
-  the per-element forcerange unset."""
+  """Continuous torque cap [N*m]. Sets actuator_forcerange. None leaves the
+  per-element forcerange unset."""
 
   gear: float = 1.0
   """Mechanical gear ratio."""
 
-  cogging: tuple[float, float, float] | None = None
-  """Cogging torque ``(amplitude, periodicity, phase)`` in
-  ``(N*m, cycles per unit length, rad)``. Models magnetic torque ripple
-  from rotor-stator interaction; at joint angle ``q`` the contribution is
-  ``amplitude * sin(periodicity * q + phase)``.
-
-  Cogging is added *after* ``effort_limit`` is enforced, matching MuJoCo's
-  physical model: ``effort_limit`` bounds the electromagnetic torque (the
-  current limit), not the mechanical torque. Total joint torque can exceed
-  ``effort_limit`` by up to ``amplitude``. None disables cogging."""
-
-  integral_gain: float = 0.0
-  """PID integral gain ``ki``. In position mode the integrator tracks
-  ``ki * integral(target - q)``; in velocity mode it tracks
-  ``ki * (integral(target) - q)`` (integral of velocity error w.r.t. time).
-  Must be 0 in voltage mode."""
-
-  integral_limit: float = 0.0
-  """Anti-windup clamp ``Imax`` on the integrator state. ``0`` disables
-  clamping (the integrator can run away)."""
-
-  slew_rate: float = 0.0
-  """Maximum rate of change of ``ctrl`` per second. Rate-limits step
-  inputs; 0 disables."""
-
   inductance: float = 0.0
-  """Winding inductance ``L`` [H]. Enables first-order electrical dynamics
-  on the motor current. Internally MuJoCo uses ``te = L / R``; pass
-  ``electrical_time_constant`` directly to skip the divide. 0 disables."""
+  """Winding inductance L [H]. Enables first-order electrical dynamics on the
+  motor current. MuJoCo internally uses te = L / R; pass
+  electrical_time_constant directly to skip the divide. 0 disables."""
 
   electrical_time_constant: float = 0.0
-  """Alternative to ``inductance``: specify ``te`` [s] directly. Ignored
-  if ``inductance > 0``. 0 disables."""
+  """Alternative to inductance: specify te [s] directly. Ignored if
+  inductance > 0. 0 disables."""
 
   thermal: tuple[float, float, float, float, float, float] | None = None
-  """Thermal model: ``(R_thermal, C_thermal, tau_thermal, alpha, T0, T_ambient)``.
-  See MuJoCo's ``<dcmotor thermal=...>`` reference for units and which
-  of the first three may be underspecified. Effective resistance becomes
-  ``R * (1 + alpha * (T + T_ambient - T0))``. None disables."""
+  """Thermal model (R_thermal, C_thermal, tau_thermal, alpha, T0, T_ambient).
+  See MuJoCo's ``<dcmotor thermal=...>`` reference for units and which of the
+  first three may be underspecified. Effective resistance becomes
+  R * (1 + alpha * (T + T_ambient - T0)). None disables."""
+
+  cogging: tuple[float, float, float] | None = None
+  """Cogging torque (amplitude, periodicity, phase) in (N*m, cycles per unit
+  length, rad). Models magnetic torque ripple from rotor-stator interaction;
+  at joint angle q the contribution is amplitude * sin(periodicity * q + phase).
+
+  Added *after* effort_limit is enforced, matching MuJoCo's physical model:
+  effort_limit bounds the electromagnetic torque (the current limit), not the
+  mechanical torque. Total joint torque can exceed effort_limit by up to
+  amplitude. None disables."""
 
   lugre: tuple[float, float, float, float, float] | None = None
-  """LuGre friction: ``(sigma0, sigma1, F_Coulomb, F_Stribeck, v_Stribeck)``.
-  Stick-slip friction model with bristle deflection state. Subtracted from
-  joint torque after the ``effort_limit`` clamp (mechanical, like cogging).
-  None disables."""
+  """LuGre friction (sigma0, sigma1, F_Coulomb, F_Stribeck, v_Stribeck).
+  Stick-slip friction with bristle-deflection state. Subtracted from joint
+  torque after the effort_limit clamp (mechanical, like cogging). None
+  disables."""
 
   def __post_init__(self) -> None:
     super().__post_init__()
@@ -374,24 +395,15 @@ class BuiltinDcMotorActuatorCfg(ActuatorCfg):
         "Use BuiltinMotorActuatorCfg for site transmission."
       )
 
-    has_nominal = self.nominal is not None
-    has_motor_const = self.motor_const is not None
-    if has_nominal == has_motor_const:
-      raise ValueError(
-        "Specify exactly one of: 'nominal', or 'motor_const' (+ 'resistance')."
-      )
-    if has_motor_const and self.resistance is None:
-      raise ValueError("'motor_const' requires 'resistance' to be set.")
-
-    if self.mode in ("position", "velocity"):
+    if self.mode in (DcMotorInputMode.POSITION, DcMotorInputMode.VELOCITY):
       if self.stiffness <= 0.0:
-        raise ValueError(f"{self.mode!r} mode requires stiffness > 0.")
+        raise ValueError(f"{self.mode.name} mode requires stiffness > 0.")
       if self.voltage_limit <= 0.0:
-        raise ValueError(f"{self.mode!r} mode requires voltage_limit > 0.")
+        raise ValueError(f"{self.mode.name} mode requires voltage_limit > 0.")
     else:
       if self.stiffness != 0.0 or self.damping != 0.0 or self.integral_gain != 0.0:
         raise ValueError(
-          "stiffness, damping, and integral_gain are unused in 'voltage' mode."
+          "stiffness, damping, and integral_gain are unused in VOLTAGE mode."
         )
 
     for name in (
@@ -414,75 +426,58 @@ class BuiltinDcMotorActuator(Actuator[BuiltinDcMotorActuatorCfg]):
   """MuJoCo native ``<dcmotor>``: one actuator per target."""
 
   def edit_spec(self, spec: mujoco.MjSpec, target_names: list[str]) -> None:
-    motorconst = (
-      list(self.cfg.motor_const) if self.cfg.motor_const is not None else [0.0, 0.0]
-    )
-    resistance = self.cfg.resistance if self.cfg.resistance is not None else 0.0
-    nominal = (
-      list(self.cfg.nominal) if self.cfg.nominal is not None else [0.0, 0.0, 0.0]
-    )
+    cfg = self.cfg
+    motorconst, resistance, nominal = cfg.motor_params._pack()
     saturation = (
-      [self.cfg.effort_limit, 0.0, 0.0]
-      if self.cfg.effort_limit is not None
-      else [0.0, 0.0, 0.0]
+      [cfg.effort_limit, 0.0, 0.0] if cfg.effort_limit is not None else [0.0] * 3
     )
     controller = [
-      self.cfg.stiffness,  # kp
-      self.cfg.integral_gain,  # ki
-      self.cfg.damping,  # kd
-      self.cfg.slew_rate,  # slewmax
-      self.cfg.integral_limit,  # Imax (anti-windup)
-      self.cfg.voltage_limit,  # v_max
+      cfg.stiffness,  # kp
+      cfg.integral_gain,  # ki
+      cfg.damping,  # kd
+      cfg.slew_rate,  # slewmax
+      cfg.integral_limit,  # Imax (anti-windup)
+      cfg.voltage_limit,  # v_max
     ]
-    cogging = (
-      list(self.cfg.cogging) if self.cfg.cogging is not None else [0.0, 0.0, 0.0]
-    )
-    inductance = [self.cfg.inductance, self.cfg.electrical_time_constant]
-    thermal = list(self.cfg.thermal) if self.cfg.thermal is not None else [0.0] * 6
-    lugre = list(self.cfg.lugre) if self.cfg.lugre is not None else [0.0] * 5
-    input_mode = _DCMOTOR_INPUT_MODE[self.cfg.mode]
-
     # SITE is rejected in __post_init__, so only JOINT and TENDON remain.
     trntype = (
       mujoco.mjtTrn.mjTRN_JOINT
-      if self.cfg.transmission_type == TransmissionType.JOINT
+      if cfg.transmission_type == TransmissionType.JOINT
       else mujoco.mjtTrn.mjTRN_TENDON
     )
 
     for target_name in target_names:
       actuator = spec.add_actuator(name=target_name, target=target_name)
       actuator.trntype = trntype
-      actuator.gear[0] = self.cfg.gear
-      # set_to_dcmotor packs gainprm/biasprm/dynprm and sets gaintype/biastype/
-      # dyntype.
+      actuator.gear[0] = cfg.gear
       actuator.set_to_dcmotor(
         motorconst=motorconst,
         resistance=resistance,
         nominal=nominal,
         saturation=saturation,
         controller=controller,
-        cogging=cogging,
-        inductance=inductance,
-        thermal=thermal,
-        lugre=lugre,
-        input_mode=input_mode,
+        cogging=_or_zeros(cfg.cogging, 3),
+        inductance=[cfg.inductance, cfg.electrical_time_constant],
+        thermal=_or_zeros(cfg.thermal, 6),
+        lugre=_or_zeros(cfg.lugre, 5),
+        input_mode=cfg.mode,
       )
 
       apply_target_overrides(
         spec,
         target_name,
-        self.cfg.transmission_type,
-        armature=self.cfg.armature,
-        frictionloss=self.cfg.frictionloss,
-        viscous_damping=self.cfg.viscous_damping,
+        cfg.transmission_type,
+        armature=cfg.armature,
+        frictionloss=cfg.frictionloss,
+        viscous_damping=cfg.viscous_damping,
       )
 
       self._mjs_actuators.append(actuator)
 
   def compute(self, cmd: ActuatorCmd) -> torch.Tensor:
-    if self.cfg.mode == "position":
+    if self.cfg.mode == DcMotorInputMode.POSITION:
       return cmd.position_target
-    if self.cfg.mode == "velocity":
+    if self.cfg.mode == DcMotorInputMode.VELOCITY:
       return cmd.velocity_target
     # voltage mode: ctrl is the drive voltage carried in effort_target.
     return cmd.effort_target

--- a/src/mjlab/actuator/builtin_actuator.py
+++ b/src/mjlab/actuator/builtin_actuator.py
@@ -7,7 +7,7 @@ created programmatically via the MjSpec API.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import mujoco
 import numpy as np
@@ -20,6 +20,7 @@ from mjlab.actuator.actuator import (
   TransmissionType,
 )
 from mjlab.utils.spec import (
+  apply_target_overrides,
   create_motor_actuator,
   create_muscle_actuator,
   create_position_actuator,
@@ -236,6 +237,254 @@ class BuiltinMotorActuator(Actuator[BuiltinMotorActuatorCfg]):
       self._mjs_actuators.append(actuator)
 
   def compute(self, cmd: ActuatorCmd) -> torch.Tensor:
+    return cmd.effort_target
+
+
+DcMotorInputMode = Literal["voltage", "position", "velocity"]
+# Values match MuJoCo's <dcmotor input=...> enum, consumed by mjs_setToDCMotor
+# and read as gainprm[8] (see mujoco/src/xml/xml_native_reader.cc dcmotorinput_map).
+_DCMOTOR_INPUT_MODE: dict[DcMotorInputMode, int] = {
+  "voltage": 0,
+  "position": 1,
+  "velocity": 2,
+}
+
+
+@dataclass(kw_only=True)
+class BuiltinDcMotorActuatorCfg(ActuatorCfg):
+  """Native MuJoCo ``<dcmotor>`` wrapper.
+
+  Models a DC motor: torque is derived from voltage via the motor constant
+  ``K`` and back-EMF, ``tau = K * (V - K * omega) / R``. The back-EMF term
+  lives in ``biasprm``, so MuJoCo's ``implicit`` / ``implicitfast``
+  integrators pick up its velocity derivative as effective damping.
+
+  Three input modes select what ``ctrl`` carries:
+
+  * "voltage": ``ctrl`` is the drive voltage. ``cmd.effort_target`` carries
+    volts, not torque.
+  * "position" / "velocity": an internal PID closes on the setpoint and
+    the motor produces torque from its (Vmax-clamped) voltage output.
+
+  Motor characterization: specify exactly one of
+
+  * ``nominal=(V_n, tau_stall, omega_no_load)``: datasheet form.
+  * ``motor_const=(Kt, Ke)`` + ``resistance=R``: physical form.
+
+  ``mjs_setToDCMotor`` derives ``K`` and ``R`` (including the viscous-damping
+  correction) and packs the generic ``gainprm`` / ``biasprm`` / ``dynprm``
+  slots.
+
+  Optional extensions, off by default: ``integral_gain`` / ``integral_limit``,
+  ``slew_rate``, ``inductance`` / ``electrical_time_constant``, ``thermal``,
+  ``lugre``, ``cogging``. ``dr.pd_gains`` randomizes only kp and kd; for DR
+  over the extensions, write directly to ``actuator_gainprm`` /
+  ``actuator_dynprm``.
+
+  Different from ``DcMotorActuator``: that class is a software PD with a
+  velocity-dependent torque clamp on top of a ``<motor>`` element; this one
+  is the real motor model with back-EMF and an optional native PID.
+  """
+
+  mode: DcMotorInputMode = "position"
+  """``ctrl`` input semantics. See class docstring."""
+
+  nominal: tuple[float, float, float] | None = None
+  """Datasheet characterization: ``(nominal_voltage, stall_torque,
+  no_load_speed)``. Provide this XOR ``motor_const`` + ``resistance``."""
+
+  motor_const: tuple[float, float] | None = None
+  """Physical characterization: ``(Kt, Ke)`` (torque and back-EMF constants).
+  Provide this and ``resistance`` XOR ``nominal``."""
+
+  resistance: float | None = None
+  """Terminal resistance R [Ohm]. Required when using ``motor_const``."""
+
+  stiffness: float = 0.0
+  """PID proportional gain ``kp``. Required when ``mode`` is "position" /
+  "velocity". Must be 0 in "voltage" mode."""
+
+  damping: float = 0.0
+  """PID derivative gain ``kd``. Used when ``mode`` is "position" /
+  "velocity". Must be 0 in "voltage" mode."""
+
+  voltage_limit: float = 0.0
+  """Max drive voltage ``Vmax``. Required when ``mode`` is "position" /
+  "velocity" (clamps the PID output). In "voltage" mode it is an
+  optional clamp on the user's ``ctrl``; 0 disables clamping."""
+
+  effort_limit: float | None = None
+  """Continuous torque cap [N*m]. Sets ``actuator_forcerange``. None leaves
+  the per-element forcerange unset."""
+
+  gear: float = 1.0
+  """Mechanical gear ratio."""
+
+  cogging: tuple[float, float, float] | None = None
+  """Cogging torque ``(amplitude, periodicity, phase)`` in
+  ``(N*m, cycles per unit length, rad)``. Models magnetic torque ripple
+  from rotor-stator interaction; at joint angle ``q`` the contribution is
+  ``amplitude * sin(periodicity * q + phase)``.
+
+  Cogging is added *after* ``effort_limit`` is enforced, matching MuJoCo's
+  physical model: ``effort_limit`` bounds the electromagnetic torque (the
+  current limit), not the mechanical torque. Total joint torque can exceed
+  ``effort_limit`` by up to ``amplitude``. None disables cogging."""
+
+  integral_gain: float = 0.0
+  """PID integral gain ``ki``. In position mode the integrator tracks
+  ``ki * integral(target - q)``; in velocity mode it tracks
+  ``ki * (integral(target) - q)`` (integral of velocity error w.r.t. time).
+  Must be 0 in voltage mode."""
+
+  integral_limit: float = 0.0
+  """Anti-windup clamp ``Imax`` on the integrator state. ``0`` disables
+  clamping (the integrator can run away)."""
+
+  slew_rate: float = 0.0
+  """Maximum rate of change of ``ctrl`` per second. Rate-limits step
+  inputs; 0 disables."""
+
+  inductance: float = 0.0
+  """Winding inductance ``L`` [H]. Enables first-order electrical dynamics
+  on the motor current. Internally MuJoCo uses ``te = L / R``; pass
+  ``electrical_time_constant`` directly to skip the divide. 0 disables."""
+
+  electrical_time_constant: float = 0.0
+  """Alternative to ``inductance``: specify ``te`` [s] directly. Ignored
+  if ``inductance > 0``. 0 disables."""
+
+  thermal: tuple[float, float, float, float, float, float] | None = None
+  """Thermal model: ``(R_thermal, C_thermal, tau_thermal, alpha, T0, T_ambient)``.
+  See MuJoCo's ``<dcmotor thermal=...>`` reference for units and which
+  of the first three may be underspecified. Effective resistance becomes
+  ``R * (1 + alpha * (T + T_ambient - T0))``. None disables."""
+
+  lugre: tuple[float, float, float, float, float] | None = None
+  """LuGre friction: ``(sigma0, sigma1, F_Coulomb, F_Stribeck, v_Stribeck)``.
+  Stick-slip friction model with bristle deflection state. Subtracted from
+  joint torque after the ``effort_limit`` clamp (mechanical, like cogging).
+  None disables."""
+
+  def __post_init__(self) -> None:
+    super().__post_init__()
+    if self.transmission_type == TransmissionType.SITE:
+      raise ValueError(
+        "BuiltinDcMotorActuatorCfg does not support SITE transmission. "
+        "Use BuiltinMotorActuatorCfg for site transmission."
+      )
+
+    has_nominal = self.nominal is not None
+    has_motor_const = self.motor_const is not None
+    if has_nominal == has_motor_const:
+      raise ValueError(
+        "Specify exactly one of: 'nominal', or 'motor_const' (+ 'resistance')."
+      )
+    if has_motor_const and self.resistance is None:
+      raise ValueError("'motor_const' requires 'resistance' to be set.")
+
+    if self.mode in ("position", "velocity"):
+      if self.stiffness <= 0.0:
+        raise ValueError(f"{self.mode!r} mode requires stiffness > 0.")
+      if self.voltage_limit <= 0.0:
+        raise ValueError(f"{self.mode!r} mode requires voltage_limit > 0.")
+    else:
+      if self.stiffness != 0.0 or self.damping != 0.0 or self.integral_gain != 0.0:
+        raise ValueError(
+          "stiffness, damping, and integral_gain are unused in 'voltage' mode."
+        )
+
+    for name in (
+      "integral_gain",
+      "integral_limit",
+      "slew_rate",
+      "inductance",
+      "electrical_time_constant",
+    ):
+      if getattr(self, name) < 0.0:
+        raise ValueError(f"{name} must be non-negative.")
+
+  def build(
+    self, entity: Entity, target_ids: list[int], target_names: list[str]
+  ) -> BuiltinDcMotorActuator:
+    return BuiltinDcMotorActuator(self, entity, target_ids, target_names)
+
+
+class BuiltinDcMotorActuator(Actuator[BuiltinDcMotorActuatorCfg]):
+  """MuJoCo native ``<dcmotor>``: one actuator per target."""
+
+  def edit_spec(self, spec: mujoco.MjSpec, target_names: list[str]) -> None:
+    motorconst = (
+      list(self.cfg.motor_const) if self.cfg.motor_const is not None else [0.0, 0.0]
+    )
+    resistance = self.cfg.resistance if self.cfg.resistance is not None else 0.0
+    nominal = (
+      list(self.cfg.nominal) if self.cfg.nominal is not None else [0.0, 0.0, 0.0]
+    )
+    saturation = (
+      [self.cfg.effort_limit, 0.0, 0.0]
+      if self.cfg.effort_limit is not None
+      else [0.0, 0.0, 0.0]
+    )
+    controller = [
+      self.cfg.stiffness,  # kp
+      self.cfg.integral_gain,  # ki
+      self.cfg.damping,  # kd
+      self.cfg.slew_rate,  # slewmax
+      self.cfg.integral_limit,  # Imax (anti-windup)
+      self.cfg.voltage_limit,  # v_max
+    ]
+    cogging = (
+      list(self.cfg.cogging) if self.cfg.cogging is not None else [0.0, 0.0, 0.0]
+    )
+    inductance = [self.cfg.inductance, self.cfg.electrical_time_constant]
+    thermal = list(self.cfg.thermal) if self.cfg.thermal is not None else [0.0] * 6
+    lugre = list(self.cfg.lugre) if self.cfg.lugre is not None else [0.0] * 5
+    input_mode = _DCMOTOR_INPUT_MODE[self.cfg.mode]
+
+    # SITE is rejected in __post_init__, so only JOINT and TENDON remain.
+    trntype = (
+      mujoco.mjtTrn.mjTRN_JOINT
+      if self.cfg.transmission_type == TransmissionType.JOINT
+      else mujoco.mjtTrn.mjTRN_TENDON
+    )
+
+    for target_name in target_names:
+      actuator = spec.add_actuator(name=target_name, target=target_name)
+      actuator.trntype = trntype
+      actuator.gear[0] = self.cfg.gear
+      # set_to_dcmotor packs gainprm/biasprm/dynprm and sets gaintype/biastype/
+      # dyntype.
+      actuator.set_to_dcmotor(
+        motorconst=motorconst,
+        resistance=resistance,
+        nominal=nominal,
+        saturation=saturation,
+        controller=controller,
+        cogging=cogging,
+        inductance=inductance,
+        thermal=thermal,
+        lugre=lugre,
+        input_mode=input_mode,
+      )
+
+      apply_target_overrides(
+        spec,
+        target_name,
+        self.cfg.transmission_type,
+        armature=self.cfg.armature,
+        frictionloss=self.cfg.frictionloss,
+        viscous_damping=self.cfg.viscous_damping,
+      )
+
+      self._mjs_actuators.append(actuator)
+
+  def compute(self, cmd: ActuatorCmd) -> torch.Tensor:
+    if self.cfg.mode == "position":
+      return cmd.position_target
+    if self.cfg.mode == "velocity":
+      return cmd.velocity_target
+    # voltage mode: ctrl is the drive voltage carried in effort_target.
     return cmd.effort_target
 
 

--- a/src/mjlab/actuator/dc_actuator.py
+++ b/src/mjlab/actuator/dc_actuator.py
@@ -33,6 +33,9 @@ class DcMotorActuatorCfg(IdealPdActuatorCfg):
   Note: effort_limit should be explicitly set to a realistic value for proper
   motor modeling. Using the default (inf) will trigger a warning. Use
   IdealPdActuator if unlimited torque is desired.
+
+  For a native MuJoCo ``<dcmotor>`` with back-EMF, voltage saturation, and
+  configurable ``Kt`` / ``Ke`` / ``R``, see ``BuiltinDcMotorActuator``.
   """
 
   saturation_effort: float

--- a/src/mjlab/envs/mdp/dr/actuator.py
+++ b/src/mjlab/envs/mdp/dr/actuator.py
@@ -13,6 +13,7 @@ from mjlab.actuator import (
   IdealPdActuator,
 )
 from mjlab.actuator.actuator import TransmissionType
+from mjlab.actuator.builtin_actuator import DcMotorInputMode
 from mjlab.actuator.xml_actuator import XmlActuator
 from mjlab.entity import Entity
 from mjlab.managers.event_manager import requires_model_fields
@@ -112,9 +113,9 @@ def pd_gains(
         env.sim.model.actuator_biasprm[env_ids[:, None], ctrl_ids, 2] = -kd_samples
 
     elif isinstance(actuator, BuiltinDcMotorActuator):
-      if actuator.cfg.mode == "voltage":
+      if actuator.cfg.mode == DcMotorInputMode.VOLTAGE:
         raise ValueError(
-          "dr.pd_gains does not apply to BuiltinDcMotorActuator in 'voltage' "
+          "dr.pd_gains does not apply to BuiltinDcMotorActuator in VOLTAGE "
           "mode (no internal PID gains to scale)."
         )
       # DC motor stores kp at gainprm[4] and kd at gainprm[6] (set via

--- a/src/mjlab/envs/mdp/dr/actuator.py
+++ b/src/mjlab/envs/mdp/dr/actuator.py
@@ -6,7 +6,12 @@ from typing import TYPE_CHECKING, Literal
 
 import torch
 
-from mjlab.actuator import BuiltinPdActuator, BuiltinPositionActuator, IdealPdActuator
+from mjlab.actuator import (
+  BuiltinDcMotorActuator,
+  BuiltinPdActuator,
+  BuiltinPositionActuator,
+  IdealPdActuator,
+)
 from mjlab.actuator.actuator import TransmissionType
 from mjlab.actuator.xml_actuator import XmlActuator
 from mjlab.entity import Entity
@@ -106,6 +111,28 @@ def pd_gains(
         env.sim.model.actuator_biasprm[env_ids[:, None], ctrl_ids, 1] = -kp_samples
         env.sim.model.actuator_biasprm[env_ids[:, None], ctrl_ids, 2] = -kd_samples
 
+    elif isinstance(actuator, BuiltinDcMotorActuator):
+      if actuator.cfg.mode == "voltage":
+        raise ValueError(
+          "dr.pd_gains does not apply to BuiltinDcMotorActuator in 'voltage' "
+          "mode (no internal PID gains to scale)."
+        )
+      # DC motor stores kp at gainprm[4] and kd at gainprm[6] (set via
+      # set_to_dcmotor). The bias slots carry back-EMF / cogging, not the PD,
+      # so we only touch gainprm.
+      if op.name == "scale":
+        default_gainprm = env.sim.get_default_field("actuator_gainprm")
+        env.sim.model.actuator_gainprm[env_ids[:, None], ctrl_ids, 4] = (
+          default_gainprm[ctrl_ids, 4] * kp_samples
+        )
+        env.sim.model.actuator_gainprm[env_ids[:, None], ctrl_ids, 6] = (
+          default_gainprm[ctrl_ids, 6] * kd_samples
+        )
+      else:
+        assert op.name == "abs"
+        env.sim.model.actuator_gainprm[env_ids[:, None], ctrl_ids, 4] = kp_samples
+        env.sim.model.actuator_gainprm[env_ids[:, None], ctrl_ids, 6] = kd_samples
+
     elif isinstance(actuator, BuiltinPdActuator):
       # ctrl_ids is laid out as [pos_0..pos_{N-1}, vel_0..vel_{N-1}], so the
       # first N rows carry kp and the next N carry kd.
@@ -155,8 +182,8 @@ def pd_gains(
     else:
       raise TypeError(
         f"pd_gains only supports BuiltinPositionActuator, BuiltinPdActuator, "
-        f"XmlActuator (position), and IdealPdActuator, "
-        f"got {type(actuator).__name__}"
+        f"BuiltinDcMotorActuator (position/velocity mode), XmlActuator (position), "
+        f"and IdealPdActuator, got {type(actuator).__name__}"
       )
 
 
@@ -216,7 +243,7 @@ def effort_limits(
       env.device,
     )
 
-    if isinstance(actuator, BuiltinPositionActuator) or (
+    if isinstance(actuator, (BuiltinPositionActuator, BuiltinDcMotorActuator)) or (
       isinstance(actuator, XmlActuator) and actuator.command_field == "position"
     ):
       if op.name == "scale":
@@ -274,6 +301,6 @@ def effort_limits(
     else:
       raise TypeError(
         f"effort_limits only supports BuiltinPositionActuator, BuiltinPdActuator, "
-        f"XmlActuator (position), and IdealPdActuator, "
+        f"BuiltinDcMotorActuator, XmlActuator (position), and IdealPdActuator, "
         f"got {type(actuator).__name__}"
       )

--- a/src/mjlab/utils/spec.py
+++ b/src/mjlab/utils/spec.py
@@ -120,6 +120,34 @@ _TRANSMISSION_TYPE_MAP = {
 }
 
 
+def apply_target_overrides(
+  spec: mujoco.MjSpec,
+  target_name: str,
+  transmission_type: TransmissionType,
+  *,
+  armature: float | None,
+  frictionloss: float | None,
+  viscous_damping: float | None,
+) -> None:
+  """Apply joint- or tendon-level overrides. ``None`` preserves the XML value.
+
+  SITE transmission is a no-op (sites have no armature / frictionloss / damping);
+  callers using SITE should not pass non-None overrides.
+  """
+  if transmission_type == TransmissionType.JOINT:
+    target = spec.joint(target_name)
+  elif transmission_type == TransmissionType.TENDON:
+    target = spec.tendon(target_name)
+  else:
+    return
+  if armature is not None:
+    target.armature = armature
+  if frictionloss is not None:
+    target.frictionloss = frictionloss
+  if viscous_damping is not None:
+    target.damping[0] = viscous_damping
+
+
 def auto_wrap_fixed_base_mocap(
   spec_fn: Callable[[], mujoco.MjSpec],
 ) -> Callable[[], mujoco.MjSpec]:
@@ -235,21 +263,14 @@ def create_motor_actuator(
   actuator.ctrllimited = True
   actuator.ctrlrange[:] = np.array([-effort_limit, effort_limit])
 
-  # Set armature, frictionloss, and viscous_damping (None = preserve XML value).
-  if transmission_type == TransmissionType.JOINT:
-    if armature is not None:
-      spec.joint(joint_name).armature = armature
-    if frictionloss is not None:
-      spec.joint(joint_name).frictionloss = frictionloss
-    if viscous_damping is not None:
-      spec.joint(joint_name).damping[0] = viscous_damping
-  elif transmission_type == TransmissionType.TENDON:
-    if armature is not None:
-      spec.tendon(joint_name).armature = armature
-    if frictionloss is not None:
-      spec.tendon(joint_name).frictionloss = frictionloss
-    if viscous_damping is not None:
-      spec.tendon(joint_name).damping[0] = viscous_damping
+  apply_target_overrides(
+    spec,
+    joint_name,
+    transmission_type,
+    armature=armature,
+    frictionloss=frictionloss,
+    viscous_damping=viscous_damping,
+  )
 
   return actuator
 
@@ -321,21 +342,14 @@ def create_position_actuator(
     actuator.forcelimited = False
     # No forcerange needed.
 
-  # Set armature, frictionloss, and viscous_damping (None = preserve XML value).
-  if transmission_type == TransmissionType.JOINT:
-    if armature is not None:
-      spec.joint(joint_name).armature = armature
-    if frictionloss is not None:
-      spec.joint(joint_name).frictionloss = frictionloss
-    if viscous_damping is not None:
-      spec.joint(joint_name).damping[0] = viscous_damping
-  elif transmission_type == TransmissionType.TENDON:
-    if armature is not None:
-      spec.tendon(joint_name).armature = armature
-    if frictionloss is not None:
-      spec.tendon(joint_name).frictionloss = frictionloss
-    if viscous_damping is not None:
-      spec.tendon(joint_name).damping[0] = viscous_damping
+  apply_target_overrides(
+    spec,
+    joint_name,
+    transmission_type,
+    armature=armature,
+    frictionloss=frictionloss,
+    viscous_damping=viscous_damping,
+  )
 
   return actuator
 
@@ -383,21 +397,14 @@ def create_velocity_actuator(
   else:
     actuator.forcelimited = False
 
-  # Set armature, frictionloss, and viscous_damping (None = preserve XML value).
-  if transmission_type == TransmissionType.JOINT:
-    if armature is not None:
-      spec.joint(joint_name).armature = armature
-    if frictionloss is not None:
-      spec.joint(joint_name).frictionloss = frictionloss
-    if viscous_damping is not None:
-      spec.joint(joint_name).damping[0] = viscous_damping
-  elif transmission_type == TransmissionType.TENDON:
-    if armature is not None:
-      spec.tendon(joint_name).armature = armature
-    if frictionloss is not None:
-      spec.tendon(joint_name).frictionloss = frictionloss
-    if viscous_damping is not None:
-      spec.tendon(joint_name).damping[0] = viscous_damping
+  apply_target_overrides(
+    spec,
+    joint_name,
+    transmission_type,
+    armature=armature,
+    frictionloss=frictionloss,
+    viscous_damping=viscous_damping,
+  )
 
   return actuator
 

--- a/tests/test_builtin_dcmotor_actuator.py
+++ b/tests/test_builtin_dcmotor_actuator.py
@@ -1,0 +1,647 @@
+"""Tests for BuiltinDcMotorActuator.
+
+Covers wiring of MuJoCo's native ``<dcmotor>`` element through mjlab: the
+three input modes (voltage / position / velocity), torque saturation,
+config validation, and DR integration.
+"""
+
+import math
+from typing import Literal
+from unittest.mock import Mock
+
+import mujoco
+import pytest
+import torch
+from conftest import (
+  create_entity_with_actuator,
+  get_test_device,
+  initialize_entity,
+  load_fixture_xml,
+)
+
+from mjlab.actuator import (
+  BuiltinDcMotorActuator,
+  BuiltinDcMotorActuatorCfg,
+)
+from mjlab.actuator.actuator import TransmissionType
+from mjlab.entity import Entity, EntityArticulationInfoCfg, EntityCfg
+from mjlab.envs.mdp import dr
+from mjlab.managers.scene_entity_config import SceneEntityCfg
+from mjlab.scene import Scene, SceneCfg
+from mjlab.sim.sim import Simulation, SimulationCfg
+
+ROBOT_XML = load_fixture_xml("floating_base_articulated")
+
+# Motor characterization used throughout (resolves to K=0.24, R=2.88).
+V_NOM, TAU_STALL, OMEGA_NL = 24.0, 2.0, 100.0
+K = V_NOM / OMEGA_NL
+R = K * V_NOM / TAU_STALL
+
+
+@pytest.fixture(scope="module")
+def device():
+  return get_test_device()
+
+
+def _make_cfg(
+  *,
+  mode: Literal["voltage", "position", "velocity"] = "position",
+  stiffness=5.0,
+  damping=0.5,
+  voltage_limit=24.0,
+  **extra,
+) -> BuiltinDcMotorActuatorCfg:
+  """Build a cfg with sensible PID defaults. ``extra`` forwards any other
+  ``BuiltinDcMotorActuatorCfg`` kwarg (effort_limit, integral_gain, thermal,
+  delay_*, etc.)."""
+  return BuiltinDcMotorActuatorCfg(
+    target_names_expr=("joint.*",),
+    mode=mode,
+    nominal=(V_NOM, TAU_STALL, OMEGA_NL),
+    stiffness=stiffness,
+    damping=damping,
+    voltage_limit=voltage_limit,
+    **extra,
+  )
+
+
+def _make_entity(**kwargs) -> Entity:
+  return create_entity_with_actuator(ROBOT_XML, _make_cfg(**kwargs))
+
+
+def _make_initialized(device, **kwargs):
+  """Build entity from cfg kwargs and initialize it through the sim."""
+  return initialize_entity(_make_entity(**kwargs), device)
+
+
+def _drive(
+  entity: Entity,
+  sim,
+  device: str,
+  *,
+  pos_target=None,
+  vel_target=None,
+  effort_target=None,
+  q0=None,
+  qd0=None,
+) -> None:
+  zero = torch.zeros(1, 2, device=device)
+  entity.write_joint_state_to_sim(
+    position=q0 if q0 is not None else zero,
+    velocity=qd0 if qd0 is not None else zero,
+  )
+  entity.set_joint_position_target(pos_target if pos_target is not None else zero)
+  entity.set_joint_velocity_target(vel_target if vel_target is not None else zero)
+  entity.set_joint_effort_target(effort_target if effort_target is not None else zero)
+  entity.write_data_to_sim()
+  sim.forward()
+
+
+# Wiring sanity.
+
+
+def test_kr_packed_into_gainprm(device):
+  """The XML compiler derives K and R from the nominal triplet."""
+  _, sim = initialize_entity(_make_entity(effort_limit=1.5), device)
+  m = sim.mj_model
+  for i in range(2):
+    assert m.actuator_gainprm[i, 0] == pytest.approx(R, abs=1e-6)
+    assert m.actuator_gainprm[i, 1] == pytest.approx(K, abs=1e-6)
+    assert m.actuator_gainprm[i, 4] == pytest.approx(5.0)  # kp
+    assert m.actuator_gainprm[i, 6] == pytest.approx(0.5)  # kd
+    assert m.actuator_gainprm[i, 7] == pytest.approx(24.0)  # Vmax
+    assert m.actuator_gainprm[i, 8] == pytest.approx(1.0)  # input_mode=position
+    assert m.actuator_gaintype[i] == mujoco.mjtGain.mjGAIN_DCMOTOR
+    assert m.actuator_biastype[i] == mujoco.mjtBias.mjBIAS_DCMOTOR
+    # No activation state: ki=0, no inductance, no thermal/lugre/slew.
+    assert m.actuator_actnum[i] == 0
+
+
+def test_motor_const_path(device):
+  """``motor_const + resistance`` packs K = sqrt(Kt*Ke) and R verbatim."""
+  cfg = BuiltinDcMotorActuatorCfg(
+    target_names_expr=("joint.*",),
+    mode="voltage",
+    motor_const=(0.1, 0.05),
+    resistance=2.0,
+  )
+  _, sim = initialize_entity(create_entity_with_actuator(ROBOT_XML, cfg), device)
+  m = sim.mj_model
+  for i in range(2):
+    assert m.actuator_gainprm[i, 0] == pytest.approx(2.0, abs=1e-6)
+    assert m.actuator_gainprm[i, 1] == pytest.approx((0.1 * 0.05) ** 0.5, abs=1e-6)
+
+
+# Stateless motor physics.
+
+
+def test_voltage_mode_steady_state(device):
+  """At rest, ctrl = V -> tau = K * V / R."""
+  cfg = BuiltinDcMotorActuatorCfg(
+    target_names_expr=("joint.*",),
+    mode="voltage",
+    nominal=(V_NOM, TAU_STALL, OMEGA_NL),
+  )
+  entity, sim = initialize_entity(create_entity_with_actuator(ROBOT_XML, cfg), device)
+  V = torch.tensor([[10.0, -5.0]], device=device)
+  _drive(entity, sim, device, effort_target=V)
+  v_adr = entity.indexing.joint_v_adr
+  expected = K * V[0] / R
+  assert torch.allclose(sim.data.qfrc_actuator[0, v_adr], expected, atol=1e-4)
+
+
+def test_voltage_mode_voltage_limit_zero_is_noop(device):
+  """Docstring promises ``voltage_limit=0`` disables clamping. Verify against
+  MuJoCo's ``dcmotor_voltage`` (which only clamps when ``Vmax > 0``)."""
+  cfg = BuiltinDcMotorActuatorCfg(
+    target_names_expr=("joint.*",),
+    mode="voltage",
+    nominal=(V_NOM, TAU_STALL, OMEGA_NL),
+    voltage_limit=0.0,
+  )
+  entity, sim = initialize_entity(create_entity_with_actuator(ROBOT_XML, cfg), device)
+  V = torch.tensor([[1000.0, 0.0]], device=device)  # absurdly high voltage.
+  _drive(entity, sim, device, effort_target=V)
+  v_adr = entity.indexing.joint_v_adr
+  expected = K * V[0] / R
+  assert torch.allclose(sim.data.qfrc_actuator[0, v_adr], expected, atol=1e-2)
+
+
+def test_back_emf_reduces_torque_at_velocity(device):
+  """Same V, joint moving at omega: tau = K * (V - K * omega) / R."""
+  cfg = BuiltinDcMotorActuatorCfg(
+    target_names_expr=("joint.*",),
+    mode="voltage",
+    nominal=(V_NOM, TAU_STALL, OMEGA_NL),
+  )
+  entity, sim = initialize_entity(create_entity_with_actuator(ROBOT_XML, cfg), device)
+  V = torch.tensor([[10.0, 0.0]], device=device)
+  omega0 = torch.tensor([[2.0, 0.0]], device=device)
+  _drive(entity, sim, device, effort_target=V, qd0=omega0)
+  v_adr = entity.indexing.joint_v_adr
+  expected = K * (V[0] - K * omega0[0]) / R
+  assert torch.allclose(sim.data.qfrc_actuator[0, v_adr], expected, atol=1e-4)
+
+
+def test_position_mode_pid_at_rest(device):
+  """kd=0, no Vmax clamp: tau = K * kp * (target - q) / R."""
+  # voltage_limit must be >0 (cfg invariant), pick it big enough not to clamp.
+  entity, sim = initialize_entity(
+    _make_entity(damping=0.0, voltage_limit=1000.0), device
+  )
+  pos = torch.tensor([[0.1, -0.05]], device=device)
+  _drive(entity, sim, device, pos_target=pos)
+  v_adr = entity.indexing.joint_v_adr
+  expected = K * 5.0 * pos[0] / R
+  assert torch.allclose(sim.data.qfrc_actuator[0, v_adr], expected, atol=1e-4)
+
+
+def test_position_mode_voltage_clamp(device):
+  """Huge position error -> PID voltage saturates at Vmax."""
+  entity, sim = initialize_entity(
+    _make_entity(stiffness=100.0, damping=0.0, voltage_limit=2.0),
+    device,
+  )
+  # kp * err = 100 * 0.5 = 50 V, well above Vmax=2.
+  pos = torch.tensor([[0.5, 0.0]], device=device)
+  _drive(entity, sim, device, pos_target=pos)
+  v_adr = entity.indexing.joint_v_adr
+  qfrc = sim.data.qfrc_actuator[0, v_adr]
+  expected_first = K * 2.0 / R  # tau at clamped V.
+  assert qfrc[0].item() == pytest.approx(expected_first, abs=1e-4)
+  assert qfrc[1].item() == pytest.approx(0.0, abs=1e-4)
+
+
+def test_velocity_mode_pid(device):
+  """P-only velocity tracking: tau = K * kp * (target - qdot) / R."""
+  entity, sim = initialize_entity(
+    _make_entity(mode="velocity", damping=0.0, voltage_limit=1000.0),
+    device,
+  )
+  qd0 = torch.tensor([[1.0, 0.0]], device=device)
+  vel_target = torch.tensor([[3.0, 0.0]], device=device)
+  _drive(entity, sim, device, vel_target=vel_target, qd0=qd0)
+  v_adr = entity.indexing.joint_v_adr
+  # back-EMF subtracts K*omega; this is folded into the dcmotor bias.
+  # voltage = kp*(target - qdot); tau = K*(voltage - K*omega)/R.
+  voltage = 5.0 * (vel_target[0] - qd0[0])
+  expected = K * (voltage - K * qd0[0]) / R
+  assert torch.allclose(sim.data.qfrc_actuator[0, v_adr], expected, atol=1e-4)
+
+
+def test_effort_limit_clamps_torque(device):
+  """forcerange clamps the algebraic torque output."""
+  entity, sim = initialize_entity(
+    _make_entity(stiffness=100.0, damping=0.0, voltage_limit=1000.0, effort_limit=0.1),
+    device,
+  )
+  m = sim.mj_model
+  for i in range(2):
+    assert m.actuator_forcelimited[i] == 1
+    assert m.actuator_forcerange[i, 0] == pytest.approx(-0.1)
+    assert m.actuator_forcerange[i, 1] == pytest.approx(0.1)
+
+  # Unclamped tau would be K * 100 * 0.5 / R ~= K*50/R, well above 0.1.
+  pos = torch.tensor([[0.5, 0.0]], device=device)
+  _drive(entity, sim, device, pos_target=pos)
+  v_adr = entity.indexing.joint_v_adr
+  qfrc = sim.data.qfrc_actuator[0, v_adr]
+  assert qfrc[0].item() == pytest.approx(0.1, abs=1e-4)
+  assert qfrc[1].item() == pytest.approx(0.0, abs=1e-4)
+
+
+# Cogging.
+
+
+def test_cogging_packed_into_biasprm(device):
+  """``cogging=(A, Np, phi)`` packs into ``biasprm[0:3]``."""
+  cfg = BuiltinDcMotorActuatorCfg(
+    target_names_expr=("joint.*",),
+    mode="voltage",
+    nominal=(V_NOM, TAU_STALL, OMEGA_NL),
+    cogging=(0.5, 4.0, 0.1),
+  )
+  _, sim = initialize_entity(create_entity_with_actuator(ROBOT_XML, cfg), device)
+  m = sim.mj_model
+  for i in range(2):
+    assert m.actuator_biasprm[i, 0] == pytest.approx(0.5)
+    assert m.actuator_biasprm[i, 1] == pytest.approx(4.0)
+    assert m.actuator_biasprm[i, 2] == pytest.approx(0.1)
+
+
+def test_cogging_contributes_torque(device):
+  """At ctrl=0 (no electromagnetic torque), qfrc_actuator equals the cogging
+  term ``A * sin(Np * q + phi)`` evaluated at the joint angle."""
+  A, Np, phi = 0.5, 4.0, 0.1
+  cfg = BuiltinDcMotorActuatorCfg(
+    target_names_expr=("joint.*",),
+    mode="voltage",
+    nominal=(V_NOM, TAU_STALL, OMEGA_NL),
+    cogging=(A, Np, phi),
+  )
+  entity, sim = initialize_entity(create_entity_with_actuator(ROBOT_XML, cfg), device)
+  q0, q1 = 0.3, -0.2
+  _drive(
+    entity,
+    sim,
+    device,
+    q0=torch.tensor([[q0, q1]], device=device),
+    effort_target=torch.zeros(1, 2, device=device),
+  )
+  v_adr = entity.indexing.joint_v_adr
+  qfrc = sim.data.qfrc_actuator[0, v_adr]
+  assert qfrc[0].item() == pytest.approx(A * math.sin(Np * q0 + phi), abs=1e-5)
+  assert qfrc[1].item() == pytest.approx(A * math.sin(Np * q1 + phi), abs=1e-5)
+
+
+def test_cogging_bypasses_effort_limit(device):
+  """Cogging is added *after* the forcerange clamp (MuJoCo's intentional
+  model: ``effort_limit`` bounds electromagnetic torque, cogging is
+  mechanical). Total torque can exceed ``effort_limit`` by up to the
+  cogging amplitude."""
+  A, Np, phi = 0.5, 0.0, math.pi / 2  # sin(pi/2)=1, so cogging = A at any q.
+  cfg = BuiltinDcMotorActuatorCfg(
+    target_names_expr=("joint.*",),
+    mode="voltage",
+    nominal=(V_NOM, TAU_STALL, OMEGA_NL),
+    cogging=(A, Np, phi),
+    effort_limit=0.05,  # An order of magnitude below A.
+  )
+  entity, sim = initialize_entity(create_entity_with_actuator(ROBOT_XML, cfg), device)
+  # Pick a voltage large enough that the electromagnetic torque alone
+  # would saturate forcerange at +/- 0.05.
+  V = torch.tensor([[100.0, 0.0]], device=device)
+  _drive(entity, sim, device, effort_target=V)
+  v_adr = entity.indexing.joint_v_adr
+  qfrc = sim.data.qfrc_actuator[0, v_adr]
+  # joint1: electromagnetic clamped to +0.05, plus cogging A=0.5.
+  assert qfrc[0].item() == pytest.approx(0.05 + A, abs=1e-5)
+  # joint2: zero voltage, electromagnetic=0, only cogging.
+  assert qfrc[1].item() == pytest.approx(A, abs=1e-5)
+
+
+# Optional stateful extensions (integral, slew, inductance, thermal, LuGre).
+# Each behavior check compares against a baseline with the feature disabled
+# so that removing the wiring in edit_spec causes the comparison to fail.
+
+
+def _step_n(entity, sim, device, n: int, *, pos_target=None, eff_target=None):
+  zero = torch.zeros(1, 2, device=device)
+  entity.write_joint_state_to_sim(position=zero, velocity=zero)
+  for _ in range(n):
+    entity.set_joint_position_target(pos_target if pos_target is not None else zero)
+    entity.set_joint_velocity_target(zero)
+    entity.set_joint_effort_target(eff_target if eff_target is not None else zero)
+    entity.write_data_to_sim()
+    sim.step()
+
+
+def _qfrc(entity, sim) -> torch.Tensor:
+  return sim.data.qfrc_actuator[0, entity.indexing.joint_v_adr].clone()
+
+
+def test_integral_gain_ramps_torque(device):
+  """Integrator in position mode ramps torque over time even with ``kp``
+  and ``kd`` near zero."""
+  # stiffness must be > 0 (validation); choose tiny so ki dominates.
+  base = dict(mode="position", stiffness=1e-4, damping=0.0, voltage_limit=24.0)
+  ent_off, sim_off = _make_initialized(device, **base, integral_gain=0.0)
+  ent_on, sim_on = _make_initialized(device, **base, integral_gain=10.0)
+
+  target = torch.tensor([[0.5, 0.0]], device=device)
+  for sim, ent in ((sim_off, ent_off), (sim_on, ent_on)):
+    _step_n(ent, sim, device, n=20, pos_target=target)
+  assert _qfrc(ent_on, sim_on)[0].abs() > 100.0 * _qfrc(ent_off, sim_off)[0].abs()
+
+
+def test_slew_rate_limits_voltage(device):
+  """``slew_rate`` rate-limits ``ctrl``: after one step, effective voltage
+  is far below the requested input."""
+  base = dict(mode="voltage", stiffness=0.0, damping=0.0, voltage_limit=0.0)
+  ent_off, sim_off = _make_initialized(device, **base, slew_rate=0.0)
+  ent_on, sim_on = _make_initialized(device, **base, slew_rate=10.0)
+
+  V = torch.tensor([[100.0, 0.0]], device=device)
+  for sim, ent in ((sim_off, ent_off), (sim_on, ent_on)):
+    _step_n(ent, sim, device, n=1, eff_target=V)
+  assert _qfrc(ent_off, sim_off)[0] > 100.0 * _qfrc(ent_on, sim_on)[0]
+
+
+def test_inductance_lags_current(device):
+  """Large ``inductance`` (te >> dt) suppresses early-step torque."""
+  base = dict(mode="voltage", stiffness=0.0, damping=0.0, voltage_limit=0.0)
+  ent_off, sim_off = _make_initialized(device, **base, inductance=0.0)
+  ent_on, sim_on = _make_initialized(device, **base, inductance=1.0)
+
+  V = torch.tensor([[10.0, 0.0]], device=device)
+  for sim, ent in ((sim_off, ent_off), (sim_on, ent_on)):
+    _step_n(ent, sim, device, n=2, eff_target=V)
+  assert _qfrc(ent_off, sim_off)[0].abs() > 10.0 * _qfrc(ent_on, sim_on)[0].abs()
+
+
+def test_thermal_decays_torque(device):
+  """I^2R heating raises T, which raises effective resistance and decays
+  torque over time."""
+  # Params chosen for visible effect in a handful of steps without going
+  # numerically unstable: small C (fast heating) and modest alpha.
+  base = dict(mode="voltage", stiffness=0.0, damping=0.0, voltage_limit=0.0)
+  ent_off, sim_off = _make_initialized(device, **base)
+  ent_on, sim_on = _make_initialized(
+    device, **base, thermal=(1.0, 0.1, 0.0, 0.01, 0.0, 0.0)
+  )
+
+  V = torch.tensor([[100.0, 0.0]], device=device)
+  for sim, ent in ((sim_off, ent_off), (sim_on, ent_on)):
+    _step_n(ent, sim, device, n=5, eff_target=V)
+  assert _qfrc(ent_on, sim_on)[0].abs() < 0.5 * _qfrc(ent_off, sim_off)[0].abs()
+
+
+def test_lugre_subtracts_friction(device):
+  """LuGre friction subtracts a velocity-dependent force after the
+  ``effort_limit`` clamp (mechanical, like cogging)."""
+  # Static comparison at v>0, ctrl=0; avoids feedback between LuGre slowing
+  # the joint and back-EMF easing off under sim.step().
+  #   no LuGre:  qfrc = -K^2 * v / R              (back-EMF only)
+  #   w/ LuGre:  qfrc = -K^2 * v / R - sigma1*v - ...
+  base = dict(mode="voltage", stiffness=0.0, damping=0.0, voltage_limit=0.0)
+  ent_off, sim_off = _make_initialized(device, **base)
+  ent_on, sim_on = _make_initialized(
+    device, **base, lugre=(1e4, 100.0, 0.1, 0.15, 0.01)
+  )
+
+  zero = torch.zeros(1, 2, device=device)
+  v0 = torch.tensor([[1.0, 0.0]], device=device)
+  for sim, ent in ((sim_off, ent_off), (sim_on, ent_on)):
+    ent.write_joint_state_to_sim(position=zero, velocity=v0)
+    ent.set_joint_position_target(zero)
+    ent.set_joint_velocity_target(zero)
+    ent.set_joint_effort_target(zero)
+    ent.write_data_to_sim()
+    sim.forward()
+  assert abs(_qfrc(ent_on, sim_on)[0]) > 100.0 * abs(_qfrc(ent_off, sim_off)[0])
+
+
+# Config validation.
+
+
+def test_motor_characterization_xor():
+  with pytest.raises(ValueError, match="exactly one"):
+    BuiltinDcMotorActuatorCfg(
+      target_names_expr=("j",), nominal=(1, 1, 1), motor_const=(1, 1), resistance=1
+    )
+  with pytest.raises(ValueError, match="exactly one"):
+    BuiltinDcMotorActuatorCfg(target_names_expr=("j",))
+
+
+def test_motor_const_requires_resistance():
+  # `nominal=None`, `motor_const` set, `resistance` missing -> XOR check
+  # passes (only one characterization), but resistance is required.
+  with pytest.raises(ValueError, match="resistance"):
+    BuiltinDcMotorActuatorCfg(target_names_expr=("j",), motor_const=(1, 1))
+
+
+def test_pid_mode_requires_gains():
+  with pytest.raises(ValueError, match="stiffness"):
+    BuiltinDcMotorActuatorCfg(
+      target_names_expr=("j",), mode="position", nominal=(1, 1, 1), voltage_limit=1.0
+    )
+  with pytest.raises(ValueError, match="voltage_limit"):
+    BuiltinDcMotorActuatorCfg(
+      target_names_expr=("j",), mode="position", nominal=(1, 1, 1), stiffness=1.0
+    )
+
+
+def test_voltage_mode_rejects_pid_gains():
+  with pytest.raises(ValueError, match="voltage"):
+    BuiltinDcMotorActuatorCfg(
+      target_names_expr=("j",),
+      mode="voltage",
+      nominal=(1, 1, 1),
+      stiffness=1.0,
+    )
+
+
+def test_site_rejected():
+  with pytest.raises(ValueError, match="SITE"):
+    BuiltinDcMotorActuatorCfg(
+      target_names_expr=("j",),
+      nominal=(1, 1, 1),
+      stiffness=1.0,
+      voltage_limit=1.0,
+      transmission_type=TransmissionType.SITE,
+    )
+
+
+# Joint-level passthrough.
+
+
+def test_armature_applied(device):
+  _, sim = initialize_entity(_make_entity(armature=0.7), device)
+  m = sim.mj_model
+  for jname in ("joint1", "joint2"):
+    dof_id = m.jnt_dofadr[m.joint(jname).id]
+    assert m.dof_armature[dof_id] == pytest.approx(0.7)
+
+
+# Domain randomization.
+
+
+def _scene_env(
+  device,
+  num_envs=2,
+  mode: Literal["voltage", "position", "velocity"] = "position",
+):
+  def spec_fn():
+    spec = mujoco.MjSpec.from_string(ROBOT_XML)
+    for a in list(spec.actuators):
+      spec.delete(a)
+    return spec
+
+  entity_cfg = EntityCfg(
+    spec_fn=spec_fn,
+    articulation=EntityArticulationInfoCfg(
+      actuators=(
+        BuiltinDcMotorActuatorCfg(
+          target_names_expr=("joint.*",),
+          mode=mode,
+          nominal=(V_NOM, TAU_STALL, OMEGA_NL),
+          stiffness=5.0 if mode != "voltage" else 0.0,
+          damping=0.5 if mode != "voltage" else 0.0,
+          voltage_limit=24.0 if mode != "voltage" else 0.0,
+          effort_limit=50.0,
+        ),
+      )
+    ),
+  )
+  scene_cfg = SceneCfg(num_envs=num_envs, entities={"robot": entity_cfg})
+  scene = Scene(scene_cfg, device)
+  model = scene.compile()
+  sim = Simulation(num_envs=num_envs, cfg=SimulationCfg(), model=model, device=device)
+  scene.initialize(model, sim.model, sim.data)
+
+  env = Mock()
+  env.num_envs = num_envs
+  env.device = device
+  env.scene = {"robot": scene["robot"]}
+  env.sim = sim
+  return env
+
+
+@pytest.mark.parametrize(
+  "operation, kp_in, kd_in, kp_expected, kd_expected",
+  [
+    # scale: multiplies the configured defaults (kp=5.0, kd=0.5).
+    ("scale", 2.0, 3.0, 2.0 * 5.0, 3.0 * 0.5),
+    # abs: writes the value directly.
+    ("abs", 10.0, 2.0, 10.0, 2.0),
+  ],
+)
+def test_dr_pd_gains_position_mode(
+  device, operation, kp_in, kd_in, kp_expected, kd_expected
+):
+  env = _scene_env(device)
+  robot = env.scene["robot"]
+  act = robot.actuators[0]
+  assert isinstance(act, BuiltinDcMotorActuator)
+  ctrl_ids = act.global_ctrl_ids
+  env.sim.expand_model_fields(("actuator_gainprm", "actuator_biasprm"))
+
+  dr.pd_gains(
+    env,
+    env_ids=torch.tensor([0], device=device),
+    kp_range=(kp_in, kp_in),
+    kd_range=(kd_in, kd_in),
+    asset_cfg=SceneEntityCfg("robot"),
+    operation=operation,
+  )
+
+  m = env.sim.model
+  n = len(ctrl_ids)
+  assert torch.allclose(
+    m.actuator_gainprm[0, ctrl_ids, 4], torch.full((n,), kp_expected, device=device)
+  )
+  assert torch.allclose(
+    m.actuator_gainprm[0, ctrl_ids, 6], torch.full((n,), kd_expected, device=device)
+  )
+  # Other env untouched (cfg defaults).
+  assert torch.allclose(m.actuator_gainprm[1, ctrl_ids, 4], torch.tensor(5.0))
+  assert torch.allclose(m.actuator_gainprm[1, ctrl_ids, 6], torch.tensor(0.5))
+
+
+def test_dr_pd_gains_voltage_mode_rejected(device):
+  env = _scene_env(device, mode="voltage")
+  env.sim.expand_model_fields(("actuator_gainprm", "actuator_biasprm"))
+  with pytest.raises(ValueError, match="voltage"):
+    dr.pd_gains(
+      env,
+      env_ids=torch.tensor([0], device=device),
+      kp_range=(1.0, 1.0),
+      kd_range=(1.0, 1.0),
+      asset_cfg=SceneEntityCfg("robot"),
+    )
+
+
+def test_dr_effort_limits_writes_forcerange(device):
+  env = _scene_env(device)
+  robot = env.scene["robot"]
+  act = robot.actuators[0]
+  ctrl_ids = act.global_ctrl_ids
+  env.sim.expand_model_fields(
+    ("actuator_forcerange", "jnt_actfrcrange", "tendon_actfrcrange")
+  )
+
+  dr.effort_limits(
+    env,
+    env_ids=torch.tensor([0], device=device),
+    effort_limit_range=(123.0, 123.0),
+    asset_cfg=SceneEntityCfg("robot"),
+    operation="abs",
+  )
+
+  m = env.sim.model
+  n = len(ctrl_ids)
+  assert torch.allclose(
+    m.actuator_forcerange[0, ctrl_ids, 0],
+    torch.full((n,), -123.0, device=device),
+  )
+  assert torch.allclose(
+    m.actuator_forcerange[0, ctrl_ids, 1],
+    torch.full((n,), 123.0, device=device),
+  )
+  # Env 1 keeps the configured default of 50.
+  assert torch.allclose(m.actuator_forcerange[1, ctrl_ids, 1], torch.tensor(50.0))
+
+
+# Delay.
+
+
+def test_delay_position_mode(device):
+  """A 2-step lag should make position-mode torque reference step-0 target."""
+  entity, sim = initialize_entity(
+    _make_entity(
+      stiffness=10.0,
+      damping=0.0,
+      voltage_limit=1000.0,
+      delay_min_lag=2,
+      delay_max_lag=2,
+    ),
+    device,
+  )
+  zero = torch.zeros(1, 2, device=device)
+  entity.write_joint_state_to_sim(position=zero, velocity=zero)
+  targets = [
+    torch.tensor([[0.1, 0.0]], device=device),
+    torch.tensor([[0.3, 0.0]], device=device),
+    torch.tensor([[0.5, 0.0]], device=device),
+  ]
+  for p in targets:
+    entity.set_joint_position_target(p)
+    entity.set_joint_velocity_target(zero)
+    entity.set_joint_effort_target(zero)
+    entity.write_data_to_sim()
+    sim.forward()
+
+  v_adr = entity.indexing.joint_v_adr
+  # With lag=2 and three writes, the effective target is targets[0].
+  expected = K * 10.0 * targets[0][0] / R
+  assert torch.allclose(sim.data.qfrc_actuator[0, v_adr], expected, atol=1e-4)

--- a/tests/test_builtin_dcmotor_actuator.py
+++ b/tests/test_builtin_dcmotor_actuator.py
@@ -6,7 +6,6 @@ config validation, and DR integration.
 """
 
 import math
-from typing import Literal
 from unittest.mock import Mock
 
 import mujoco
@@ -22,6 +21,9 @@ from conftest import (
 from mjlab.actuator import (
   BuiltinDcMotorActuator,
   BuiltinDcMotorActuatorCfg,
+  DcMotorDatasheetParams,
+  DcMotorInputMode,
+  DcMotorPhysicalParams,
 )
 from mjlab.actuator.actuator import TransmissionType
 from mjlab.entity import Entity, EntityArticulationInfoCfg, EntityCfg
@@ -43,21 +45,26 @@ def device():
   return get_test_device()
 
 
+DATASHEET = DcMotorDatasheetParams(
+  nominal_voltage=V_NOM, stall_torque=TAU_STALL, no_load_speed=OMEGA_NL
+)
+
+
 def _make_cfg(
   *,
-  mode: Literal["voltage", "position", "velocity"] = "position",
+  mode: DcMotorInputMode = DcMotorInputMode.POSITION,
   stiffness=5.0,
   damping=0.5,
   voltage_limit=24.0,
   **extra,
 ) -> BuiltinDcMotorActuatorCfg:
   """Build a cfg with sensible PID defaults. ``extra`` forwards any other
-  ``BuiltinDcMotorActuatorCfg`` kwarg (effort_limit, integral_gain, thermal,
+  BuiltinDcMotorActuatorCfg kwarg (effort_limit, integral_gain, thermal,
   delay_*, etc.)."""
   return BuiltinDcMotorActuatorCfg(
     target_names_expr=("joint.*",),
     mode=mode,
-    nominal=(V_NOM, TAU_STALL, OMEGA_NL),
+    motor_params=DATASHEET,
     stiffness=stiffness,
     damping=damping,
     voltage_limit=voltage_limit,
@@ -118,12 +125,11 @@ def test_kr_packed_into_gainprm(device):
 
 
 def test_motor_const_path(device):
-  """``motor_const + resistance`` packs K = sqrt(Kt*Ke) and R verbatim."""
+  """Physical params pack K = sqrt(Kt*Ke) and R verbatim."""
   cfg = BuiltinDcMotorActuatorCfg(
     target_names_expr=("joint.*",),
-    mode="voltage",
-    motor_const=(0.1, 0.05),
-    resistance=2.0,
+    mode=DcMotorInputMode.VOLTAGE,
+    motor_params=DcMotorPhysicalParams(kt=0.1, ke=0.05, resistance=2.0),
   )
   _, sim = initialize_entity(create_entity_with_actuator(ROBOT_XML, cfg), device)
   m = sim.mj_model
@@ -139,8 +145,8 @@ def test_voltage_mode_steady_state(device):
   """At rest, ctrl = V -> tau = K * V / R."""
   cfg = BuiltinDcMotorActuatorCfg(
     target_names_expr=("joint.*",),
-    mode="voltage",
-    nominal=(V_NOM, TAU_STALL, OMEGA_NL),
+    mode=DcMotorInputMode.VOLTAGE,
+    motor_params=DATASHEET,
   )
   entity, sim = initialize_entity(create_entity_with_actuator(ROBOT_XML, cfg), device)
   V = torch.tensor([[10.0, -5.0]], device=device)
@@ -155,8 +161,8 @@ def test_voltage_mode_voltage_limit_zero_is_noop(device):
   MuJoCo's ``dcmotor_voltage`` (which only clamps when ``Vmax > 0``)."""
   cfg = BuiltinDcMotorActuatorCfg(
     target_names_expr=("joint.*",),
-    mode="voltage",
-    nominal=(V_NOM, TAU_STALL, OMEGA_NL),
+    mode=DcMotorInputMode.VOLTAGE,
+    motor_params=DATASHEET,
     voltage_limit=0.0,
   )
   entity, sim = initialize_entity(create_entity_with_actuator(ROBOT_XML, cfg), device)
@@ -171,8 +177,8 @@ def test_back_emf_reduces_torque_at_velocity(device):
   """Same V, joint moving at omega: tau = K * (V - K * omega) / R."""
   cfg = BuiltinDcMotorActuatorCfg(
     target_names_expr=("joint.*",),
-    mode="voltage",
-    nominal=(V_NOM, TAU_STALL, OMEGA_NL),
+    mode=DcMotorInputMode.VOLTAGE,
+    motor_params=DATASHEET,
   )
   entity, sim = initialize_entity(create_entity_with_actuator(ROBOT_XML, cfg), device)
   V = torch.tensor([[10.0, 0.0]], device=device)
@@ -215,7 +221,7 @@ def test_position_mode_voltage_clamp(device):
 def test_velocity_mode_pid(device):
   """P-only velocity tracking: tau = K * kp * (target - qdot) / R."""
   entity, sim = initialize_entity(
-    _make_entity(mode="velocity", damping=0.0, voltage_limit=1000.0),
+    _make_entity(mode=DcMotorInputMode.VELOCITY, damping=0.0, voltage_limit=1000.0),
     device,
   )
   qd0 = torch.tensor([[1.0, 0.0]], device=device)
@@ -257,8 +263,8 @@ def test_cogging_packed_into_biasprm(device):
   """``cogging=(A, Np, phi)`` packs into ``biasprm[0:3]``."""
   cfg = BuiltinDcMotorActuatorCfg(
     target_names_expr=("joint.*",),
-    mode="voltage",
-    nominal=(V_NOM, TAU_STALL, OMEGA_NL),
+    mode=DcMotorInputMode.VOLTAGE,
+    motor_params=DATASHEET,
     cogging=(0.5, 4.0, 0.1),
   )
   _, sim = initialize_entity(create_entity_with_actuator(ROBOT_XML, cfg), device)
@@ -275,8 +281,8 @@ def test_cogging_contributes_torque(device):
   A, Np, phi = 0.5, 4.0, 0.1
   cfg = BuiltinDcMotorActuatorCfg(
     target_names_expr=("joint.*",),
-    mode="voltage",
-    nominal=(V_NOM, TAU_STALL, OMEGA_NL),
+    mode=DcMotorInputMode.VOLTAGE,
+    motor_params=DATASHEET,
     cogging=(A, Np, phi),
   )
   entity, sim = initialize_entity(create_entity_with_actuator(ROBOT_XML, cfg), device)
@@ -302,8 +308,8 @@ def test_cogging_bypasses_effort_limit(device):
   A, Np, phi = 0.5, 0.0, math.pi / 2  # sin(pi/2)=1, so cogging = A at any q.
   cfg = BuiltinDcMotorActuatorCfg(
     target_names_expr=("joint.*",),
-    mode="voltage",
-    nominal=(V_NOM, TAU_STALL, OMEGA_NL),
+    mode=DcMotorInputMode.VOLTAGE,
+    motor_params=DATASHEET,
     cogging=(A, Np, phi),
     effort_limit=0.05,  # An order of magnitude below A.
   )
@@ -344,7 +350,9 @@ def test_integral_gain_ramps_torque(device):
   """Integrator in position mode ramps torque over time even with ``kp``
   and ``kd`` near zero."""
   # stiffness must be > 0 (validation); choose tiny so ki dominates.
-  base = dict(mode="position", stiffness=1e-4, damping=0.0, voltage_limit=24.0)
+  base = dict(
+    mode=DcMotorInputMode.POSITION, stiffness=1e-4, damping=0.0, voltage_limit=24.0
+  )
   ent_off, sim_off = _make_initialized(device, **base, integral_gain=0.0)
   ent_on, sim_on = _make_initialized(device, **base, integral_gain=10.0)
 
@@ -357,7 +365,9 @@ def test_integral_gain_ramps_torque(device):
 def test_slew_rate_limits_voltage(device):
   """``slew_rate`` rate-limits ``ctrl``: after one step, effective voltage
   is far below the requested input."""
-  base = dict(mode="voltage", stiffness=0.0, damping=0.0, voltage_limit=0.0)
+  base = dict(
+    mode=DcMotorInputMode.VOLTAGE, stiffness=0.0, damping=0.0, voltage_limit=0.0
+  )
   ent_off, sim_off = _make_initialized(device, **base, slew_rate=0.0)
   ent_on, sim_on = _make_initialized(device, **base, slew_rate=10.0)
 
@@ -369,7 +379,9 @@ def test_slew_rate_limits_voltage(device):
 
 def test_inductance_lags_current(device):
   """Large ``inductance`` (te >> dt) suppresses early-step torque."""
-  base = dict(mode="voltage", stiffness=0.0, damping=0.0, voltage_limit=0.0)
+  base = dict(
+    mode=DcMotorInputMode.VOLTAGE, stiffness=0.0, damping=0.0, voltage_limit=0.0
+  )
   ent_off, sim_off = _make_initialized(device, **base, inductance=0.0)
   ent_on, sim_on = _make_initialized(device, **base, inductance=1.0)
 
@@ -384,7 +396,9 @@ def test_thermal_decays_torque(device):
   torque over time."""
   # Params chosen for visible effect in a handful of steps without going
   # numerically unstable: small C (fast heating) and modest alpha.
-  base = dict(mode="voltage", stiffness=0.0, damping=0.0, voltage_limit=0.0)
+  base = dict(
+    mode=DcMotorInputMode.VOLTAGE, stiffness=0.0, damping=0.0, voltage_limit=0.0
+  )
   ent_off, sim_off = _make_initialized(device, **base)
   ent_on, sim_on = _make_initialized(
     device, **base, thermal=(1.0, 0.1, 0.0, 0.01, 0.0, 0.0)
@@ -403,7 +417,9 @@ def test_lugre_subtracts_friction(device):
   # the joint and back-EMF easing off under sim.step().
   #   no LuGre:  qfrc = -K^2 * v / R              (back-EMF only)
   #   w/ LuGre:  qfrc = -K^2 * v / R - sigma1*v - ...
-  base = dict(mode="voltage", stiffness=0.0, damping=0.0, voltage_limit=0.0)
+  base = dict(
+    mode=DcMotorInputMode.VOLTAGE, stiffness=0.0, damping=0.0, voltage_limit=0.0
+  )
   ent_off, sim_off = _make_initialized(device, **base)
   ent_on, sim_on = _make_initialized(
     device, **base, lugre=(1e4, 100.0, 0.1, 0.15, 0.01)
@@ -424,39 +440,29 @@ def test_lugre_subtracts_friction(device):
 # Config validation.
 
 
-def test_motor_characterization_xor():
-  with pytest.raises(ValueError, match="exactly one"):
-    BuiltinDcMotorActuatorCfg(
-      target_names_expr=("j",), nominal=(1, 1, 1), motor_const=(1, 1), resistance=1
-    )
-  with pytest.raises(ValueError, match="exactly one"):
-    BuiltinDcMotorActuatorCfg(target_names_expr=("j",))
-
-
-def test_motor_const_requires_resistance():
-  # `nominal=None`, `motor_const` set, `resistance` missing -> XOR check
-  # passes (only one characterization), but resistance is required.
-  with pytest.raises(ValueError, match="resistance"):
-    BuiltinDcMotorActuatorCfg(target_names_expr=("j",), motor_const=(1, 1))
-
-
 def test_pid_mode_requires_gains():
   with pytest.raises(ValueError, match="stiffness"):
     BuiltinDcMotorActuatorCfg(
-      target_names_expr=("j",), mode="position", nominal=(1, 1, 1), voltage_limit=1.0
+      target_names_expr=("j",),
+      mode=DcMotorInputMode.POSITION,
+      motor_params=DATASHEET,
+      voltage_limit=1.0,
     )
   with pytest.raises(ValueError, match="voltage_limit"):
     BuiltinDcMotorActuatorCfg(
-      target_names_expr=("j",), mode="position", nominal=(1, 1, 1), stiffness=1.0
+      target_names_expr=("j",),
+      mode=DcMotorInputMode.POSITION,
+      motor_params=DATASHEET,
+      stiffness=1.0,
     )
 
 
 def test_voltage_mode_rejects_pid_gains():
-  with pytest.raises(ValueError, match="voltage"):
+  with pytest.raises(ValueError, match="VOLTAGE"):
     BuiltinDcMotorActuatorCfg(
       target_names_expr=("j",),
-      mode="voltage",
-      nominal=(1, 1, 1),
+      mode=DcMotorInputMode.VOLTAGE,
+      motor_params=DATASHEET,
       stiffness=1.0,
     )
 
@@ -465,7 +471,7 @@ def test_site_rejected():
   with pytest.raises(ValueError, match="SITE"):
     BuiltinDcMotorActuatorCfg(
       target_names_expr=("j",),
-      nominal=(1, 1, 1),
+      motor_params=DATASHEET,
       stiffness=1.0,
       voltage_limit=1.0,
       transmission_type=TransmissionType.SITE,
@@ -489,7 +495,7 @@ def test_armature_applied(device):
 def _scene_env(
   device,
   num_envs=2,
-  mode: Literal["voltage", "position", "velocity"] = "position",
+  mode: DcMotorInputMode = DcMotorInputMode.POSITION,
 ):
   def spec_fn():
     spec = mujoco.MjSpec.from_string(ROBOT_XML)
@@ -504,10 +510,10 @@ def _scene_env(
         BuiltinDcMotorActuatorCfg(
           target_names_expr=("joint.*",),
           mode=mode,
-          nominal=(V_NOM, TAU_STALL, OMEGA_NL),
-          stiffness=5.0 if mode != "voltage" else 0.0,
-          damping=0.5 if mode != "voltage" else 0.0,
-          voltage_limit=24.0 if mode != "voltage" else 0.0,
+          motor_params=DATASHEET,
+          stiffness=5.0 if mode != DcMotorInputMode.VOLTAGE else 0.0,
+          damping=0.5 if mode != DcMotorInputMode.VOLTAGE else 0.0,
+          voltage_limit=24.0 if mode != DcMotorInputMode.VOLTAGE else 0.0,
           effort_limit=50.0,
         ),
       )
@@ -569,9 +575,9 @@ def test_dr_pd_gains_position_mode(
 
 
 def test_dr_pd_gains_voltage_mode_rejected(device):
-  env = _scene_env(device, mode="voltage")
+  env = _scene_env(device, mode=DcMotorInputMode.VOLTAGE)
   env.sim.expand_model_fields(("actuator_gainprm", "actuator_biasprm"))
-  with pytest.raises(ValueError, match="voltage"):
+  with pytest.raises(ValueError, match="VOLTAGE"):
     dr.pd_gains(
       env,
       env_ids=torch.tensor([0], device=device),


### PR DESCRIPTION
Adds `BuiltinDcMotorActuator`, which wraps the newly introduced antive MuJoCo [`<dcmotor>`](https://mujoco.readthedocs.io/en/stable/XMLreference.html#actuator-dcmotor) actuator.