### PR TITLE
Carry reset-only log keys forward so rsl_rl keeps logging them

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -119,6 +119,12 @@ Changed
 Fixed
 ^^^^^
 
+- Fixed ``Episode_Reward/*``, ``Episode_Metrics/*``, ``Curriculum/*``, and
+  ``Episode_Termination/*`` log keys disappearing from the training output
+  after :issue:`957` was fixed. ``rsl_rl``'s logger derives its key set from
+  the first rollout step, which typically has no resets; ``RslRlVecEnvWrapper``
+  now maintains a log cache seeded from the initial reset so all keys are
+  present from step 0.
 - Removed use of deprecated ``warp-lang`` symbols (``wp.context.runtime``
   and ``wp.context.Device``) that were dropped in newer ``warp-lang``
   releases, causing ``AttributeError: module 'warp' has no attribute

--- a/src/mjlab/rl/vecenv_wrapper.py
+++ b/src/mjlab/rl/vecenv_wrapper.py
@@ -23,6 +23,9 @@ class RslRlVecEnvWrapper(VecEnv):
 
     # Reset at the start since rsl_rl does not call reset.
     self.env.reset()
+    # Cache from the initial reset the key set from first rollout so step() can
+    # carry those keys forward and they keep getting logged.
+    self._log_cache: dict = dict(self.unwrapped.extras.get("log", {}))
 
   @property
   def cfg(self) -> ManagerBasedRlEnvCfg:
@@ -75,6 +78,9 @@ class RslRlVecEnvWrapper(VecEnv):
     if self.clip_actions is not None:
       actions = torch.clamp(actions, -self.clip_actions, self.clip_actions)
     obs_dict, rew, terminated, truncated, extras = self.env.step(actions)
+    if "log" in extras:
+      self._log_cache.update(extras["log"])
+      extras["log"] = dict(self._log_cache)
     term_or_trunc = terminated | truncated
     assert isinstance(rew, torch.Tensor)
     assert isinstance(term_or_trunc, torch.Tensor)

--- a/tests/test_vecenv_wrapper.py
+++ b/tests/test_vecenv_wrapper.py
@@ -1,0 +1,95 @@
+"""Tests for RslRlVecEnvWrapper."""
+
+import mujoco
+import pytest
+import torch
+from conftest import get_test_device
+
+from mjlab.actuator import XmlActuatorCfg
+from mjlab.entity import EntityArticulationInfoCfg, EntityCfg
+from mjlab.envs import ManagerBasedRlEnv, ManagerBasedRlEnvCfg, mdp
+from mjlab.managers.observation_manager import ObservationGroupCfg, ObservationTermCfg
+from mjlab.managers.reward_manager import RewardTermCfg
+from mjlab.rl import RslRlVecEnvWrapper
+from mjlab.scene import SceneCfg
+from mjlab.sim import MujocoCfg, SimulationCfg
+from mjlab.terrains import TerrainEntityCfg
+
+
+@pytest.fixture
+def env():
+  robot_xml = """
+  <mujoco>
+    <worldbody>
+      <body name="base" pos="0 0 1">
+        <freejoint name="free_joint"/>
+        <geom name="base_geom" type="box" size="0.2 0.2 0.1" mass="1.0"/>
+        <body name="link1" pos="0 0 0">
+          <joint name="joint1" type="hinge" axis="0 0 1" range="-1.57 1.57"/>
+          <geom name="link1_geom" type="box" size="0.1 0.1 0.1" mass="0.1"/>
+        </body>
+      </body>
+    </worldbody>
+    <actuator>
+      <motor name="actuator1" joint="joint1" gear="1.0"/>
+    </actuator>
+  </mujoco>
+  """
+  robot_cfg = EntityCfg(
+    spec_fn=lambda: mujoco.MjSpec.from_string(robot_xml),
+    articulation=EntityArticulationInfoCfg(
+      actuators=(XmlActuatorCfg(target_names_expr=(".*",)),)
+    ),
+  )
+
+  env_cfg = ManagerBasedRlEnvCfg(
+    scene=SceneCfg(
+      terrain=TerrainEntityCfg(terrain_type="plane"),
+      num_envs=2,
+      extent=1.0,
+      entities={"robot": robot_cfg},
+    ),
+    observations={
+      "actor": ObservationGroupCfg(
+        terms={
+          "joint_pos": ObservationTermCfg(
+            func=lambda env: env.scene["robot"].data.joint_pos
+          ),
+        },
+      ),
+    },
+    actions={
+      "joint_pos": mdp.JointPositionActionCfg(
+        entity_name="robot", actuator_names=(".*",), scale=1.0
+      )
+    },
+    # Episode-level reward metric written only on reset, never during compute().
+    rewards={
+      "const": RewardTermCfg(
+        func=lambda env: torch.ones(env.num_envs, device=env.device), weight=1.0
+      )
+    },
+    sim=SimulationCfg(mujoco=MujocoCfg(timestep=0.01, iterations=1)),
+    decimation=1,
+    # Long episode with no terminations so the first step never resets.
+    episode_length_s=100.0,
+  )
+
+  env = ManagerBasedRlEnv(cfg=env_cfg, device=get_test_device())
+  yield env
+  env.close()
+
+
+def test_reset_only_log_keys_survive_nonreset_steps(env):
+  """Keys written only on reset must keep appearing on non-reset steps.
+
+  rsl_rl's logger derives its key set from the first rollout step, which
+  typically has no resets. The wrapper caches the initial reset's keys and
+  carries them forward so they remain in ``extras["log"]`` on every step.
+  """
+  wrapper = RslRlVecEnvWrapper(env)
+  actions = torch.zeros(wrapper.num_envs, wrapper.num_actions, device=wrapper.device)
+  _, _, dones, extras = wrapper.step(actions)
+
+  assert not dones.any(), "test assumes no reset on the first step"
+  assert "Episode_Reward/const" in extras["log"]

--- a/tests/test_vecenv_wrapper.py
+++ b/tests/test_vecenv_wrapper.py
@@ -90,6 +90,7 @@ def test_reset_only_log_keys_survive_nonreset_steps(env):
   wrapper = RslRlVecEnvWrapper(env)
   actions = torch.zeros(wrapper.num_envs, wrapper.num_actions, device=wrapper.device)
   _, _, dones, extras = wrapper.step(actions)
+  assert "Episode_Reward/const" in wrapper._log_cache
 
   assert not dones.any(), "test assumes no reset on the first step"
   assert "Episode_Reward/const" in extras["log"]


### PR DESCRIPTION
After the changes introduced in the PR: https://github.com/mujocolab/mjlab/pull/960, the rollout logs printed by the train are diminished quite a lot. This PR addresses the issue by adding a regression test and also the appropriate fix.

**Prior to #960 change:**
```

################################################################################
                           Learning iteration 1/30000                            

                            Total steps: 48 
                       Steps per second: 94 
                        Collection time: 0.194s 
                          Learning time: 0.061s 
                        Mean value loss: 1.7166
                    Mean surrogate loss: -0.0369
                      Mean entropy loss: 41.1550
                        Mean action std: 1.00
   Episode_Reward/track_linear_velocity: 0.0000
  Episode_Reward/track_angular_velocity: 0.0000
                 Episode_Reward/upright: 0.0000
                    Episode_Reward/pose: 0.0000
            Episode_Reward/body_ang_vel: 0.0000
        Episode_Reward/angular_momentum: 0.0000
          Episode_Reward/dof_pos_limits: 0.0000
          Episode_Reward/action_rate_l2: 0.0000
                Episode_Reward/air_time: 0.0000
          Episode_Reward/foot_clearance: 0.0000
       Episode_Reward/foot_swing_height: 0.0000
               Episode_Reward/foot_slip: 0.0000
            Episode_Reward/soft_landing: 0.0000
         Episode_Reward/self_collisions: 0.0000
        Episode_Metrics/mean_action_acc: 0.0000
   Curriculum/command_vel/lin_vel_x_min: -1.0000
   Curriculum/command_vel/lin_vel_x_max: 1.0000
   Curriculum/command_vel/lin_vel_y_min: -1.0000
   Curriculum/command_vel/lin_vel_y_max: 1.0000
   Curriculum/command_vel/ang_vel_z_min: -0.5000
   Curriculum/command_vel/ang_vel_z_max: 0.5000
             Metrics/twist/error_vel_xy: 0.0000
            Metrics/twist/error_vel_yaw: 0.0000
           Episode_Termination/time_out: 0.0000
          Episode_Termination/fell_over: 0.0000
          Metrics/angular_momentum_mean: 6.4334
               Metrics/peak_height_mean: 0.0000
             Metrics/slip_velocity_mean: 0.4838
             Metrics/landing_force_mean: 0.0000
--------------------------------------------------------------------------------
                         Iteration time: 0.26s
                           Time elapsed: 00:00:00
                                    ETA: 03:40:21

```

**After the #960 change:**
```

################################################################################
                           Learning iteration 0/30000                            

                            Total steps: 24 
                       Steps per second: 45 
                        Collection time: 0.408s 
                          Learning time: 0.123s 
                        Mean value loss: 0.5401
                    Mean surrogate loss: -0.0897
                      Mean entropy loss: 41.1523
                        Mean action std: 1.00
          Metrics/angular_momentum_mean: 1.4151
               Metrics/peak_height_mean: 0.0051
             Metrics/slip_velocity_mean: 0.4666
             Metrics/landing_force_mean: 129.7581
--------------------------------------------------------------------------------
                         Iteration time: 0.53s
                           Time elapsed: 00:00:00
                                    ETA: 04:25:17

```