### PR TITLE
Use mjviser 0.0.14 from PyPI instead of git pin

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -17,6 +17,7 @@ Changed
 ^^^^^^^
 
 - Bumped ``rsl-rl-lib`` from 5.2.0 to 5.4.0.
+- Switched ``mjviser`` from a pinned git commit to the PyPI ``0.0.14`` release.
 
 Version 1.4.0 (May 26, 2026)
 ----------------------------

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -17,7 +17,6 @@ Changed
 ^^^^^^^
 
 - Bumped ``rsl-rl-lib`` from 5.2.0 to 5.4.0.
-- Switched ``mjviser`` from a pinned git commit to the PyPI ``0.0.14`` release.
 
 Version 1.4.0 (May 26, 2026)
 ----------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,7 +142,6 @@ torch = [
 ]
 mujoco = { index = "mujoco" }
 mujoco-warp = { git = "https://github.com/google-deepmind/mujoco_warp", rev = "88b55fc2696960b927bc12584994bb8412b36558" }
-mjviser = { git = "https://github.com/mujocolab/mjviser", rev = "1bdfd6fe79066b847a5f430000fcfbb53ec31a6f" }
 
 [tool.ruff]
 src = ["src"]  # Helpful for recognizing first-party imports.

--- a/uv.lock
+++ b/uv.lock
@@ -1717,7 +1717,7 @@ docs = [
 requires-dist = [
     { name = "imageio-ffmpeg" },
     { name = "mediapy", specifier = ">=1.2.6" },
-    { name = "mjviser", git = "https://github.com/mujocolab/mjviser?rev=1bdfd6fe79066b847a5f430000fcfbb53ec31a6f" },
+    { name = "mjviser", specifier = ">=0.0.14" },
     { name = "mujoco", specifier = "~=3.8.0", index = "https://py.mujoco.org/" },
     { name = "mujoco-warp", git = "https://github.com/google-deepmind/mujoco_warp?rev=88b55fc2696960b927bc12584994bb8412b36558" },
     { name = "onnxscript", specifier = ">=0.5.4" },
@@ -1770,8 +1770,8 @@ docs = [
 
 [[package]]
 name = "mjviser"
-version = "0.0.13"
-source = { git = "https://github.com/mujocolab/mjviser?rev=1bdfd6fe79066b847a5f430000fcfbb53ec31a6f#1bdfd6fe79066b847a5f430000fcfbb53ec31a6f" }
+version = "0.0.14"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mujoco" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-5-mjlab-cpu' and extra == 'extra-5-mjlab-cu128')" },
@@ -1779,6 +1779,10 @@ dependencies = [
     { name = "pillow" },
     { name = "trimesh" },
     { name = "viser" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/e4/eef89b279fb1811b5f120a99ac9284c32ff2ca4fad5e6f5c93035f72ba9a/mjviser-0.0.14.tar.gz", hash = "sha256:ebde2203dab89959a13ae549b4d3e5e5cf9eb69de11a1a2fd759cbe8f8c641f3", size = 29576, upload-time = "2026-05-07T03:35:13.128Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/c2/4534d678ad1b3f7dee6fd83110112800287be21ba007d988abb9ddc8e0ac/mjviser-0.0.14-py3-none-any.whl", hash = "sha256:4b09f8e90506fc4a71d76fc628872147157947e9292428213ab78cfe137c9a26", size = 32296, upload-time = "2026-05-07T03:35:14.252Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
mjviser was pinned to a specific git commit in pyproject.toml. Now that 0.0.14 is published on PyPI and matches the lower bound we already declared, switch to the PyPI release so installs don't need to clone the repo and resolution is faster.