### PR TITLE
Make curriculum terrain difficulty deterministic.

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -17,6 +17,9 @@ Changed
 ^^^^^^^
 
 - Bumped ``rsl-rl-lib`` from 5.2.0 to 5.4.0.
+- Curriculum-mode terrain difficulty is now deterministic across rows
+  and reaches the configured ``difficulty_range`` endpoints
+  (:issue:`1027`).
 
 Fixed
 ^^^^^

--- a/docs/source/terrain.rst
+++ b/docs/source/terrain.rst
@@ -49,7 +49,6 @@ the geometry and how it scales with difficulty.
         terrain_generator=TerrainGeneratorCfg(
             size=(8.0, 8.0),
             num_rows=10,
-            num_cols=20,
             border_width=20.0,
             curriculum=True,
             sub_terrains={
@@ -70,10 +69,12 @@ the geometry and how it scales with difficulty.
         max_init_terrain_level=5,
     )
 
-The generator creates a ``num_rows x num_cols`` grid of patches. The
-``sub_terrains`` dictionary maps names to ``SubTerrainCfg`` instances,
-and each sub-terrain's ``proportion`` weight controls how many columns
-(curriculum mode) or sampling probability (random mode) it receives.
+The generator creates a grid of patches sized ``num_rows`` by either
+``num_cols`` (random mode) or ``len(sub_terrains)`` (curriculum mode,
+where ``num_cols`` is ignored). The ``sub_terrains`` dictionary maps
+names to ``SubTerrainCfg`` instances; each sub-terrain's ``proportion``
+controls robot spawning distribution across columns in curriculum mode,
+or per-patch sampling probability in random mode.
 
 
 Grid layout
@@ -82,30 +83,48 @@ Grid layout
 Two generation modes control how terrain types are distributed across
 the grid:
 
-**Curriculum mode** (``curriculum=True``). Columns are deterministically
-assigned to terrain types based on their ``proportion`` weights. A type
-with proportion 0.4 in a 20-column grid gets 8 columns. All patches in
-a column share the same terrain type, and difficulty increases from row 0
-(easiest) to row ``num_rows - 1`` (hardest). This structured layout is
-what enables the curriculum system to advance environments to harder rows
-as performance improves.
+**Curriculum mode** (``curriculum=True``). Each terrain type gets exactly
+one column; the generator uses ``len(sub_terrains)`` columns regardless of
+``num_cols``. All patches in a column share the same terrain type, and
+difficulty increases from row 0 (easiest) to row ``num_rows - 1``
+(hardest). The ``proportion`` field controls how robots are distributed
+across columns at spawn time, not column count. This structured layout
+is what enables the curriculum system to advance environments to harder
+rows as performance improves.
 
 **Random mode** (``curriculum=False``). Every patch independently samples
 a terrain type weighted by ``proportion`` and a difficulty from
-``difficulty_range``. This provides maximum variety but no structured
-difficulty progression.
+``difficulty_range``. ``num_cols`` is honored. This provides maximum
+variety but no structured difficulty progression.
 
 
 The difficulty parameter
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 Each sub-terrain's generation function receives a ``difficulty`` value
-in ``[0, 1]``. This value linearly interpolates the terrain's
-configurable ranges. For example, a ``BoxPyramidStairsTerrainCfg`` with
+that linearly interpolates the terrain's configurable ranges. For
+example, a ``BoxPyramidStairsTerrainCfg`` with
 ``step_height_range=(0.0, 0.2)`` produces flat ground at difficulty 0
-and 20 cm steps at difficulty 1. In curriculum mode, difficulty is
-determined by the row: row 0 gets the minimum, row ``num_rows - 1`` gets
-the maximum.
+and 20 cm steps at difficulty 1.
+
+In curriculum mode, difficulty is determined by the row:
+``difficulty = lower + (upper - lower) * row / max(num_rows - 1, 1)``,
+where ``(lower, upper) = difficulty_range``. Row 0 is exactly
+``lower``, row ``num_rows - 1`` is exactly ``upper``, and intermediate
+rows are evenly spaced between them. All columns in a given row share
+the same difficulty scalar; the visible variation across columns comes
+from each sub-terrain type generating different geometry at the same
+difficulty.
+
+.. note::
+
+   With ``num_rows=1`` and ``curriculum=True``, every patch is generated
+   at ``difficulty = lower`` (the easiest configured difficulty). Use
+   ``curriculum=False`` if you want a single grid of randomly sampled
+   difficulties instead.
+
+In random mode, difficulty is sampled uniformly from
+``difficulty_range`` independently for every patch.
 
 
 Sub-terrain types
@@ -244,17 +263,23 @@ and undulating ground that box geoms cannot represent.
 Preset configurations
 ---------------------
 
-mjlab ships two ready-made ``TerrainGeneratorCfg`` presets in
+mjlab ships three ready-made ``TerrainGeneratorCfg`` presets in
 ``mjlab.terrains.config``:
 
 ``ROUGH_TERRAINS_CFG``
-    A 10x20 grid with seven terrain types (flat, stairs, inverted
-    stairs, slopes, inverted slopes, random rough, waves). Designed for
-    locomotion training with a moderate difficulty range.
+    A 10x20 random-mode grid with seven terrain types (flat, stairs,
+    inverted stairs, slopes, inverted slopes, random rough, waves).
+    Designed for locomotion training with a moderate difficulty range.
+    Set ``curriculum=True`` via ``dataclasses.replace`` to use it as a
+    curriculum grid (one column per terrain type).
+
+``STAIRS_TERRAINS_CFG``
+    A 10-row curriculum grid focused on stair traversal: flat plus
+    three pyramid-stair variants of increasing difficulty.
 
 ``ALL_TERRAINS_CFG``
-    A 10x16 grid with all sixteen terrain types at equal proportion.
-    Useful for training on maximum terrain variety.
+    A 10-row random-mode grid covering all available terrain types at
+    equal proportion. Useful for training on maximum terrain variety.
 
 Both can be used directly or customized with ``dataclasses.replace()``:
 
@@ -285,9 +310,9 @@ The key concepts:
 - The built-in ``terrain_levels_vel`` curriculum term promotes
   environments that track commanded velocity well and demotes
   environments that fall or fail to make progress.
-- When an environment reaches the maximum row, it is randomly reassigned
-  to a lower row to prevent the policy from collapsing to a single
-  difficulty level.
+- When an environment is promoted past the hardest row, it is randomly
+  reassigned to any row in ``[0, num_rows)`` to prevent the policy from
+  collapsing to a single difficulty level.
 
 
 Flat patch detection

--- a/src/mjlab/terrains/primitive_terrains.py
+++ b/src/mjlab/terrains/primitive_terrains.py
@@ -106,7 +106,7 @@ class BoxPyramidStairsTerrainCfg(SubTerrainCfg):
     first_step_rgba = brand_ramp(_MUJOCO_BLUE, 0.0)
     border_rgba = darken_rgba(first_step_rgba, 0.85)
 
-    if self.border_width > 0.0 and not self.holes:
+    if self.border_width > 0.0 and not self.holes and step_height > 0.0:
       border_center = (0.5 * self.size[0], 0.5 * self.size[1], -step_height / 2)
       border_inner_size = (
         self.size[0] - 2 * self.border_width,
@@ -279,7 +279,7 @@ class BoxInvertedPyramidStairsTerrainCfg(BoxPyramidStairsTerrainCfg):
     first_step_rgba = brand_ramp(_MUJOCO_RED, 0.0)
     border_rgba = darken_rgba(first_step_rgba, 0.85)
 
-    if self.border_width > 0.0 and not self.holes:
+    if self.border_width > 0.0 and not self.holes and step_height > 0.0:
       border_center = (0.5 * self.size[0], 0.5 * self.size[1], -0.5 * step_height)
       border_inner_size = (
         self.size[0] - 2 * self.border_width,

--- a/src/mjlab/terrains/terrain_generator.py
+++ b/src/mjlab/terrains/terrain_generator.py
@@ -257,11 +257,11 @@ class TerrainGenerator:
     # One column per terrain type — proportion is only for spawning.
     sub_terrains_cfgs = list(self.cfg.sub_terrains.values())
 
+    lower, upper = self.cfg.difficulty_range
     for sub_col in range(self._num_cols):
       for sub_row in range(self.cfg.num_rows):
-        lower, upper = self.cfg.difficulty_range
-        difficulty = (sub_row + self.np_rng.uniform()) / self.cfg.num_rows
-        difficulty = lower + (upper - lower) * difficulty
+        t = sub_row / max(self.cfg.num_rows - 1, 1)
+        difficulty = lower + (upper - lower) * t
         world_position = self._get_sub_terrain_position(sub_row, sub_col)
         spawn_origin = self._create_terrain_geom(
           spec,


### PR DESCRIPTION
In #1027, Robin correctly pointed out that curriculum-mode terrain difficulty is randomly sampled within each row's bin, which makes the `difficulty_range` endpoints unreachable and makes `num_rows=1` behave randomly instead of as the easiest level.

This PR addresses that by replacing the sampling with a deterministic interpolation: `lower + (upper - lower) * row / max(num_rows - 1, 1)`, so row 0 hits the configured min, row N-1 hits the max, and `num_rows=1` produces the easiest difficulty.

It also fixes the doc inaccuracies Robin flagged, namely the inverted description of curriculum-mode column allocation (in #811 it became one column per terrain type, with `proportion` controlling robot spawning rather than column count).