### PR TITLE
Fix GPU selection crash with MIG devices

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -18,6 +18,11 @@ Changed
 
 - Bumped ``rsl-rl-lib`` from 5.2.0 to 5.4.0.
 
+Fixed
+^^^^^
+
+- Fixed ``select_gpus`` crashing when ``CUDA_VISIBLE_DEVICES`` contains MIG UUIDs instead of numeric indices.
+
 Version 1.4.0 (May 26, 2026)
 ----------------------------
 

--- a/src/mjlab/utils/gpu.py
+++ b/src/mjlab/utils/gpu.py
@@ -3,10 +3,12 @@
 import os
 from typing import Literal
 
+GpuId = int | str
+
 
 def select_gpus(
   gpu_ids: list[int] | Literal["all"] | None,
-) -> tuple[list[int] | None, int]:
+) -> tuple[list[GpuId] | None, int]:
   """Select GPUs based on CUDA_VISIBLE_DEVICES and user specification.
 
   This function treats the `gpu_ids` parameter as indices into the existing
@@ -19,7 +21,8 @@ def select_gpus(
 
   Returns:
     A tuple of (selected_gpu_ids, num_gpus) where:
-    - selected_gpu_ids: List of physical GPU IDs to use, or None for CPU mode
+    - selected_gpu_ids: List of physical GPU IDs (int for numeric, str for MIG
+      UUIDs), or None for CPU mode
     - num_gpus: Number of GPUs selected (0 for CPU mode)
 
   Examples:
@@ -50,8 +53,11 @@ def select_gpus(
 
   if existing_visible_devices is not None:
     # Parse existing CUDA_VISIBLE_DEVICES.
-    available_gpus = [
-      int(x.strip()) for x in existing_visible_devices.split(",") if x.strip()
+    # Use int for numeric IDs, keep as string for MIG UUIDs.
+    available_gpus: list[GpuId] = [
+      int(x.strip()) if x.strip().isdigit() else x.strip()
+      for x in existing_visible_devices.split(",")
+      if x.strip()
     ]
     # Empty CUDA_VISIBLE_DEVICES means CPU mode.
     if not available_gpus:
@@ -60,15 +66,16 @@ def select_gpus(
     # If not set, default to all available GPUs.
     import torch.cuda
 
-    available_gpus = list(range(torch.cuda.device_count()))
+    available_gpus: list[GpuId] = list(range(torch.cuda.device_count()))
 
   # Map gpu_ids indices to actual GPU IDs.
+  selected: list[GpuId]
   if gpu_ids == "all":
-    selected_gpus = available_gpus
+    selected = available_gpus
   else:
     # gpu_ids are indices into available_gpus.
-    selected_gpus = [available_gpus[i] for i in gpu_ids]
+    selected = [available_gpus[i] for i in gpu_ids]
 
-  num_gpus = len(selected_gpus)
+  num_gpus = len(selected)
 
-  return selected_gpus, num_gpus
+  return selected, num_gpus

--- a/tests/test_gpu_selection.py
+++ b/tests/test_gpu_selection.py
@@ -113,3 +113,16 @@ def test_select_gpus_cpu_mode_empty_cuda_visible_devices():
   selected, num = select_gpus([0])
   assert selected is None
   assert num == 0
+
+
+def test_select_gpus_mig_uuids():
+  """Handles MIG GPU UUIDs in CUDA_VISIBLE_DEVICES."""
+  os.environ["CUDA_VISIBLE_DEVICES"] = "MIG-GPU-abc-123,MIG-GPU-def-456"
+
+  selected, num = select_gpus("all")
+  assert selected == ["MIG-GPU-abc-123", "MIG-GPU-def-456"]
+  assert num == 2
+
+  selected, num = select_gpus([0])
+  assert selected == ["MIG-GPU-abc-123"]
+  assert num == 1


### PR DESCRIPTION
When NVIDIA MIG is enabled, `CUDA_VISIBLE_DEVICES` contains UUIDs like "MIG-GPU-abc-123" instead of numeric indices. The `int()` call in `select_gpus` would crash on these. This change parses numeric entries as int preserving existing behavior and passes non-numeric entries through as strings.
I also added a `GpuId = int | str` type alias to reflect this in the type system and a test covering MIG UUIDs.