### PR TITLE
Remove CUDA syncs from circular buffer

### DIFF
--- a/src/mjlab/utils/buffers/circular_buffer.py
+++ b/src/mjlab/utils/buffers/circular_buffer.py
@@ -209,8 +209,7 @@ class CircularBuffer:
 
     # Backfill entire history with first frame for newly initialized batches.
     is_first_push = self._num_pushes == 0
-    if torch.any(is_first_push):
-      self._buffer[:, is_first_push] = data[is_first_push]
+    torch.where(is_first_push[None, :, None], data[None, :, :], self._buffer, out=self._buffer)
 
     self._num_pushes += 1
 
@@ -235,9 +234,6 @@ class CircularBuffer:
 
     pushes = self._num_pushes.clamp_min(1)
     valid = torch.minimum(key, pushes - 1).clamp_min(0)
-
-    if torch.all(valid == 0):
-      return self._buffer[self._pointer]
 
     idx = torch.remainder(self._pointer - valid, self._max_len)
     return self._buffer[idx, self._all_indices]

--- a/src/mjlab/utils/buffers/circular_buffer.py
+++ b/src/mjlab/utils/buffers/circular_buffer.py
@@ -209,7 +209,9 @@ class CircularBuffer:
 
     # Backfill entire history with first frame for newly initialized batches.
     is_first_push = self._num_pushes == 0
-    torch.where(is_first_push[None, :, None], data[None, :, :], self._buffer, out=self._buffer)
+    torch.where(
+      is_first_push[None, :, None], data[None, :, :], self._buffer, out=self._buffer
+    )
 
     self._num_pushes += 1
 


### PR DESCRIPTION
I was doing some CUDA profiling of our RL environments and found some surprising CUDA syncs associated with actuator delays. I tracked them down to these two places in `circular_buffer.py`, in which the attempt to skip an unnecessary op actually slowed things down by forcing a CUDA sync. Note that I'm still pretty new to this; I'm just following https://docs.nvidia.com/dl-cuda-graph/torch-cuda-graph/sync-free-code.html

In our internal example, I got a ~3% speedup from this change, though I suspect the effect size will vary a lot based on whether the rest of the MDP is sync-free. 

@kevinzakka I'll try to run your benchmarks from https://github.com/mujocolab/mjlab/pull/1020