### PR TITLE
Set MUJOCO_GL default before mujoco import

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -60,6 +60,7 @@ Fixed
   threshold, where the stone grid re-tiled as its spacing crossed an integer
   boundary, and leaving an oversized gap around the center platform. The grid is
   now difficulty-independent and the platform snaps to it as a clean island.
+- Fixed ``train --video``, ``play``, and ``demo`` crashing with ``OpenGL platform library not loaded`` on headless hosts that don't pre-set ``MUJOCO_GL``. The default is now applied in ``mjlab/__init__.py`` so it takes effect before mujoco's GL backend selection runs.
 
 Version 1.4.0 (May 26, 2026)
 ----------------------------

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -60,7 +60,10 @@ Fixed
   threshold, where the stone grid re-tiled as its spacing crossed an integer
   boundary, and leaving an oversized gap around the center platform. The grid is
   now difficulty-independent and the platform snaps to it as a clean island.
-- Fixed ``train --video``, ``play``, and ``demo`` crashing with ``OpenGL platform library not loaded`` on headless hosts that don't pre-set ``MUJOCO_GL``. The default is now applied in ``mjlab/__init__.py`` so it takes effect before mujoco's GL backend selection runs.
+- Fixed ``train --video``, ``play``, and ``demo`` crashing with ``OpenGL
+  platform library not loaded`` on headless Linux hosts that don't pre-set
+  ``MUJOCO_GL``. The default is now applied in ``mjlab/__init__.py`` (Linux
+  only) so it takes effect before mujoco's GL backend selection runs.
 
 Version 1.4.0 (May 26, 2026)
 ----------------------------

--- a/src/mjlab/__init__.py
+++ b/src/mjlab/__init__.py
@@ -1,4 +1,10 @@
 import os
+
+# Default to EGL for GPU-accelerated offscreen rendering. Must be set before
+# any mujoco import: mujoco's gl_context module captures MUJOCO_GL once at load
+# time. Override with e.g. MUJOCO_GL=osmesa on clusters without EGL.
+os.environ.setdefault("MUJOCO_GL", "egl")
+
 import sys
 import traceback
 from importlib.metadata import entry_points

--- a/src/mjlab/__init__.py
+++ b/src/mjlab/__init__.py
@@ -1,11 +1,15 @@
 import os
-
-# Default to EGL for GPU-accelerated offscreen rendering. Must be set before
-# any mujoco import: mujoco's gl_context module captures MUJOCO_GL once at load
-# time. Override with e.g. MUJOCO_GL=osmesa on clusters without EGL.
-os.environ.setdefault("MUJOCO_GL", "egl")
-
 import sys
+
+# Default to EGL for GPU-accelerated offscreen rendering on Linux. Must be set
+# before any mujoco import: mujoco's gl_context module captures MUJOCO_GL once
+# at load time. Override with e.g. MUJOCO_GL=osmesa on clusters without EGL.
+# Linux-only because mujoco's gl_context rejects "egl" on macOS/Windows and
+# raises at import. On those platforms we leave MUJOCO_GL alone so mujoco
+# defaults to GLFW.
+if sys.platform.startswith("linux"):
+  os.environ.setdefault("MUJOCO_GL", "egl")
+
 import traceback
 from importlib.metadata import entry_points
 from pathlib import Path

--- a/src/mjlab/scripts/train.py
+++ b/src/mjlab/scripts/train.py
@@ -197,7 +197,6 @@ def launch_training(task_id: str, args: TrainConfig | None = None):
     os.environ["CUDA_VISIBLE_DEVICES"] = ""
   else:
     os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(map(str, selected_gpus))
-  os.environ["MUJOCO_GL"] = "egl"
 
   if num_gpus <= 1:
     # CPU or single GPU: run directly without torchrunx.


### PR DESCRIPTION
mjlab was setting `MUJOCO_GL=egl` inside `launch_training` in `src/mjlab/scripts/train.py`, but the top-level imports there had already pulled in `mujoco.rendering.classic.gl_context`, which reads `MUJOCO_GL` once at import time. By then mujoco had picked its GL backend against an empty value and never `dlopen`'d a platform library, so `train --video True` crashed with `mujoco.FatalError: an OpenGL platform library has not been loaded` on hosts where `MUJOCO_GL` wasn't set in the shell. `play` and `demo` share the same import chain and hit the same crash whenever they render.

This moves the default into `src/mjlab/__init__.py` ahead of any other import in the package, so the env var is set before any code that might pull in mujoco. That fixes all three entry points in one place and also covers library users who never go through the CLI scripts.

`setdefault` (not plain assignment) preserves user overrides like `MUJOCO_GL=osmesa` for clusters without EGL. Verified on a headless H100 container: `unset MUJOCO_GL && uv run train Mjlab-Cartpole-Balance --video True ...` finishes and uploads videos to W&B, and `MUJOCO_GL=osmesa python -c 'import mjlab'` keeps `osmesa` set.
