### PR TITLE
Fix terrain generation bugs and rework heightfield coloring

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -12,6 +12,10 @@ Added
   Supports voltage / position / velocity input modes with back-EMF,
   configurable motor constants, and optional integral, slew, inductance,
   thermal, LuGre, and cogging extensions.
+- Added ``scale_with_difficulty`` to ``HfRandomUniformTerrainCfg``. When
+  enabled, the noise amplitude scales with difficulty (flat at 0, full
+  ``noise_range`` at 1) so the terrain progresses in a curriculum. Defaults to
+  ``False``, preserving the previous difficulty-independent behavior.
 
 Changed
 ^^^^^^^
@@ -20,11 +24,42 @@ Changed
 - Curriculum-mode terrain difficulty is now deterministic across rows
   and reaches the configured ``difficulty_range`` endpoints
   (:issue:`1027`).
+- Heightfield terrains now color by absolute height with a diverging palette
+  (cool below the ground plane, green at ground level, warm above) on a fixed
+  scale, replacing the per-patch normalization. Color is now consistent across
+  terrains, and low-amplitude terrain such as ``random_rough`` reads as gently
+  tinted ground instead of high-contrast noise.
+- ``BoxNestedRingsTerrainCfg`` now builds uniform-height concentric ridges
+  whose separating gaps widen with difficulty, replacing the random per-ring
+  heights. Rings are colored by height (like the other terrains) and the outer
+  border matches the ring height.
+- Terrain generation no longer prints timing information to stdout.
 
 Fixed
 ^^^^^
 
 - Fixed ``select_gpus`` crashing when ``CUDA_VISIBLE_DEVICES`` contains MIG UUIDs instead of numeric indices.
+- Fixed pyramid-stairs terrains (``BoxPyramidStairsTerrainCfg``,
+  ``BoxInvertedPyramidStairsTerrainCfg``, and ``BoxOpenStairsTerrainCfg``)
+  leaving an empty, geometry-free border at difficulty 0, where the step
+  height collapses to zero. The flat border frame is now always generated as
+  solid geometry flush with the ground (:issue:`1033`).
+- Fixed ``HfPerlinNoiseTerrainCfg`` failing to compile at difficulty 0, where
+  the target height collapses to zero and MuJoCo rejects the non-positive
+  heightfield size.
+- Fixed ``BoxRandomGridTerrainCfg`` producing NaN colors (and failing to build)
+  at difficulty 0, where the grid height is zero and the color normalization
+  divided by zero.
+- Fixed the center platform z-fighting with surrounding geometry in
+  ``BoxRandomGridTerrainCfg`` (grid cells were left underneath the platform) and
+  ``BoxRandomSpreadTerrainCfg`` (the platform duplicated the floor surface).
+- Fixed ``BoxNarrowBeamsTerrainCfg`` square platform corners protruding between
+  the beams at high difficulty; the platform now shrinks to stay within the
+  beams' angular coverage.
+- Fixed ``BoxSteppingStonesTerrainCfg`` reconfiguring abruptly at a difficulty
+  threshold, where the stone grid re-tiled as its spacing crossed an integer
+  boundary, and leaving an oversized gap around the center platform. The grid is
+  now difficulty-independent and the platform snaps to it as a clean island.
 
 Version 1.4.0 (May 26, 2026)
 ----------------------------

--- a/scripts/tools/terrain_explorer.py
+++ b/scripts/tools/terrain_explorer.py
@@ -1,0 +1,115 @@
+"""Interactive single-patch terrain explorer (Viser + MuJoCo MjSpec).
+
+Run with:
+  uv run python scripts/tools/terrain_explorer.py
+  uv run python scripts/tools/terrain_explorer.py --port 8081
+
+Then open the printed URL (default http://localhost:8080).
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+
+import mujoco
+import numpy as np
+import viser
+from mjviser.conversions import merge_geoms
+
+from mjlab.terrains.config import ALL_TERRAIN_PRESETS
+from mjlab.terrains.terrain_generator import TerrainGenerator, TerrainGeneratorCfg
+
+PATCH_SIZE = (8.0, 8.0)
+
+
+# Per-preset overrides applied when building in the explorer (e.g. to surface
+# difficulty-driven behavior that is off by default).
+_PRESET_OVERRIDES: dict[str, dict] = {
+  "random_rough": {"scale_with_difficulty": True},
+}
+
+
+def _build_terrain_mesh(preset_name: str, difficulty: float, seed: int):
+  """Generate a single terrain patch and return a merged trimesh (or raise)."""
+  preset_fn = ALL_TERRAIN_PRESETS[preset_name]
+  overrides = _PRESET_OVERRIDES.get(preset_name, {})
+  generator_cfg = TerrainGeneratorCfg(
+    seed=seed,
+    size=PATCH_SIZE,
+    num_rows=1,
+    num_cols=1,
+    border_width=0.0,
+    curriculum=False,
+    # A degenerate range pins the single patch to exactly this difficulty.
+    difficulty_range=(difficulty, difficulty),
+    color_scheme="height",
+    sub_terrains={preset_name: preset_fn(proportion=1.0, **overrides)},
+  )
+  generator = TerrainGenerator(generator_cfg)
+  spec = mujoco.MjSpec()
+  generator.compile(spec)
+  model = spec.compile()
+
+  terrain_body_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, "terrain")
+  geom_ids = [i for i in range(model.ngeom) if model.geom_bodyid[i] == terrain_body_id]
+  return merge_geoms(model, geom_ids)
+
+
+def main() -> None:
+  parser = argparse.ArgumentParser(description=__doc__)
+  parser.add_argument(
+    "--port", type=int, default=8080, help="Port for the viser server."
+  )
+  args = parser.parse_args()
+
+  server = viser.ViserServer(port=args.port)
+  preset_names = sorted(ALL_TERRAIN_PRESETS)
+
+  terrain_dropdown = server.gui.add_dropdown(
+    "Terrain", options=preset_names, initial_value=preset_names[0]
+  )
+  difficulty_slider = server.gui.add_slider(
+    "Difficulty", min=0.0, max=1.0, step=0.01, initial_value=0.0
+  )
+  seed_input = server.gui.add_number("Seed", initial_value=42, step=1)
+  status = server.gui.add_markdown("**Status:** ready")
+
+  handle: viser.SceneNodeHandle | None = None
+
+  def update() -> None:
+    nonlocal handle
+    name = terrain_dropdown.value
+    difficulty = float(difficulty_slider.value)
+    seed = int(seed_input.value)
+    status.content = f"**Status:** building `{name}` at difficulty {difficulty:.2f}..."
+    try:
+      mesh = _build_terrain_mesh(name, difficulty, seed)
+    except Exception as e:  # noqa: BLE001 - surface any generation failure in the UI.
+      status.content = f"**Error:** {type(e).__name__}: {e}"
+      print(f"Failed to build {name} at difficulty {difficulty}: {e}")
+      return
+    if handle is not None:
+      handle.remove()
+    handle = server.scene.add_mesh_trimesh("/terrain", mesh)
+    status.content = (
+      f"**Loaded** `{name}` at difficulty {difficulty:.2f} ({len(mesh.faces):,} faces)"
+    )
+
+  terrain_dropdown.on_update(lambda _: update())
+  difficulty_slider.on_update(lambda _: update())
+  seed_input.on_update(lambda _: update())
+
+  # Top-down-ish initial camera.
+  @server.on_client_connect
+  def _(client: viser.ClientHandle) -> None:
+    client.camera.position = np.array([10.0, 10.0, 8.0])
+    client.camera.look_at = np.array([0.0, 0.0, 0.0])
+
+  update()
+  while True:
+    time.sleep(1.0)
+
+
+if __name__ == "__main__":
+  main()

--- a/src/mjlab/terrains/heightfield_terrains.py
+++ b/src/mjlab/terrains/heightfield_terrains.py
@@ -24,14 +24,32 @@ from mjlab.terrains.terrain_generator import (
 )
 from mjlab.terrains.utils import find_flat_patches_from_heightfield
 
+# Smallest positive hfield elevation/base size, in meters. MuJoCo rejects
+# non-positive hfield sizes, so flat heightfields (difficulty 0) are clamped to
+# this instead of zero.
+_MIN_HFIELD_HEIGHT = 1e-3
+
+# Physical height (meters) that maps to full color saturation. Heights are
+# colored on this fixed absolute scale rather than normalized per patch, so a
+# given height reads the same color across every terrain and small-amplitude
+# terrain stays gently tinted instead of stretching into rainbow noise.
+_COLOR_SCALE = 0.75
+
 
 def color_by_height(
   spec: mujoco.MjSpec,
   noise: np.ndarray,
   unique_id: str,
-  normalized_elevation: np.ndarray,
+  physical_heights: np.ndarray,
   texture_size: int = 128,
 ) -> str:
+  """Build a height-colored texture for a heightfield.
+
+  Diverging colormap anchored at the ground plane (z=0): cool blue below ground,
+  green at z=0, warm red above. ``physical_heights`` is the surface height of
+  each cell in meters relative to z=0; it is colored on the fixed ``_COLOR_SCALE``
+  so color encodes absolute height consistently across all terrains.
+  """
   texture_name = f"hf_texture_{unique_id}"
   texture = spec.add_texture(
     name=texture_name,
@@ -40,16 +58,20 @@ def color_by_height(
     height=texture_size,
   )
 
-  texture_elevation = ndimage.zoom(
-    normalized_elevation,
+  texture_height = ndimage.zoom(
+    physical_heights,
     (texture_size / noise.shape[0], texture_size / noise.shape[1]),
     order=1,
   )
-  texture_elevation = np.asarray(texture_elevation)
+  texture_height = np.asarray(texture_height)
 
-  hue = 0.5 - texture_elevation * 0.45
-  saturation = 0.6 - texture_elevation * 0.2
-  value = 0.4 + texture_elevation * 0.3
+  # Signed deviation from the ground plane in [-1, 1] on a fixed absolute scale.
+  signed = np.clip(texture_height / _COLOR_SCALE, -1.0, 1.0)
+
+  # signed=+1 -> hue 0.0 (red, high), 0 -> 0.33 (green, ground), -1 -> 0.66 (blue, low).
+  hue = 0.33 - 0.33 * signed
+  saturation = 0.45 + 0.25 * np.abs(signed)
+  value = 0.45 + 0.25 * np.abs(signed)
 
   c = value * saturation
   x = c * (1 - np.abs((hue * 6) % 2 - 1))
@@ -326,7 +348,8 @@ class HfPyramidSlopedTerrainCfg(SubTerrainCfg):
     else:
       hfield_z_offset = 0
 
-    material_name = color_by_height(spec, noise, unique_id, normalized_elevation)
+    physical_heights = hfield_z_offset + normalized_elevation * max_physical_height
+    material_name = color_by_height(spec, noise, unique_id, physical_heights)
 
     hfield_geom = body.add_geom(
       type=mujoco.mjtGeom.mjGEOM_HFIELD,
@@ -378,13 +401,23 @@ class HfRandomUniformTerrainCfg(SubTerrainCfg):
   border_width: float = 0.0
   """Width of the flat border around the terrain edges, in meters. Must be >=
   horizontal_scale if non-zero."""
+  scale_with_difficulty: bool = False
+  """If False (default), the roughness is fixed and ``difficulty`` is ignored,
+  matching upstream behavior. If True, the noise amplitude scales linearly with
+  difficulty (flat at 0, full ``noise_range`` at 1) so the terrain progresses in
+  a curriculum."""
 
   def function(
     self, difficulty: float, spec: mujoco.MjSpec, rng: np.random.Generator
   ) -> TerrainOutput:
-    del difficulty  # Unused.
-
     body = spec.body("terrain")
+
+    # When difficulty scaling is enabled, ramp the noise amplitude from flat (0)
+    # to the full configured range (1). Otherwise use the full range regardless
+    # of difficulty (difficulty is ignored).
+    scale = difficulty if self.scale_with_difficulty else 1.0
+    noise_lo = self.noise_range[0] * scale
+    noise_hi = self.noise_range[1] * scale
 
     if self.border_width > 0 and self.border_width < self.horizontal_scale:
       raise ValueError(
@@ -419,8 +452,8 @@ class HfRandomUniformTerrainCfg(SubTerrainCfg):
       width_downsampled = int(inner_size[0] / downsampled_scale)
       length_downsampled = int(inner_size[1] / downsampled_scale)
 
-      height_min = int(self.noise_range[0] / self.vertical_scale)
-      height_max = int(self.noise_range[1] / self.vertical_scale)
+      height_min = int(noise_lo / self.vertical_scale)
+      height_max = int(noise_hi / self.vertical_scale)
       height_step = int(self.noise_step / self.vertical_scale)
 
       height_range = np.arange(height_min, height_max + height_step, height_step)
@@ -443,8 +476,8 @@ class HfRandomUniformTerrainCfg(SubTerrainCfg):
     else:
       width_downsampled = int(self.size[0] / downsampled_scale)
       length_downsampled = int(self.size[1] / downsampled_scale)
-      height_min = int(self.noise_range[0] / self.vertical_scale)
-      height_max = int(self.noise_range[1] / self.vertical_scale)
+      height_min = int(noise_lo / self.vertical_scale)
+      height_max = int(noise_hi / self.vertical_scale)
       height_step = int(self.noise_step / self.vertical_scale)
 
       height_range = np.arange(height_min, height_max + height_step, height_step)
@@ -489,7 +522,8 @@ class HfRandomUniformTerrainCfg(SubTerrainCfg):
       userdata=normalized_elevation.flatten().astype(np.float32).tolist(),
     )
 
-    material_name = color_by_height(spec, noise, unique_id, normalized_elevation)
+    physical_heights = normalized_elevation * max_physical_height
+    material_name = color_by_height(spec, noise, unique_id, physical_heights)
 
     hfield_geom = body.add_geom(
       type=mujoco.mjtGeom.mjGEOM_HFIELD,
@@ -498,7 +532,7 @@ class HfRandomUniformTerrainCfg(SubTerrainCfg):
       material=material_name,
     )
 
-    spawn_height = (self.noise_range[0] + self.noise_range[1]) / 2
+    spawn_height = (noise_lo + noise_hi) / 2
     origin = np.array([self.size[0] / 2, self.size[1] / 2, spawn_height])
 
     flat_patches = _compute_flat_patches(
@@ -616,7 +650,11 @@ class HfWaveTerrainCfg(SubTerrainCfg):
       userdata=normalized_elevation.flatten().astype(np.float32).tolist(),
     )
 
-    material_name = color_by_height(spec, noise, unique_id, normalized_elevation)
+    # The wave oscillates around z=0 (geom is offset down by half the range).
+    physical_heights = (
+      normalized_elevation * max_physical_height - max_physical_height / 2
+    )
+    material_name = color_by_height(spec, noise, unique_id, physical_heights)
 
     hfield_geom = body.add_geom(
       type=mujoco.mjtGeom.mjGEOM_HFIELD,
@@ -783,7 +821,9 @@ class HfDiscreteObstaclesTerrainCfg(SubTerrainCfg):
     else:
       hfield_z_offset = 0
 
-    material_name = color_by_height(spec, noise, unique_id, normalized_elevation)
+    # Physical surface height per cell (pits negative, bumps positive about z=0).
+    physical_heights = hfield_z_offset + normalized_elevation * max_physical_height
+    material_name = color_by_height(spec, noise, unique_id, physical_heights)
 
     hfield_geom = body.add_geom(
       type=mujoco.mjtGeom.mjGEOM_HFIELD,
@@ -887,8 +927,13 @@ class HfPerlinNoiseTerrainCfg(SubTerrainCfg):
       noise_range = noise_max - noise_min if noise_max > noise_min else 1.0
       normalized_elevation = ((noise_raw - noise_min) / noise_range).astype(np.float32)
 
-    max_physical_height = target_height
-    base_thickness = max_physical_height * self.base_thickness_ratio
+    # MuJoCo requires positive hfield elevation and base sizes. At difficulty 0
+    # (target_height == 0) the surface is flat; clamp to a small positive height
+    # so compilation does not fail with "size parameter is not positive".
+    max_physical_height = max(target_height, _MIN_HFIELD_HEIGHT)
+    base_thickness = max(
+      max_physical_height * self.base_thickness_ratio, _MIN_HFIELD_HEIGHT
+    )
 
     unique_id = uuid.uuid4().hex
     field = spec.add_hfield(
@@ -904,8 +949,9 @@ class HfPerlinNoiseTerrainCfg(SubTerrainCfg):
       userdata=normalized_elevation.flatten().tolist(),
     )
 
+    physical_heights = normalized_elevation * max_physical_height
     material_name = color_by_height(
-      spec, normalized_elevation, unique_id, normalized_elevation
+      spec, normalized_elevation, unique_id, physical_heights
     )
 
     hfield_geom = body.add_geom(

--- a/src/mjlab/terrains/primitive_terrains.py
+++ b/src/mjlab/terrains/primitive_terrains.py
@@ -11,7 +11,6 @@ References:
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Tuple
 
 import mujoco
 import numpy as np
@@ -23,30 +22,19 @@ from mjlab.terrains.terrain_generator import (
 )
 from mjlab.terrains.utils import make_border, make_plane
 from mjlab.utils.color import (
-  HSV,
   brand_ramp,
-  clamp,
   darken_rgba,
-  hsv_to_rgb,
-  rgb_to_hsv,
 )
 
 _MUJOCO_BLUE = (0.20, 0.45, 0.95)
 _MUJOCO_RED = (0.90, 0.30, 0.30)
 _MUJOCO_GREEN = (0.25, 0.80, 0.45)
 
-
-def _get_platform_color(
-  base_rgb: Tuple[float, float, float],
-  desaturation_factor: float = 0.4,
-  lightening_factor: float = 0.25,
-) -> Tuple[float, float, float, float]:
-  hsv = rgb_to_hsv(base_rgb)
-  new_s = hsv.s * desaturation_factor
-  new_v = clamp(hsv.v + lightening_factor)
-  new_hsv = HSV(hsv.h, new_s, new_v)
-  r, g, b = hsv_to_rgb(new_hsv)
-  return (r, g, b, 1.0)
+# Minimum vertical extent of a flat border frame, in meters. The border top sits
+# flush at z=0 and extends downward, so this depth is not visible from above; it
+# only guarantees the frame is solid (never a degenerate zero-height geom) when
+# the step height collapses to zero at difficulty 0.
+_MIN_BORDER_HEIGHT = 0.05
 
 
 @dataclass(kw_only=True)
@@ -106,14 +94,19 @@ class BoxPyramidStairsTerrainCfg(SubTerrainCfg):
     first_step_rgba = brand_ramp(_MUJOCO_BLUE, 0.0)
     border_rgba = darken_rgba(first_step_rgba, 0.85)
 
-    if self.border_width > 0.0 and not self.holes and step_height > 0.0:
-      border_center = (0.5 * self.size[0], 0.5 * self.size[1], -step_height / 2)
+    if self.border_width > 0.0 and not self.holes:
+      # Decouple the border's vertical extent from step_height so difficulty 0
+      # (step_height == 0) still produces a solid, gap-free frame instead of
+      # being skipped or generating degenerate zero-height geoms. The top stays
+      # flush with the ground at z=0.
+      border_height = max(step_height, _MIN_BORDER_HEIGHT)
+      border_center = (0.5 * self.size[0], 0.5 * self.size[1], -border_height / 2)
       border_inner_size = (
         self.size[0] - 2 * self.border_width,
         self.size[1] - 2 * self.border_width,
       )
       border_boxes = make_border(
-        body, self.size, border_inner_size, step_height, border_center
+        body, self.size, border_inner_size, border_height, border_center
       )
       boxes.extend(border_boxes)
       for _ in range(len(border_boxes)):
@@ -279,14 +272,17 @@ class BoxInvertedPyramidStairsTerrainCfg(BoxPyramidStairsTerrainCfg):
     first_step_rgba = brand_ramp(_MUJOCO_RED, 0.0)
     border_rgba = darken_rgba(first_step_rgba, 0.85)
 
-    if self.border_width > 0.0 and not self.holes and step_height > 0.0:
-      border_center = (0.5 * self.size[0], 0.5 * self.size[1], -0.5 * step_height)
+    if self.border_width > 0.0 and not self.holes:
+      # See BoxPyramidStairsTerrainCfg: keep the border solid and flush at z=0
+      # even when step_height collapses to 0 at difficulty 0.
+      border_height = max(step_height, _MIN_BORDER_HEIGHT)
+      border_center = (0.5 * self.size[0], 0.5 * self.size[1], -0.5 * border_height)
       border_inner_size = (
         self.size[0] - 2 * self.border_width,
         self.size[1] - 2 * self.border_width,
       )
       border_boxes = make_border(
-        body, self.size, border_inner_size, step_height, border_center
+        body, self.size, border_inner_size, border_height, border_center
       )
       boxes.extend(border_boxes)
       for _ in range(len(border_boxes)):
@@ -546,8 +542,7 @@ class BoxRandomGridTerrainCfg(SubTerrainCfg):
       pos=(self.size[0] / 2, self.size[1] / 2, platform_center_z),
     )
     boxes_list.append(box)
-    platform_rgba = _get_platform_color(_MUJOCO_GREEN)
-    box_colors.append(platform_rgba)
+    box_colors.append(brand_ramp(_MUJOCO_GREEN, 0.5))
 
     origin = np.array([self.size[0] / 2, self.size[1] / 2, grid_height])
 
@@ -575,6 +570,22 @@ class BoxRandomGridTerrainCfg(SubTerrainCfg):
     half_border_width = border_width / 2
     neg_half_terrain = -terrain_height / 2
 
+    # Mark cells under the center platform as visited so they are never emitted
+    # or merged; the platform box covers that region and would otherwise z-fight
+    # with the cells beneath it.
+    platform_half = self.platform_width / 2
+    terrain_center = self.size[0] / 2
+    platform_min = terrain_center - platform_half
+    platform_max = terrain_center + platform_half
+    for i in range(num_boxes_x):
+      cx = half_border_width + (i + 0.5) * self.grid_width
+      if not (platform_min <= cx <= platform_max):
+        continue
+      for j in range(num_boxes_y):
+        cy = half_border_width + (j + 0.5) * self.grid_width
+        if platform_min <= cy <= platform_max:
+          visited[i, j] = True
+
     # Quantize heights to create more merging opportunities
     quantized_heights = (
       np.round(height_map / self.height_merge_threshold) * self.height_merge_threshold
@@ -588,7 +599,12 @@ class BoxRandomGridTerrainCfg(SubTerrainCfg):
         # Find rectangular region with similar height
         height = quantized_heights[i, j]
 
-        normalized_height = (height + grid_height) / (2 * grid_height)
+        # grid_height == 0 (difficulty 0) means a flat grid; use the midpoint
+        # color and avoid dividing by zero.
+        if grid_height > 0:
+          normalized_height = (height + grid_height) / (2 * grid_height)
+        else:
+          normalized_height = 0.5
         t = float(np.clip(normalized_height, 0.0, 1.0))
         rgba = brand_ramp(_MUJOCO_GREEN, t)
 
@@ -653,14 +669,10 @@ class BoxRandomGridTerrainCfg(SubTerrainCfg):
     half_border_width = border_width / 2
     neg_half_terrain = -terrain_height / 2
 
-    if self.holes:
-      platform_half = self.platform_width / 2
-      terrain_center = self.size[0] / 2
-      platform_min = terrain_center - platform_half
-      platform_max = terrain_center + platform_half
-    else:
-      platform_min = None
-      platform_max = None
+    platform_half = self.platform_width / 2
+    terrain_center = self.size[0] / 2
+    platform_min = terrain_center - platform_half
+    platform_max = terrain_center + platform_half
 
     for i in range(num_boxes_x):
       box_center_x = half_border_width + (i + 0.5) * self.grid_width
@@ -678,11 +690,24 @@ class BoxRandomGridTerrainCfg(SubTerrainCfg):
           if not (in_x_strip or in_y_strip):
             continue
 
+        # Skip cells under the center platform so the platform is the only
+        # geometry there. Otherwise the platform box sits on top of these cells
+        # and the coplanar faces z-fight.
+        if (platform_min <= box_center_x <= platform_max) and (
+          platform_min <= box_center_y <= platform_max
+        ):
+          continue
+
         height_noise = height_map[i, j]
         box_height = terrain_height + height_noise
         box_center_z = neg_half_terrain + height_noise / 2
 
-        normalized_height = (height_noise + grid_height) / (2 * grid_height)
+        # grid_height == 0 (difficulty 0) means a flat grid; use the midpoint
+        # color and avoid dividing by zero.
+        if grid_height > 0:
+          normalized_height = (height_noise + grid_height) / (2 * grid_height)
+        else:
+          normalized_height = 0.5
         t = float(np.clip(normalized_height, 0.0, 1.0))
         rgba = brand_ramp(_MUJOCO_GREEN, t)
         box_colors.append(rgba)
@@ -744,13 +769,17 @@ class BoxRandomSpreadTerrainCfg(SubTerrainCfg):
       )
       geometries.append(TerrainGeometry(geom=floor_geom, color=(0.4, 0.4, 0.4, 1.0)))
 
-    # Platform
-    platform_geom = body.add_geom(
-      type=mujoco.mjtGeom.mjGEOM_BOX,
-      size=(self.platform_width / 2, self.platform_width / 2, terrain_height / 2),
-      pos=(self.size[0] / 2, self.size[1] / 2, -terrain_height / 2),
-    )
-    geometries.append(TerrainGeometry(geom=platform_geom, color=(0.4, 0.4, 0.4, 1.0)))
+    # Center platform. When a floor is present it already provides flat ground at
+    # z=0 across the (box-free) center, so an extra platform box would only
+    # duplicate that surface and z-fight with the floor. Add the platform only
+    # when there is no floor, where it is the sole ground at the spawn point.
+    if not self.add_floor:
+      platform_geom = body.add_geom(
+        type=mujoco.mjtGeom.mjGEOM_BOX,
+        size=(self.platform_width / 2, self.platform_width / 2, terrain_height / 2),
+        pos=(self.size[0] / 2, self.size[1] / 2, -terrain_height / 2),
+      )
+      geometries.append(TerrainGeometry(geom=platform_geom, color=(0.4, 0.4, 0.4, 1.0)))
 
     platform_half = self.platform_width / 2
     terrain_center = self.size[0] / 2
@@ -840,13 +869,15 @@ class BoxOpenStairsTerrainCfg(SubTerrainCfg):
     border_rgba = darken_rgba(first_step_rgba, 0.85)
 
     if self.border_width > 0.0:
-      border_center = (0.5 * self.size[0], 0.5 * self.size[1], -step_height / 2)
+      # Keep the border solid and flush at z=0 even if step_height is 0.
+      border_height = max(step_height, _MIN_BORDER_HEIGHT)
+      border_center = (0.5 * self.size[0], 0.5 * self.size[1], -border_height / 2)
       border_inner_size = (
         self.size[0] - 2 * self.border_width,
         self.size[1] - 2 * self.border_width,
       )
       border_boxes = make_border(
-        body, self.size, border_inner_size, step_height, border_center
+        body, self.size, border_inner_size, border_height, border_center
       )
       for box in border_boxes:
         geometries.append(TerrainGeometry(geom=box, color=border_rgba))
@@ -1132,7 +1163,12 @@ class BoxRandomStairsTerrainCfg(SubTerrainCfg):
 @dataclass(kw_only=True)
 class BoxSteppingStonesTerrainCfg(SubTerrainCfg):
   stone_size_range: tuple[float, float] = (0.4, 0.8)
+  """Max and min stone side length, in meters. Stones shrink from the max toward
+  the min as difficulty increases, which widens the gaps between them."""
   stone_distance_range: tuple[float, float] = (0.2, 0.5)
+  """Gap between stones, in meters. The lower bound seeds the (fixed) grid
+  density; the gap itself grows with difficulty as the stones shrink, so the
+  upper bound is no longer used directly."""
   stone_height: float = 0.2
   stone_height_variation: float = 0.1
   stone_size_variation: float = 0.1
@@ -1152,23 +1188,56 @@ class BoxSteppingStonesTerrainCfg(SubTerrainCfg):
     displacement_range = self.displacement_range * difficulty
     stone_height_variation = self.stone_height_variation * difficulty
 
-    # Increase distance between stones with difficulty.
-    d_low, d_high = self.stone_distance_range
-    avg_distance = d_low + difficulty * (d_high - d_low)
-
-    # Decrease stone size with difficulty (larger stones are easier).
+    # Decrease stone size with difficulty (larger stones are easier). With the
+    # grid pitch held fixed (below), shrinking stones means the gaps between them
+    # grow, which is the actual difficulty curriculum.
     s_min, s_max = self.stone_size_range
     avg_stone_size = s_max - difficulty * (s_max - s_min)
-    spacing = avg_stone_size + avg_distance
 
-    # Aggressive grid density to reach borders.
+    # Difficulty-INDEPENDENT grid. The count and pitch are fixed across difficulty
+    # so the layout never re-tiles (previously, num = floor(inner / spacing) + 1
+    # jumped by one as the difficulty-varying spacing crossed an integer boundary,
+    # shifting every stone at once). The pitch exactly spans the inner region so
+    # edge stones always reach the borders. Density is seeded by the tightest
+    # nominal spacing (largest stones + smallest gap).
     inner_w = self.size[0] - 2 * self.border_width
     inner_h = self.size[1] - 2 * self.border_width
-    num_x = int(np.floor(inner_w / spacing)) + 1
-    num_y = int(np.floor(inner_h / spacing)) + 1
+    nominal_spacing = s_max + self.stone_distance_range[0]
+    num_x = max(2, int(np.floor(inner_w / nominal_spacing)) + 1)
+    num_y = max(2, int(np.floor(inner_h / nominal_spacing)) + 1)
+    pitch_x = inner_w / (num_x - 1)
+    pitch_y = inner_h / (num_y - 1)
 
-    offset_x = self.border_width + (inner_w - (num_x - 1) * spacing) / 2
-    offset_y = self.border_width + (inner_h - (num_y - 1) * spacing) / 2
+    # Inter-stone gap (grows with difficulty as stones shrink).
+    gap_x = max(0.0, pitch_x - avg_stone_size)
+    gap_y = max(0.0, pitch_y - avg_stone_size)
+
+    # Snap the central platform out to the grid. It is at least the configured
+    # width and reaches to exactly one gap before the nearest *full* stone, so the
+    # ring of stones around it are whole (no clipped slivers that pop in and out
+    # with difficulty) and sit one consistent gap away. The platform simply
+    # absorbs the stones that would otherwise be partially under it.
+    center_x, center_y = self.size[0] / 2, self.size[1] / 2
+    half_stone = avg_stone_size / 2
+    a0 = self.platform_width / 2
+
+    def _snapped_half(center: float, pitch: float, gap: float, num: int) -> float:
+      # Nearest grid stone that can stay full while the platform is >= a0 wide.
+      threshold = center + a0 + half_stone + gap
+      i_keep = min(num - 1, int(np.ceil((threshold - self.border_width) / pitch)))
+      c_keep = self.border_width + i_keep * pitch
+      return max(a0, c_keep - half_stone - gap - center)
+
+    platform_half_x = _snapped_half(center_x, pitch_x, gap_x, num_x)
+    platform_half_y = _snapped_half(center_y, pitch_y, gap_y, num_y)
+    platform_min_x, platform_max_x = (
+      center_x - platform_half_x,
+      center_x + platform_half_x,
+    )
+    platform_min_y, platform_max_y = (
+      center_y - platform_half_y,
+      center_y + platform_half_y,
+    )
 
     border_rgba = darken_rgba(brand_ramp(_MUJOCO_GREEN, 0.0), 0.85)
     z_center = (self.stone_height - self.floor_depth) / 2
@@ -1195,24 +1264,19 @@ class BoxSteppingStonesTerrainCfg(SubTerrainCfg):
     )
     geometries.append(TerrainGeometry(geom=floor_geom, color=(0.1, 0.1, 0.1, 1.0)))
 
-    # Platform Column.
+    # Platform Column (grid-snapped, see above).
     platform_geom = body.add_geom(
       type=mujoco.mjtGeom.mjGEOM_BOX,
       size=(
-        np.maximum(1e-6, self.platform_width / 2),
-        np.maximum(1e-6, self.platform_width / 2),
+        np.maximum(1e-6, platform_half_x),
+        np.maximum(1e-6, platform_half_y),
         np.maximum(1e-6, half_height),
       ),
-      pos=(self.size[0] / 2, self.size[1] / 2, z_center),
+      pos=(center_x, center_y, z_center),
     )
     geometries.append(
       TerrainGeometry(geom=platform_geom, color=brand_ramp(_MUJOCO_GREEN, 0.5))
     )
-
-    platform_half = self.platform_width / 2
-    terrain_center = self.size[0] / 2
-    platform_min = terrain_center - platform_half
-    platform_max = terrain_center + platform_half
 
     inner_min_x, inner_max_x = self.border_width, self.size[0] - self.border_width
     inner_min_y, inner_max_y = self.border_width, self.size[1] - self.border_width
@@ -1221,12 +1285,17 @@ class BoxSteppingStonesTerrainCfg(SubTerrainCfg):
       for j in range(num_y):
         base_size = avg_stone_size
 
-        # Proposed position with displacement.
+        # Proposed position on the fixed grid with random displacement. Centers
+        # span border to (size - border), so edge stones reach the borders.
         px = (
-          offset_x + i * spacing + rng.uniform(-displacement_range, displacement_range)
+          self.border_width
+          + i * pitch_x
+          + rng.uniform(-displacement_range, displacement_range)
         )
         py = (
-          offset_y + j * spacing + rng.uniform(-displacement_range, displacement_range)
+          self.border_width
+          + j * pitch_y
+          + rng.uniform(-displacement_range, displacement_range)
         )
 
         # Randomized size.
@@ -1237,10 +1306,11 @@ class BoxSteppingStonesTerrainCfg(SubTerrainCfg):
         x_min, x_max = px - size_x / 2, px + size_x / 2
         y_min, y_max = py - size_y / 2, py + size_y / 2
 
-        # Skip stones centered inside the platform. Stones whose edges
-        # extend under the platform are kept; the platform covers the overlap.
-        if (platform_min <= px <= platform_max) and (
-          platform_min <= py <= platform_max
+        # Drop stones whose center lies under the (grid-snapped) platform; the
+        # platform absorbs them. Every remaining stone stays full size and sits
+        # one gap from the platform, so there are no clipped slivers.
+        if (platform_min_x <= px <= platform_max_x) and (
+          platform_min_y <= py <= platform_max_y
         ):
           continue
 
@@ -1296,6 +1366,7 @@ class BoxNarrowBeamsTerrainCfg(SubTerrainCfg):
   def function(
     self, difficulty: float, spec: mujoco.MjSpec, rng: np.random.Generator
   ) -> TerrainOutput:
+    del rng  # Beam layout is deterministic.
     body = spec.body("terrain")
     geometries = []
 
@@ -1305,6 +1376,19 @@ class BoxNarrowBeamsTerrainCfg(SubTerrainCfg):
     # Narrower beams with difficulty (interp from max to min).
     w_min, w_max = self.beam_width_range
     beam_width = w_max - difficulty * (w_max - w_min)
+
+    # Shrink the square platform so its corners stay within the beams' angular
+    # coverage rather than protruding into the pit between beams. A corner sits at
+    # radius r*sqrt(2) and, in the worst case, pi/num_beams away from the nearest
+    # beam, so it is covered while r*sqrt(2)*sin(pi/num_beams) <= beam_width/2.
+    # Beams thin with difficulty, so the safe radius shrinks with it. The beams
+    # attach at this same radius (below), so shrinking never opens a fall gap.
+    spacing_sin = float(np.sin(np.pi / num_beams)) if num_beams > 1 else 0.0
+    if spacing_sin > 1e-9:
+      max_no_protrude = beam_width / (2.0 * np.sqrt(2.0) * spacing_sin)
+      platform_radius = float(min(self.platform_width / 2.0, max_no_protrude))
+    else:
+      platform_radius = self.platform_width / 2.0
 
     border_rgba = darken_rgba(brand_ramp(_MUJOCO_BLUE, 0.0), 0.85)
     z_center = (self.beam_height - self.floor_depth) / 2
@@ -1335,8 +1419,8 @@ class BoxNarrowBeamsTerrainCfg(SubTerrainCfg):
     platform_geom = body.add_geom(
       type=mujoco.mjtGeom.mjGEOM_BOX,
       size=(
-        np.maximum(1e-6, self.platform_width / 2),
-        np.maximum(1e-6, self.platform_width / 2),
+        np.maximum(1e-6, platform_radius),
+        np.maximum(1e-6, platform_radius),
         np.maximum(1e-6, half_height),
       ),
       pos=(self.size[0] / 2, self.size[1] / 2, z_center),
@@ -1347,7 +1431,6 @@ class BoxNarrowBeamsTerrainCfg(SubTerrainCfg):
 
     inner_size = self.size[0] - 2 * self.border_width
     center_x, center_y = self.size[0] / 2, self.size[1] / 2
-    platform_radius = self.platform_width / 2
 
     # Radial beams as columns.
     angles = np.linspace(0, 2 * np.pi, num_beams, endpoint=False)
@@ -1526,6 +1609,8 @@ class BoxNestedRingsTerrainCfg(SubTerrainCfg):
   ring_width_range: tuple[float, float] = (0.3, 0.6)
   gap_range: tuple[float, float] = (0.0, 0.2)
   height_range: tuple[float, float] = (0.1, 0.4)
+  """Min and max ring height, in meters. All rings share a single fixed height
+  taken as the midpoint of this range; difficulty does not scale it."""
   platform_width: float = 1.0
   border_width: float = 0.25
   floor_depth: float = 2.0
@@ -1533,20 +1618,25 @@ class BoxNestedRingsTerrainCfg(SubTerrainCfg):
   def function(
     self, difficulty: float, spec: mujoco.MjSpec, rng: np.random.Generator
   ) -> TerrainOutput:
+    del rng  # Ring layout is deterministic.
     body = spec.body("terrain")
     geometries = []
 
-    # Difficulty scaling: wider width range and higher average height.
-    h_scale = 1.0 + difficulty * 0.5
+    # Concentric ridges of a single fixed height. Difficulty controls
+    # gap-crossing only: gaps widen and rings narrow, so the terrain reads
+    # consistently across difficulty instead of weakly scaling height.
     w_min, w_max = self.ring_width_range
     ring_width = w_max - difficulty * (w_max - w_min)
 
+    ring_height = 0.5 * (self.height_range[0] + self.height_range[1])
+    ring_rgba = brand_ramp(_MUJOCO_BLUE, 0.6)
+
     border_rgba = darken_rgba(brand_ramp(_MUJOCO_BLUE, 0.0), 0.85)
-    # Use ground level z=0 as top of border/beams for consistency with NarrowBeams.
-    # In beam terrain, border top was at beam_height.
 
     if self.border_width > 0.0:
-      border_h = 0.5
+      # Outer border wall matches the ring height so there is no arbitrary
+      # crossover between the two as difficulty changes.
+      border_h = ring_height
       border_center = (
         0.5 * self.size[0],
         0.5 * self.size[1],
@@ -1582,12 +1672,9 @@ class BoxNestedRingsTerrainCfg(SubTerrainCfg):
     gap_min, gap_max = self.gap_range
     gap = gap_min + difficulty * (gap_max - gap_min)
 
-    for k in range(self.num_rings):
-      # Ring k: randomized height.
-      h = rng.uniform(self.height_range[0], self.height_range[1]) * h_scale
-
-      t = k / max(self.num_rings - 1, 1)
-      rgba = brand_ramp(_MUJOCO_BLUE, t)
+    for _ in range(self.num_rings):
+      h = ring_height
+      rgba = ring_rgba
 
       # Outer dimensions of this ring.
       ring_outer_size = (
@@ -1655,7 +1742,8 @@ class BoxNestedRingsTerrainCfg(SubTerrainCfg):
       ),  # Fill the ring hole + gap area.
       np.maximum(1e-2, current_outer_size[1] + 2 * gap),
     )
-    platform_h = 0.2
+    # Center pad sits flush with the ring height.
+    platform_h = ring_height
 
     platform_half_h = (platform_h + self.floor_depth) / 2
     platform_z = (platform_h - self.floor_depth) / 2

--- a/src/mjlab/terrains/terrain_generator.py
+++ b/src/mjlab/terrains/terrain_generator.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import abc
-import time
 from dataclasses import dataclass, field
 from typing import Literal
 
@@ -194,16 +193,9 @@ class TerrainGenerator:
     body = spec.worldbody.add_body(name="terrain")
 
     if self.cfg.curriculum:
-      tic = time.perf_counter()
       self._generate_curriculum_terrains(spec)
-      toc = time.perf_counter()
-      print(f"Curriculum terrain generation took {toc - tic:.4f} seconds.")
-
     else:
-      tic = time.perf_counter()
       self._generate_random_terrains(spec)
-      toc = time.perf_counter()
-      print(f"Terrain generation took {toc - tic:.4f} seconds.")
 
     self._add_terrain_border(spec)
     self._add_grid_lights(spec)

--- a/tests/test_terrains.py
+++ b/tests/test_terrains.py
@@ -2,8 +2,15 @@
 
 import mujoco
 import numpy as np
+import pytest
 
-from mjlab.terrains.primitive_terrains import BoxSteppingStonesTerrainCfg
+from mjlab.terrains.config import ALL_TERRAIN_PRESETS
+from mjlab.terrains.primitive_terrains import (
+  _MIN_BORDER_HEIGHT,
+  BoxInvertedPyramidStairsTerrainCfg,
+  BoxPyramidStairsTerrainCfg,
+  BoxSteppingStonesTerrainCfg,
+)
 
 _CFG = BoxSteppingStonesTerrainCfg(
   proportion=1.0,
@@ -37,12 +44,10 @@ def _generate_stones(
     if geom is None:
       continue
     pos, size = geom.pos, geom.size
-    # Skip platform, floor, and border geoms.
-    is_platform = (
-      np.isclose(pos[0], center)
-      and np.isclose(pos[1], center)
-      and np.isclose(size[0], cfg.platform_width / 2, atol=1e-4)
-    )
+    # Skip platform, floor, and border geoms. The platform is the geom centered
+    # exactly at the patch center (its size is grid-snapped, not the configured
+    # width, so it is identified by position alone).
+    is_platform = np.isclose(pos[0], center) and np.isclose(pos[1], center)
     is_full_span = np.isclose(size[0], cfg.size[0] / 2) or np.isclose(
       size[1], cfg.size[1] / 2
     )
@@ -74,3 +79,50 @@ def test_stone_size_decreases_with_difficulty():
     sizes[difficulty] = np.mean([hx + hy for _, _, hx, hy in stones])
 
   assert sizes[0.0] > sizes[1.0]
+
+
+@pytest.mark.parametrize(
+  "cfg_cls", [BoxPyramidStairsTerrainCfg, BoxInvertedPyramidStairsTerrainCfg]
+)
+def test_pyramid_stairs_border_present_at_zero_difficulty(cfg_cls):
+  """At difficulty 0 the step height collapses to 0, but the flat border frame
+  must still be generated as solid, non-degenerate geometry (regression for the
+  empty-boundary bug, issue #1033)."""
+  cfg = cfg_cls(
+    size=(8.0, 8.0),
+    step_height_range=(0.0, 0.2),
+    step_width=0.3,
+    platform_width=3.0,
+    border_width=1.0,
+  )
+  spec = mujoco.MjSpec()
+  spec.worldbody.add_body(name="terrain")
+  output = cfg.function(difficulty=0.0, spec=spec, rng=np.random.default_rng(0))
+
+  # The border frame sits below z=0 (top flush at ground level); inner step
+  # boxes are centered at z=0. Identify the frame by its downward offset.
+  border_geoms = [
+    g.geom for g in output.geometries if g.geom is not None and g.geom.pos[2] < -1e-4
+  ]
+  assert len(border_geoms) == 4, "Expected four border frame boxes."
+  for geom in border_geoms:
+    # Each frame box must be solid, not a degenerate zero-height geom, and its
+    # top must be flush with the ground plane at z=0.
+    assert geom.size[2] >= _MIN_BORDER_HEIGHT / 2 - 1e-9
+    assert np.isclose(geom.pos[2] + geom.size[2], 0.0, atol=1e-6)
+
+
+@pytest.mark.parametrize("preset_name", sorted(ALL_TERRAIN_PRESETS))
+@pytest.mark.parametrize("difficulty", [0.0, 1.0])
+def test_preset_compiles_across_difficulty(preset_name, difficulty):
+  """Every terrain preset must generate compilable MuJoCo geometry across the
+  full difficulty range. Difficulty 0 is exercised explicitly because curriculum
+  row 0 lands there deterministically, which previously produced degenerate
+  geometry (zero-height hfields, NaN colors, missing borders)."""
+  cfg = ALL_TERRAIN_PRESETS[preset_name](size=(8.0, 8.0))
+  spec = mujoco.MjSpec()
+  spec.worldbody.add_body(name="terrain")
+  cfg.function(difficulty=difficulty, spec=spec, rng=np.random.default_rng(0))
+  # Compiling validates geom/hfield sizes and rgba values (catches NaNs and
+  # non-positive sizes that MuJoCo rejects).
+  spec.compile()


### PR DESCRIPTION
Starting from #1033 (pyramid-stairs showing an empty border at difficulty 0), this PR audits the terrain generators and fixes a batch of related issues, mostly visual and mostly at the difficulty extremes:

- **Difficulty-0 robustness:** pyramid-stairs borders, perlin, and random-grid no longer vanish, crash, or render as NaN when a patch flattens at row 0.
- **Cleaner platforms:** the center pad no longer z-fights its surroundings (e.g. random-grid).
- **Smoother stepping stones:** no abrupt re-tiling at a difficulty threshold, and the center is a clean island rather than a moat.
- **Coherent coloring:** heightfields color by absolute height, consistent across terrains.
- **Nested rings:** reworked into uniform concentric ridges whose gaps widen with difficulty.
- **Random-rough:** adds an opt-in `scale_with_difficulty`.

Most of these were found and verified with a new helper, `scripts/tools/terrain_explorer.py`: a small interactive Viser tool to pick a terrain, scrub a difficulty slider, and watch the patch recompile live (`uv run python scripts/tools/terrain_explorer.py`).

https://github.com/user-attachments/assets/01516ba3-e68e-428d-8a88-e41d13ed4299

Fixes #1033.
