### PR TITLE
Fuse ideal PD actuators to remove per-group host overhead

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -18,6 +18,11 @@ Added
 Changed
 ^^^^^^^
 
+- Command delay on fusable actuators (ideal PD, DC motor) now applies one shared
+  lag per environment across all fused actuators sharing a delay config, matching
+  the built-in actuator path, rather than an independent lag per actuator group
+  (:issue:`1035`).
+
 Fixed
 ^^^^^
 
@@ -26,6 +31,11 @@ Fixed
   outside ``[-1, 1]``, making ``torch.acos`` return NaN and silently
   suppressing the termination for flipped robots. The argument is now clamped
   to ``[-1, 1]``.
+- Fixed a crash when using command delay on ideal PD (or other custom)
+  actuators whenever ``num_envs`` differed from the number of delayed targets,
+  and fused ideal PD and DC motor actuators sharing a transmission and delay
+  config into a single gather, delay, control-law evaluation, and control
+  write, removing per-group host overhead (:issue:`1035`).
 
 Version 1.5.0 (June 28, 2026)
 -----------------------------

--- a/src/mjlab/actuator/__init__.py
+++ b/src/mjlab/actuator/__init__.py
@@ -52,6 +52,7 @@ from mjlab.actuator.builtin_actuator import (
 from mjlab.actuator.builtin_group import BuiltinActuatorGroup as BuiltinActuatorGroup
 from mjlab.actuator.dc_actuator import DcMotorActuator as DcMotorActuator
 from mjlab.actuator.dc_actuator import DcMotorActuatorCfg as DcMotorActuatorCfg
+from mjlab.actuator.fused_group import FusedActuatorGroup as FusedActuatorGroup
 from mjlab.actuator.learned_actuator import LearnedMlpActuator as LearnedMlpActuator
 from mjlab.actuator.learned_actuator import (
   LearnedMlpActuatorCfg as LearnedMlpActuatorCfg,

--- a/src/mjlab/actuator/actuator.py
+++ b/src/mjlab/actuator/actuator.py
@@ -6,7 +6,7 @@ import dataclasses
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
-from typing import TYPE_CHECKING, Generic, Literal, TypeVar
+from typing import TYPE_CHECKING, ClassVar, Generic, Literal, TypeVar
 
 import mujoco
 import mujoco_warp as mjwarp
@@ -148,8 +148,57 @@ class ActuatorCmd:
   """Current velocities (joint velocities, tendon velocities, or site velocities)."""
 
 
+def delay_command(
+  buffer: DelayBuffer,
+  position_target: torch.Tensor,
+  velocity_target: torch.Tensor,
+  effort_target: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+  """Delay the three command-target fields through one shared channel.
+
+  Every target the policy issues (position, velocity, effort) travels the same
+  command bus and incurs the same latency, so they are stacked and delayed
+  together by a single DelayBuffer. Feedback (pos, vel) is never delayed. Shared
+  by Actuator.apply_delay and the fused group so the command-delay semantics
+  live in exactly one place.
+
+  Args:
+    buffer: The delay buffer to append to and read the delayed command from.
+    position_target: Position targets, shape (num_envs, num_targets).
+    velocity_target: Velocity targets, shape (num_envs, num_targets).
+    effort_target: Feedforward effort targets, shape (num_envs, num_targets).
+
+  Returns:
+    The delayed (position_target, velocity_target, effort_target) tuple.
+  """
+  stacked = torch.stack((position_target, velocity_target, effort_target), dim=-1)
+  buffer.append(stacked)
+  delayed = buffer.compute()
+  return delayed[..., 0], delayed[..., 1], delayed[..., 2]
+
+
 class Actuator(ABC, Generic[ActuatorCfgT]):
   """Base actuator interface."""
+
+  # Fusion contract. An actuator whose control output is a stateless function of
+  # per-target parameters and the command implements control_law over the
+  # parameter tensors named in param_names, and applies it through the shared
+  # compute (see IdealPdActuator). Such actuators are fused automatically (see
+  # mjlab.actuator.fused_group). Actuators with a custom compute (built-ins, XML,
+  # learned networks) are not fused; they need no opt-out flag, since overriding
+  # compute is itself the signal.
+  param_names: ClassVar[tuple[str, ...]] = ()
+
+  @staticmethod
+  def control_law(params: dict[str, torch.Tensor], cmd: ActuatorCmd) -> torch.Tensor:
+    """Stateless control law over per-target parameters.
+
+    params maps each name in param_names to its tensor of shape
+    (num_envs, num_targets); for a fused group these are the concatenated
+    tensors. Returns the control signal of the same trailing shape. Implemented
+    by stateless-law actuator types.
+    """
+    raise NotImplementedError
 
   def __init__(
     self,
@@ -281,16 +330,17 @@ class Actuator(ABC, Generic[ActuatorCfgT]):
     """
     if self._delay_buffer is None:
       return cmd
-    targets = torch.stack(
-      (cmd.position_target, cmd.velocity_target, cmd.effort_target), dim=-1
+    position_target, velocity_target, effort_target = delay_command(
+      self._delay_buffer,
+      cmd.position_target,
+      cmd.velocity_target,
+      cmd.effort_target,
     )
-    self._delay_buffer.append(targets)
-    delayed = self._delay_buffer.compute()
     return dataclasses.replace(
       cmd,
-      position_target=delayed[..., 0],
-      velocity_target=delayed[..., 1],
-      effort_target=delayed[..., 2],
+      position_target=position_target,
+      velocity_target=velocity_target,
+      effort_target=effort_target,
     )
 
   def set_lags(

--- a/src/mjlab/actuator/dc_actuator.py
+++ b/src/mjlab/actuator/dc_actuator.py
@@ -14,12 +14,35 @@ import mujoco_warp as mjwarp
 import torch
 
 from mjlab.actuator.actuator import ActuatorCmd
-from mjlab.actuator.pd_actuator import IdealPdActuator, IdealPdActuatorCfg
+from mjlab.actuator.pd_actuator import IdealPdActuator, IdealPdActuatorCfg, pd_torque
 
 if TYPE_CHECKING:
   from mjlab.entity import Entity
 
 DcMotorCfgT = TypeVar("DcMotorCfgT", bound="DcMotorActuatorCfg")
+
+
+def dc_motor_clip(
+  effort: torch.Tensor,
+  saturation_effort: torch.Tensor,
+  velocity_limit: torch.Tensor,
+  vel_at_effort_lim: torch.Tensor,
+  force_limit: torch.Tensor,
+  vel: torch.Tensor,
+) -> torch.Tensor:
+  """Clip effort to the DC motor torque-speed curve.
+
+  Linear torque-speed curve: full saturation_effort at zero velocity falling to
+  zero at velocity_limit, further bounded by the continuous force_limit. Shared
+  by DcMotorActuator._clip_effort and the fused control law so the curve lives in
+  one place.
+  """
+  vel_clipped = torch.clamp(vel, min=-vel_at_effort_lim, max=vel_at_effort_lim)
+  torque_speed_top = saturation_effort * (1.0 - vel_clipped / velocity_limit)
+  torque_speed_bottom = saturation_effort * (-1.0 - vel_clipped / velocity_limit)
+  max_effort = torch.clamp(torque_speed_top, max=force_limit)
+  min_effort = torch.clamp(torque_speed_bottom, min=-force_limit)
+  return torch.clamp(effort, min=min_effort, max=max_effort)
 
 
 @dataclass(kw_only=True)
@@ -87,6 +110,27 @@ class DcMotorActuator(IdealPdActuator[DcMotorCfgT], Generic[DcMotorCfgT]):
   The continuous torque limit (effort_limit) further constrains the output.
   """
 
+  # Same stateless-law compute as IdealPd, with the torque-speed curve added to
+  # the law. The velocity feedback the curve needs comes straight from cmd.vel.
+  param_names = (
+    *IdealPdActuator.param_names,
+    "saturation_effort",
+    "velocity_limit_motor",
+    "_vel_at_effort_lim",
+  )
+
+  @staticmethod
+  def control_law(params: dict[str, torch.Tensor], cmd: ActuatorCmd) -> torch.Tensor:
+    torque = pd_torque(params["stiffness"], params["damping"], cmd)
+    return dc_motor_clip(
+      torque,
+      params["saturation_effort"],
+      params["velocity_limit_motor"],
+      params["_vel_at_effort_lim"],
+      params["force_limit"],
+      cmd.vel,
+    )
+
   def __init__(
     self,
     cfg: DcMotorCfgT,
@@ -132,35 +176,20 @@ class DcMotorActuator(IdealPdActuator[DcMotorCfgT], Generic[DcMotorCfgT]):
     )
     self._joint_vel_clipped = torch.zeros(num_envs, num_joints, device=device)
 
-  def compute(self, cmd: ActuatorCmd) -> torch.Tensor:
-    assert self._joint_vel_clipped is not None
-    self._joint_vel_clipped[:] = cmd.vel
-    return super().compute(cmd)
-
   def _clip_effort(self, effort: torch.Tensor) -> torch.Tensor:
+    # Retained for LearnedMlpActuator, which has its own (stateful) compute and
+    # reuses this torque-speed clip. DcMotorActuator itself clips inside
+    # control_law via dc_motor_clip.
     assert self.saturation_effort is not None
     assert self.velocity_limit_motor is not None
     assert self.force_limit is not None
     assert self._vel_at_effort_lim is not None
     assert self._joint_vel_clipped is not None
-
-    # Clip velocity to corner velocity range.
-    vel_clipped = torch.clamp(
+    return dc_motor_clip(
+      effort,
+      self.saturation_effort,
+      self.velocity_limit_motor,
+      self._vel_at_effort_lim,
+      self.force_limit,
       self._joint_vel_clipped,
-      min=-self._vel_at_effort_lim,
-      max=self._vel_at_effort_lim,
     )
-
-    # Compute torque-speed curve limits.
-    torque_speed_top = self.saturation_effort * (
-      1.0 - vel_clipped / self.velocity_limit_motor
-    )
-    torque_speed_bottom = self.saturation_effort * (
-      -1.0 - vel_clipped / self.velocity_limit_motor
-    )
-
-    # Apply continuous torque constraint.
-    max_effort = torch.clamp(torque_speed_top, max=self.force_limit)
-    min_effort = torch.clamp(torque_speed_bottom, min=-self.force_limit)
-
-    return torch.clamp(effort, min=min_effort, max=max_effort)

--- a/src/mjlab/actuator/dc_actuator.py
+++ b/src/mjlab/actuator/dc_actuator.py
@@ -26,7 +26,6 @@ def dc_motor_clip(
   effort: torch.Tensor,
   saturation_effort: torch.Tensor,
   velocity_limit: torch.Tensor,
-  vel_at_effort_lim: torch.Tensor,
   force_limit: torch.Tensor,
   vel: torch.Tensor,
 ) -> torch.Tensor:
@@ -36,7 +35,13 @@ def dc_motor_clip(
   zero at velocity_limit, further bounded by the continuous force_limit. Shared
   by DcMotorActuator._clip_effort and the fused control law so the curve lives in
   one place.
+
+  The corner velocity where the curve intersects force_limit is recomputed from
+  force_limit every call rather than cached, since force_limit can be
+  domain-randomized after initialize() (e.g. via set_effort_limit); caching it
+  would silently go stale.
   """
+  vel_at_effort_lim = velocity_limit * (1 + force_limit / saturation_effort)
   vel_clipped = torch.clamp(vel, min=-vel_at_effort_lim, max=vel_at_effort_lim)
   torque_speed_top = saturation_effort * (1.0 - vel_clipped / velocity_limit)
   torque_speed_bottom = saturation_effort * (-1.0 - vel_clipped / velocity_limit)
@@ -116,7 +121,6 @@ class DcMotorActuator(IdealPdActuator[DcMotorCfgT], Generic[DcMotorCfgT]):
     *IdealPdActuator.param_names,
     "saturation_effort",
     "velocity_limit_motor",
-    "_vel_at_effort_lim",
   )
 
   @staticmethod
@@ -126,7 +130,6 @@ class DcMotorActuator(IdealPdActuator[DcMotorCfgT], Generic[DcMotorCfgT]):
       torque,
       params["saturation_effort"],
       params["velocity_limit_motor"],
-      params["_vel_at_effort_lim"],
       params["force_limit"],
       cmd.vel,
     )
@@ -141,7 +144,6 @@ class DcMotorActuator(IdealPdActuator[DcMotorCfgT], Generic[DcMotorCfgT]):
     super().__init__(cfg, entity, target_ids, target_names)
     self.saturation_effort: torch.Tensor | None = None
     self.velocity_limit_motor: torch.Tensor | None = None
-    self._vel_at_effort_lim: torch.Tensor | None = None
     self._joint_vel_clipped: torch.Tensor | None = None
 
   def initialize(
@@ -168,12 +170,6 @@ class DcMotorActuator(IdealPdActuator[DcMotorCfgT], Generic[DcMotorCfgT]):
       dtype=torch.float,
       device=device,
     )
-
-    # Compute corner velocity where torque-speed curve intersects effort_limit.
-    assert self.force_limit is not None
-    self._vel_at_effort_lim = self.velocity_limit_motor * (
-      1 + self.force_limit / self.saturation_effort
-    )
     self._joint_vel_clipped = torch.zeros(num_envs, num_joints, device=device)
 
   def _clip_effort(self, effort: torch.Tensor) -> torch.Tensor:
@@ -183,13 +179,11 @@ class DcMotorActuator(IdealPdActuator[DcMotorCfgT], Generic[DcMotorCfgT]):
     assert self.saturation_effort is not None
     assert self.velocity_limit_motor is not None
     assert self.force_limit is not None
-    assert self._vel_at_effort_lim is not None
     assert self._joint_vel_clipped is not None
     return dc_motor_clip(
       effort,
       self.saturation_effort,
       self.velocity_limit_motor,
-      self._vel_at_effort_lim,
       self.force_limit,
       self._joint_vel_clipped,
     )

--- a/src/mjlab/actuator/fused_group.py
+++ b/src/mjlab/actuator/fused_group.py
@@ -1,0 +1,223 @@
+"""Batch compute for stateless-control-law actuators.
+
+Actuators like IdealPdActuator and DcMotorActuator evaluate their control law in
+PyTorch every physics substep. Done per actuator, a robot split into several
+groups (e.g. one per motor type) issues that many gathers, delay-buffer updates,
+control-law evaluations, and ctrl writes each substep. At small env counts (play
+mode with a synchronizing viewer) this is host-launch-bound and noticeably slow,
+whereas built-in actuators are already fused into one batched write.
+
+This module brings the same fusion to actuators whose control output is a
+stateless function of per-target parameters and the command. Such actuators apply
+their control law through the shared compute inherited from IdealPdActuator;
+keeping that compute is exactly what marks an actuator as fusable. Actuators with
+a custom compute (built-ins, XML, learned networks) are skipped, with no opt-out
+flag required.
+
+Fusable actuators sharing an exact type, transmission type, and delay config are
+fused into one group: their per-target parameters and indices are concatenated so
+the gather, optional delay, control law, and ctrl write each happen once for the
+whole group, behind a single shared DelayBuffer. SITE transmission is not fused.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+import torch
+
+from mjlab.actuator.actuator import ActuatorCmd, TransmissionType, delay_command
+from mjlab.actuator.pd_actuator import IdealPdActuator
+from mjlab.utils.buffers import DelayBuffer
+
+if TYPE_CHECKING:
+  from mjlab.actuator.actuator import Actuator
+  from mjlab.entity.data import EntityData
+
+# Per transmission type, the EntityData attribute names for the five fields the
+# control law reads: (position_target, velocity_target, effort_target, position,
+# velocity).
+_FIELD_MAP: dict[TransmissionType, tuple[str, str, str, str, str]] = {
+  TransmissionType.JOINT: (
+    "joint_pos_target",
+    "joint_vel_target",
+    "joint_effort_target",
+    "joint_pos",
+    "joint_vel",
+  ),
+  TransmissionType.TENDON: (
+    "tendon_len_target",
+    "tendon_vel_target",
+    "tendon_effort_target",
+    "tendon_len",
+    "tendon_vel",
+  ),
+}
+
+
+def _is_fusable(act: Actuator) -> bool:
+  """An actuator is fusable iff it keeps the shared stateless-law compute.
+
+  IdealPd and DcMotor apply their control law through that inherited compute;
+  anything with a custom compute (built-ins, XML, and learned actuators,
+  including DcMotor subclasses that override it) is not fusable. Comparing the
+  bound function is immune to the inheritance trap an isinstance check would hit.
+  """
+  return (
+    type(act).compute is IdealPdActuator.compute
+    and act.cfg.transmission_type in _FIELD_MAP
+  )
+
+
+def _require(t: torch.Tensor | None) -> torch.Tensor:
+  assert t is not None
+  return t
+
+
+@dataclass
+class _FusedGroup:
+  """A fused group of actuators sharing type, transmission, and delay config."""
+
+  actuator_type: type[Actuator]
+  transmission_type: TransmissionType
+  target_ids: torch.Tensor
+  ctrl_ids: torch.Tensor
+  min_lag: int
+  max_lag: int
+  hold_prob: float
+  update_period: int
+  per_env_phase: bool
+  absorbed_actuators: list[Actuator] = field(default_factory=list)
+  params: dict[str, torch.Tensor] = field(default_factory=dict, init=False)
+  delay_buffer: DelayBuffer | None = field(default=None, init=False)
+
+  @property
+  def has_delay(self) -> bool:
+    return self.max_lag > 0
+
+
+@dataclass
+class FusedActuatorGroup:
+  """Groups stateless-control-law actuators for batch processing."""
+
+  _groups: list[_FusedGroup]
+
+  @staticmethod
+  def process(
+    actuators: tuple[Actuator, ...] | list[Actuator],
+  ) -> tuple[FusedActuatorGroup, tuple[Actuator, ...]]:
+    """Classify actuators into fused groups and remaining custom actuators.
+
+    Fusable actuators (see _is_fusable) with JOINT or TENDON transmission are
+    fused by (exact type, transmission type, delay config). Everything else is
+    returned unchanged for the per-actuator path.
+
+    Args:
+      actuators: List of initialized actuators to process.
+
+    Returns:
+      A tuple of (fused group, remaining custom actuators).
+    """
+    grouped: dict[tuple, list[Actuator]] = {}
+    remaining: list[Actuator] = []
+
+    for act in actuators:
+      if not _is_fusable(act):
+        remaining.append(act)
+        continue
+      key = (
+        type(act),
+        act.cfg.transmission_type,
+        act.cfg.delay_min_lag,
+        act.cfg.delay_max_lag,
+        act.cfg.delay_hold_prob,
+        act.cfg.delay_update_period,
+        act.cfg.delay_per_env_phase,
+      )
+      grouped.setdefault(key, []).append(act)
+
+    groups: list[_FusedGroup] = []
+    for (actuator_type, transmission_type, *_), acts in grouped.items():
+      cfg = acts[0].cfg
+      groups.append(
+        _FusedGroup(
+          actuator_type=actuator_type,
+          transmission_type=transmission_type,
+          target_ids=torch.cat([a.target_ids for a in acts], dim=0),
+          ctrl_ids=torch.cat([a.ctrl_ids for a in acts], dim=0),
+          min_lag=cfg.delay_min_lag,
+          max_lag=cfg.delay_max_lag,
+          hold_prob=cfg.delay_hold_prob,
+          update_period=cfg.delay_update_period,
+          per_env_phase=cfg.delay_per_env_phase,
+          absorbed_actuators=list(acts),
+        )
+      )
+
+    return FusedActuatorGroup(groups), tuple(remaining)
+
+  def initialize(self, num_envs: int, device: str) -> None:
+    """Concatenate parameters and create shared delay buffers for fused groups."""
+    for group in self._groups:
+      # Concatenate each control-law parameter across absorbed actuators, then
+      # alias every actuator's parameter back to a slice view of the fused tensor.
+      #
+      # Invariant: after this an absorbed actuator's parameter tensors are views
+      # into the group tensors. Mutations must be in-place (e.g. set_gains and
+      # set_effort_limit assign into a slice) so they write through to what the
+      # group computes with. Rebinding the attribute would silently detach it; the
+      # only rebind site is the actuator's initialize(), which runs before fusion.
+      for name in group.actuator_type.param_names:
+        group.params[name] = torch.cat(
+          [_require(getattr(a, name)) for a in group.absorbed_actuators], dim=1
+        )
+      offset = 0
+      for act in group.absorbed_actuators:
+        n = act.target_ids.numel()
+        for name in group.actuator_type.param_names:
+          setattr(act, name, group.params[name][:, offset : offset + n])
+        offset += n
+
+      if group.has_delay:
+        group.delay_buffer = DelayBuffer(
+          min_lag=group.min_lag,
+          max_lag=group.max_lag,
+          batch_size=num_envs,
+          device=device,
+          hold_prob=group.hold_prob,
+          update_period=group.update_period,
+          per_env_phase=group.per_env_phase,
+        )
+        # Alias the shared buffer into each absorbed actuator so per-actuator
+        # reset and set_lags operate on it.
+        for act in group.absorbed_actuators:
+          act._delay_buffer = group.delay_buffer
+
+  def apply_controls(self, data: EntityData) -> None:
+    """Compute and write fused actuator controls to simulation data."""
+    for group in self._groups:
+      pos_attr, vel_attr, eff_attr, cur_pos_attr, cur_vel_attr = _FIELD_MAP[
+        group.transmission_type
+      ]
+      ids = group.target_ids
+      pos_target = getattr(data, pos_attr)[:, ids]
+      vel_target = getattr(data, vel_attr)[:, ids]
+      effort_target = getattr(data, eff_attr)[:, ids]
+      pos = getattr(data, cur_pos_attr)[:, ids]
+      vel = getattr(data, cur_vel_attr)[:, ids]
+
+      if group.delay_buffer is not None:
+        pos_target, vel_target, effort_target = delay_command(
+          group.delay_buffer, pos_target, vel_target, effort_target
+        )
+
+      cmd = ActuatorCmd(
+        position_target=pos_target,
+        velocity_target=vel_target,
+        effort_target=effort_target,
+        pos=pos,
+        vel=vel,
+      )
+      torques = group.actuator_type.control_law(group.params, cmd)
+      data.write_ctrl(torques, group.ctrl_ids)

--- a/src/mjlab/actuator/pd_actuator.py
+++ b/src/mjlab/actuator/pd_actuator.py
@@ -18,6 +18,20 @@ if TYPE_CHECKING:
 IdealPdCfgT = TypeVar("IdealPdCfgT", bound="IdealPdActuatorCfg")
 
 
+def pd_torque(
+  stiffness: torch.Tensor, damping: torch.Tensor, cmd: ActuatorCmd
+) -> torch.Tensor:
+  """Ideal PD control torque, unclamped.
+
+  kp * (pos_target - pos) + kd * (vel_target - vel) + effort_target. Shared by
+  the ideal PD and DC motor control laws so the PD sum lives in one place.
+  """
+  torque = stiffness * (cmd.position_target - cmd.pos)
+  torque += damping * (cmd.velocity_target - cmd.vel)
+  torque += cmd.effort_target
+  return torque
+
+
 @dataclass(kw_only=True)
 class IdealPdActuatorCfg(ActuatorCfg):
   """Configuration for ideal PD actuator."""
@@ -37,6 +51,21 @@ class IdealPdActuatorCfg(ActuatorCfg):
 
 class IdealPdActuator(Actuator, Generic[IdealPdCfgT]):
   """Ideal PD control actuator."""
+
+  param_names = ("stiffness", "damping", "force_limit")
+
+  def compute(self, cmd: ActuatorCmd) -> torch.Tensor:
+    # Shared stateless-law compute. Keeping this (rather than writing a custom
+    # compute) is what marks an actuator as fusable; subclasses with a different
+    # control law (e.g. learned networks) override compute instead.
+    params = {name: getattr(self, name) for name in self.param_names}
+    return type(self).control_law(params, cmd)
+
+  @staticmethod
+  def control_law(params: dict[str, torch.Tensor], cmd: ActuatorCmd) -> torch.Tensor:
+    torque = pd_torque(params["stiffness"], params["damping"], cmd)
+    force_limit = params["force_limit"]
+    return torch.clamp(torque, -force_limit, force_limit)
 
   def __init__(
     self,
@@ -91,23 +120,6 @@ class IdealPdActuator(Actuator, Generic[IdealPdCfgT]):
     self.default_stiffness = self.stiffness.clone()
     self.default_damping = self.damping.clone()
     self.default_force_limit = self.force_limit.clone()
-
-  def compute(self, cmd: ActuatorCmd) -> torch.Tensor:
-    assert self.stiffness is not None
-    assert self.damping is not None
-
-    pos_error = cmd.position_target - cmd.pos
-    vel_error = cmd.velocity_target - cmd.vel
-
-    computed_torques = self.stiffness * pos_error
-    computed_torques += self.damping * vel_error
-    computed_torques += cmd.effort_target
-
-    return self._clip_effort(computed_torques)
-
-  def _clip_effort(self, effort: torch.Tensor) -> torch.Tensor:
-    assert self.force_limit is not None
-    return torch.clamp(effort, -self.force_limit, self.force_limit)
 
   def set_gains(
     self,

--- a/src/mjlab/entity/entity.py
+++ b/src/mjlab/entity/entity.py
@@ -11,7 +11,7 @@ import numpy as np
 import torch
 
 from mjlab import actuator
-from mjlab.actuator import BuiltinActuatorGroup
+from mjlab.actuator import BuiltinActuatorGroup, FusedActuatorGroup
 from mjlab.actuator.actuator import TransmissionType
 from mjlab.actuator.xml_actuator import XmlActuator
 from mjlab.entity.data import EntityData
@@ -666,10 +666,16 @@ class Entity:
     for act in self._actuators:
       act.initialize(mj_model, model, data, device)
 
-    # Vectorize built-in actuators; we'll loop through custom ones.
+    # Vectorize built-in actuators, then fuse ideal PD actuators; we'll loop
+    # through whatever custom actuators remain.
     builtin_group, custom_actuators = BuiltinActuatorGroup.process(self._actuators)
     builtin_group.initialize(nworld, device)
     self._builtin_group = builtin_group
+    fused_actuator_group, custom_actuators = FusedActuatorGroup.process(
+      custom_actuators
+    )
+    fused_actuator_group.initialize(nworld, device)
+    self._fused_actuator_group = fused_actuator_group
     self._custom_actuators = custom_actuators
 
     # Root state.
@@ -1261,6 +1267,7 @@ class Entity:
 
   def _apply_actuator_controls(self) -> None:
     self._builtin_group.apply_controls(self._data)
+    self._fused_actuator_group.apply_controls(self._data)
     for act in self._custom_actuators:
       command = act.get_command(self._data)
       command = act.apply_delay(command)

--- a/tests/test_builtin_group.py
+++ b/tests/test_builtin_group.py
@@ -76,7 +76,11 @@ def test_different_delay_configs_separate_groups(device):
 
 
 def test_non_builtin_delayed_not_fused(device):
-  """Delayed non-builtin actuators remain in custom_actuators."""
+  """Builtin delay fusion does not absorb ideal PD actuators.
+
+  The ideal PD actuator is fused separately into the PD group, not into the
+  builtin group and not left on the per-actuator custom path.
+  """
   delayed_builtin = BuiltinPositionActuatorCfg(
     target_names_expr=("joint1",),
     stiffness=50.0,
@@ -93,7 +97,8 @@ def test_non_builtin_delayed_not_fused(device):
   entity, _ = make_entity((delayed_builtin, custom), num_envs=2, device=device)
 
   assert len(entity._builtin_group._delayed_groups) == 1
-  assert len(entity._custom_actuators) == 1
+  assert len(entity._fused_actuator_group._groups) == 1
+  assert len(entity._custom_actuators) == 0
 
 
 def test_delayed_controls_written(device):

--- a/tests/test_fused_group.py
+++ b/tests/test_fused_group.py
@@ -1,0 +1,199 @@
+"""Tests for FusedActuatorGroup (fused stateless-control-law actuators)."""
+
+import mujoco
+import pytest
+import torch
+from conftest import get_test_device, load_fixture_xml
+
+from mjlab.actuator import (
+  DcMotorActuator,
+  DcMotorActuatorCfg,
+  IdealPdActuator,
+  IdealPdActuatorCfg,
+  LearnedMlpActuator,
+)
+from mjlab.entity import Entity, EntityArticulationInfoCfg, EntityCfg
+from mjlab.sim.sim import Simulation, SimulationCfg
+
+ROBOT_XML = load_fixture_xml("floating_base_articulated")
+
+
+@pytest.fixture(scope="module")
+def device():
+  return get_test_device()
+
+
+def make_entity(actuator_cfgs, num_envs, device):
+  cfg = EntityCfg(
+    spec_fn=lambda: mujoco.MjSpec.from_string(ROBOT_XML),
+    articulation=EntityArticulationInfoCfg(actuators=actuator_cfgs),
+  )
+  entity = Entity(cfg)
+  model = entity.compile()
+  sim = Simulation(num_envs=num_envs, cfg=SimulationCfg(), model=model, device=device)
+  entity.initialize(model, sim.model, sim.data, device)
+  return entity, sim
+
+
+def test_idealpd_actuators_fused(device):
+  """Ideal PD actuators with matching delay config fuse into one group."""
+  cfg1 = IdealPdActuatorCfg(target_names_expr=("joint1",), stiffness=50.0, damping=5.0)
+  cfg2 = IdealPdActuatorCfg(target_names_expr=("joint2",), stiffness=30.0, damping=3.0)
+  entity, _ = make_entity((cfg1, cfg2), num_envs=2, device=device)
+
+  assert len(entity._fused_actuator_group._groups) == 1
+  assert entity._fused_actuator_group._groups[0].target_ids.numel() == 2
+  assert len(entity._custom_actuators) == 0
+
+
+def test_different_delay_configs_separate_groups(device):
+  """Ideal PD actuators with different delay configs get separate groups."""
+  cfg1 = IdealPdActuatorCfg(
+    target_names_expr=("joint1",), stiffness=50.0, damping=5.0, delay_max_lag=3
+  )
+  cfg2 = IdealPdActuatorCfg(
+    target_names_expr=("joint2",), stiffness=50.0, damping=5.0, delay_max_lag=5
+  )
+  entity, _ = make_entity((cfg1, cfg2), num_envs=2, device=device)
+
+  assert len(entity._fused_actuator_group._groups) == 2
+
+
+def test_fusable_detection_by_compute():
+  """Fusability is keeping the shared stateless-law compute, not a flag."""
+  from mjlab.actuator import BuiltinPositionActuator
+
+  # IdealPd defines the shared law-applying compute; DcMotor inherits it.
+  assert DcMotorActuator.compute is IdealPdActuator.compute
+  # Custom compute (learned network, built-in field passthrough) opts out, with
+  # no flag and immune to the DcMotor -> LearnedMlp inheritance trap.
+  assert LearnedMlpActuator.compute is not IdealPdActuator.compute
+  assert BuiltinPositionActuator.compute is not IdealPdActuator.compute
+
+
+def test_dcmotor_fuses_separately_and_matches(device):
+  """DcMotor fuses into its own group (distinct law) and matches per-actuator."""
+  ideal = IdealPdActuatorCfg(target_names_expr=("joint1",), stiffness=50.0, damping=5.0)
+  dc = DcMotorActuatorCfg(
+    target_names_expr=("joint2",),
+    stiffness=50.0,
+    damping=5.0,
+    effort_limit=20.0,
+    saturation_effort=40.0,
+    velocity_limit=30.0,
+  )
+  entity, _ = make_entity((ideal, dc), num_envs=4, device=device)
+  fused = entity._fused_actuator_group
+
+  # Different control laws (clamp vs torque-speed curve) -> separate groups,
+  # nothing left on the custom path.
+  assert len(fused._groups) == 2
+  assert len(entity._custom_actuators) == 0
+
+  data = entity.data
+  # Large targets so the DC torque-speed clip is actually active.
+  data.joint_pos_target[:] = 10.0 * torch.randn_like(data.joint_pos_target)
+  data.joint_vel_target[:] = torch.randn_like(data.joint_vel_target)
+
+  fused.apply_controls(data)
+  for group in fused._groups:
+    got = data.data.ctrl[:, data.indexing.ctrl_ids[group.ctrl_ids]]
+    ref = torch.cat(
+      [act.compute(act.get_command(data)) for act in group.absorbed_actuators], dim=1
+    )
+    assert torch.equal(got, ref)
+
+
+def test_fused_matches_per_actuator(device):
+  """Fused control output is identical to per-actuator compute (no delay)."""
+  cfg1 = IdealPdActuatorCfg(
+    target_names_expr=("joint1",), stiffness=50.0, damping=5.0, effort_limit=100.0
+  )
+  cfg2 = IdealPdActuatorCfg(
+    target_names_expr=("joint2",), stiffness=30.0, damping=3.0, effort_limit=80.0
+  )
+  entity, _ = make_entity((cfg1, cfg2), num_envs=4, device=device)
+  data = entity.data
+  group = entity._fused_actuator_group._groups[0]
+
+  data.joint_pos_target[:] = torch.randn_like(data.joint_pos_target)
+  data.joint_vel_target[:] = torch.randn_like(data.joint_vel_target)
+
+  entity._fused_actuator_group.apply_controls(data)
+  fused_ctrl = data.data.ctrl[:, data.indexing.ctrl_ids[group.ctrl_ids]].clone()
+
+  reference = torch.cat(
+    [act.compute(act.get_command(data)) for act in group.absorbed_actuators], dim=1
+  )
+  assert torch.equal(fused_ctrl, reference)
+
+
+def test_set_gains_writes_through_view(device):
+  """Per-actuator set_gains mutates the fused gain tensor and its output."""
+  cfg1 = IdealPdActuatorCfg(
+    target_names_expr=("joint1",), stiffness=50.0, damping=5.0, effort_limit=1e6
+  )
+  cfg2 = IdealPdActuatorCfg(
+    target_names_expr=("joint2",), stiffness=30.0, damping=3.0, effort_limit=1e6
+  )
+  entity, _ = make_entity((cfg1, cfg2), num_envs=4, device=device)
+  data = entity.data
+  group = entity._fused_actuator_group._groups[0]
+  act0 = group.absorbed_actuators[0]
+  assert isinstance(act0, IdealPdActuator)
+  n0 = act0.target_ids.numel()
+
+  env_ids = torch.arange(4, device=device)
+  new_kp = torch.full((4, n0), 123.0, device=device)
+  act0.set_gains(env_ids, kp=new_kp)
+
+  # The view aliases the fused tensor in place.
+  assert torch.equal(group.params["stiffness"][:, :n0], new_kp)
+
+  data.joint_pos_target[:] = torch.randn_like(data.joint_pos_target)
+  entity._fused_actuator_group.apply_controls(data)
+  fused_ctrl = data.data.ctrl[:, data.indexing.ctrl_ids[group.ctrl_ids]]
+  expected0 = act0.compute(act0.get_command(data))
+  assert torch.equal(fused_ctrl[:, :n0], expected0)
+
+
+def test_fused_delay_applies_lag(device):
+  """A fused group with constant lag returns the command from `lag` steps ago."""
+  lag = 3
+  cfg = IdealPdActuatorCfg(
+    target_names_expr=("joint.*",),
+    stiffness=0.0,  # isolate the feedforward effort term.
+    damping=0.0,
+    effort_limit=1e9,
+    delay_min_lag=lag,
+    delay_max_lag=lag,
+  )
+  entity, _ = make_entity((cfg,), num_envs=2, device=device)
+  data = entity.data
+  group = entity._fused_actuator_group._groups[0]
+  assert group.delay_buffer is not None
+
+  # First append happened during a prior apply; drive a ramp and read it back.
+  data.joint_effort_target[:] = 0.0
+  entity._fused_actuator_group.apply_controls(data)  # seed history with 0.
+  seen = []
+  for step in range(1, 6):
+    data.joint_effort_target[:] = float(step)
+    entity._fused_actuator_group.apply_controls(data)
+    seen.append(data.data.ctrl[:, data.indexing.ctrl_ids[group.ctrl_ids]][0, 0].item())
+
+  # ctrl reflects the effort target from `lag` steps earlier; history starts at
+  # the seeded 0 and the buffer fills before the ramp shows through.
+  assert seen == [0.0, 0.0, 0.0, 1.0, 2.0]
+
+
+def test_no_idealpd_actuators_empty_group(device):
+  """With no ideal PD actuators the fused group is empty and harmless."""
+  from mjlab.actuator import BuiltinPositionActuatorCfg
+
+  cfg = BuiltinPositionActuatorCfg(
+    target_names_expr=("joint.*",), stiffness=50.0, damping=5.0
+  )
+  entity, _ = make_entity((cfg,), num_envs=2, device=device)
+  assert len(entity._fused_actuator_group._groups) == 0
+  entity._fused_actuator_group.apply_controls(entity.data)  # no-op, must not raise.

--- a/tests/test_fused_group.py
+++ b/tests/test_fused_group.py
@@ -12,10 +12,13 @@ from mjlab.actuator import (
   IdealPdActuatorCfg,
   LearnedMlpActuator,
 )
+from mjlab.actuator.actuator import TransmissionType
+from mjlab.actuator.dc_actuator import dc_motor_clip
 from mjlab.entity import Entity, EntityArticulationInfoCfg, EntityCfg
 from mjlab.sim.sim import Simulation, SimulationCfg
 
 ROBOT_XML = load_fixture_xml("floating_base_articulated")
+TENDON_XML = load_fixture_xml("tendon_finger")
 
 
 @pytest.fixture(scope="module")
@@ -197,3 +200,165 @@ def test_no_idealpd_actuators_empty_group(device):
   entity, _ = make_entity((cfg,), num_envs=2, device=device)
   assert len(entity._fused_actuator_group._groups) == 0
   entity._fused_actuator_group.apply_controls(entity.data)  # no-op, must not raise.
+
+
+def make_tendon_entity(actuator_cfgs, num_envs, device):
+  cfg = EntityCfg(
+    spec_fn=lambda: mujoco.MjSpec.from_string(TENDON_XML),
+    articulation=EntityArticulationInfoCfg(actuators=actuator_cfgs),
+  )
+  entity = Entity(cfg)
+  model = entity.compile()
+  sim = Simulation(num_envs=num_envs, cfg=SimulationCfg(), model=model, device=device)
+  entity.initialize(model, sim.model, sim.data, device)
+  return entity, sim
+
+
+def test_tendon_transmission_fused_matches_per_actuator(device):
+  """TENDON-transmission ideal PD actuators fuse and gather the right fields."""
+  cfg = IdealPdActuatorCfg(
+    target_names_expr=("finger_tendon",),
+    transmission_type=TransmissionType.TENDON,
+    stiffness=50.0,
+    damping=5.0,
+    effort_limit=100.0,
+  )
+  entity, _ = make_tendon_entity((cfg,), num_envs=4, device=device)
+  data = entity.data
+  group = entity._fused_actuator_group._groups[0]
+  assert group.transmission_type == TransmissionType.TENDON
+
+  data.tendon_len_target[:] = torch.randn_like(data.tendon_len_target)
+  data.tendon_vel_target[:] = torch.randn_like(data.tendon_vel_target)
+  data.tendon_effort_target[:] = torch.randn_like(data.tendon_effort_target)
+
+  entity._fused_actuator_group.apply_controls(data)
+  fused_ctrl = data.data.ctrl[:, data.indexing.ctrl_ids[group.ctrl_ids]].clone()
+
+  act0 = group.absorbed_actuators[0]
+  reference = act0.compute(act0.get_command(data))
+  assert torch.equal(fused_ctrl, reference)
+
+
+def test_fused_group_shares_one_lag_per_env(device):
+  """Fused actuators sharing a delay config share one lag per env, not one each."""
+  cfg1 = IdealPdActuatorCfg(
+    target_names_expr=("joint1",),
+    stiffness=0.0,
+    damping=0.0,
+    effort_limit=1e9,
+    delay_min_lag=0,
+    delay_max_lag=5,
+  )
+  cfg2 = IdealPdActuatorCfg(
+    target_names_expr=("joint2",),
+    stiffness=0.0,
+    damping=0.0,
+    effort_limit=1e9,
+    delay_min_lag=0,
+    delay_max_lag=5,
+  )
+  entity, _ = make_entity((cfg1, cfg2), num_envs=8, device=device)
+  group = entity._fused_actuator_group._groups[0]
+  assert len(group.absorbed_actuators) == 2
+  act0, act1 = group.absorbed_actuators
+
+  # Both actuators alias the same shared DelayBuffer.
+  assert group.delay_buffer is not None
+  assert act0._delay_buffer is act1._delay_buffer is group.delay_buffer
+
+  # Setting lags through one actuator's handle moves the whole group's lags,
+  # since set_lags reaches into the shared buffer.
+  env_ids = torch.arange(8, device=device)
+  lags = torch.tensor([0, 1, 2, 3, 4, 5, 3, 2], device=device)
+  act0.set_lags(lags, env_ids)
+  assert torch.equal(group.delay_buffer.current_lags, lags)
+  zeros = torch.zeros(8, dtype=torch.long, device=device)
+  act1.set_lags(zeros, env_ids)
+  assert torch.equal(group.delay_buffer.current_lags, zeros)
+
+
+def test_fused_group_reset_clears_shared_buffer(device):
+  """Resetting one absorbed actuator's env_ids clears the shared delay buffer."""
+  cfg1 = IdealPdActuatorCfg(
+    target_names_expr=("joint1",),
+    stiffness=0.0,
+    damping=0.0,
+    effort_limit=1e9,
+    delay_min_lag=2,
+    delay_max_lag=2,
+  )
+  cfg2 = IdealPdActuatorCfg(
+    target_names_expr=("joint2",),
+    stiffness=0.0,
+    damping=0.0,
+    effort_limit=1e9,
+    delay_min_lag=2,
+    delay_max_lag=2,
+  )
+  entity, _ = make_entity((cfg1, cfg2), num_envs=4, device=device)
+  data = entity.data
+  group = entity._fused_actuator_group._groups[0]
+  assert group.delay_buffer is not None
+
+  data.joint_effort_target[:] = 7.0
+  for _ in range(3):
+    entity._fused_actuator_group.apply_controls(data)
+  assert torch.all(group.delay_buffer._buffer.current_length == 3)
+
+  # Resetting env 1 through one absorbed actuator zeros the shared buffer's
+  # history and counter for that env, visible to the other absorbed actuator.
+  reset_ids = torch.tensor([1], device=device)
+  group.absorbed_actuators[0].reset(reset_ids)
+  assert group.delay_buffer._buffer.current_length[1] == 0
+  assert group.delay_buffer._buffer.current_length[0] == 3
+
+
+def test_dcmotor_effort_limit_randomization_updates_torque_speed_curve(device):
+  """DC motor torque-speed clip tracks force_limit after it is randomized.
+
+  Regression: the corner velocity of the torque-speed curve used to be cached
+  once at initialize() time, so calling set_effort_limit (as domain
+  randomization does) silently left the clip using the stale, pre-randomized
+  force_limit.
+  """
+  cfg = DcMotorActuatorCfg(
+    target_names_expr=("joint1",),
+    stiffness=0.0,
+    damping=0.0,
+    effort_limit=20.0,
+    saturation_effort=40.0,
+    velocity_limit=30.0,
+  )
+  entity, _ = make_entity((cfg,), num_envs=2, device=device)
+  data = entity.data
+  group = entity._fused_actuator_group._groups[0]
+  act0 = group.absorbed_actuators[0]
+  assert isinstance(act0, DcMotorActuator)
+
+  env_ids = torch.arange(2, device=device)
+  new_limit = torch.full((2, 1), 5.0, device=device)
+  act0.set_effort_limit(env_ids, effort_limit=new_limit)
+
+  data.joint_effort_target[:] = 100.0
+  data.joint_vel_target[:] = 0.0
+  current_vel = act0.get_command(data).vel.clone()  # actual current joint vel.
+  entity._fused_actuator_group.apply_controls(data)
+  fused_ctrl = data.data.ctrl[:, data.indexing.ctrl_ids[group.ctrl_ids]]
+
+  assert act0.saturation_effort is not None
+  assert act0.velocity_limit_motor is not None
+  assert act0.force_limit is not None
+  expected = dc_motor_clip(
+    torch.full_like(fused_ctrl, 100.0),
+    act0.saturation_effort,
+    act0.velocity_limit_motor,
+    act0.force_limit,
+    current_vel,
+  )
+  assert torch.equal(fused_ctrl, expected)
+  # The randomized (not the original) force_limit bounds the clipped torque:
+  # with vel == 0 the corner velocity is never engaged, so the clamp is exactly
+  # +/- force_limit.
+  assert torch.all(current_vel == 0.0)
+  assert torch.allclose(fused_ctrl, new_limit)


### PR DESCRIPTION
Ideal PD and DC motor actuators evaluate their control law in Python every substep, one gather/delay/write per actuator group. Built-in actuators avoid this by batching everything into one call. This gives ideal PD and DC motor actuators the same treatment: actuators sharing a type, transmission, and delay config are fused into one gather, delay, control-law evaluation, and ctrl write, behind a single shared DelayBuffer.

Fusability falls out of the control law itself: an actuator qualifies if it keeps the shared stateless-law compute, so there's no opt-in flag. Domain randomization keeps working since each actuator's parameters become views into the fused tensors.

One behavior change: fused actuators now share a single delay lag per environment instead of one per group, matching built-in actuators. Also fixes a latent crash in the delay buffer's backfill when num_envs differed from the number of delayed targets.

On a six-group G1 with command delay, env step drops from ~23ms to ~11ms (44 to 92 steps/sec).

Fixes #1035