### PR TITLE
Add actuator velocity limit metadata

### DIFF
--- a/src/mjlab/actuator/actuator.py
+++ b/src/mjlab/actuator/actuator.py
@@ -46,6 +46,15 @@ class ActuatorCfg(ABC):
   armature: float | None = None
   """Reflected rotor inertia. None preserves the XML value."""
 
+  velocity_limit: float | None = None
+  """Maximum joint velocity metadata. None leaves it unspecified.
+
+  MuJoCo does not expose an Isaac Lab-style solver velocity cap for joints or
+  tendons, so this common field is not written into the compiled model. Actuator
+  models may use it for their own torque-speed limits, and downstream terms can
+  read it as hardware metadata.
+  """
+
   frictionloss: float | None = None
   """Friction loss force limit. None preserves the XML value.
 
@@ -89,6 +98,8 @@ class ActuatorCfg(ABC):
   def __post_init__(self) -> None:
     if self.armature is not None:
       assert self.armature >= 0.0, "armature must be non-negative."
+    if self.velocity_limit is not None:
+      assert self.velocity_limit > 0.0, "velocity_limit must be positive."
     if self.frictionloss is not None:
       assert self.frictionloss >= 0.0, "frictionloss must be non-negative."
     if self.viscous_damping is not None:

--- a/src/mjlab/actuator/dc_actuator.py
+++ b/src/mjlab/actuator/dc_actuator.py
@@ -41,8 +41,8 @@ class DcMotorActuatorCfg(IdealPdActuatorCfg):
   saturation_effort: float
   """Peak motor torque at zero velocity (stall torque)."""
 
-  velocity_limit: float
-  """Maximum motor velocity (no-load speed)."""
+  velocity_limit: float | None = None
+  """Maximum motor velocity (no-load speed). Required."""
 
   def __post_init__(self) -> None:
     """Validate DC motor parameters."""
@@ -58,6 +58,10 @@ class DcMotorActuatorCfg(IdealPdActuatorCfg):
         UserWarning,
         stacklevel=2,
       )
+
+    assert self.velocity_limit is not None, (
+      "velocity_limit is required for DcMotorActuator."
+    )
 
     if self.effort_limit > self.saturation_effort:
       warnings.warn(
@@ -118,9 +122,11 @@ class DcMotorActuator(IdealPdActuator[DcMotorCfgT], Generic[DcMotorCfgT]):
       dtype=torch.float,
       device=device,
     )
+    velocity_limit = self.cfg.velocity_limit
+    assert velocity_limit is not None
     self.velocity_limit_motor = torch.full(
       (num_envs, num_joints),
-      self.cfg.velocity_limit,
+      velocity_limit,
       dtype=torch.float,
       device=device,
     )

--- a/tests/test_actuator.py
+++ b/tests/test_actuator.py
@@ -91,6 +91,36 @@ def test_targets_cleared_on_reset(device, robot_xml):
   )
 
 
+def test_common_velocity_limit_metadata(device, robot_xml):
+  """velocity_limit is accepted on common actuator configs as metadata."""
+  actuator_cfg = BuiltinVelocityActuatorCfg(
+    target_names_expr=("joint.*",),
+    damping=5.0,
+    effort_limit=100.0,
+    velocity_limit=1.0,
+  )
+  entity = create_entity_with_actuator(robot_xml, actuator_cfg)
+  entity, sim = initialize_entity(entity, device)
+
+  velocity_target = torch.tensor([[3.0, -4.0]], device=device)
+  entity.set_joint_velocity_target(velocity_target)
+  entity.write_data_to_sim()
+
+  assert actuator_cfg.velocity_limit == pytest.approx(1.0)
+  assert torch.allclose(sim.data.ctrl[0], velocity_target[0])
+
+
+@pytest.mark.parametrize("velocity_limit", [0.0, -1.0])
+def test_common_velocity_limit_must_be_positive(velocity_limit):
+  with pytest.raises(AssertionError, match="velocity_limit"):
+    BuiltinPositionActuatorCfg(
+      target_names_expr=("joint.*",),
+      stiffness=50.0,
+      damping=5.0,
+      velocity_limit=velocity_limit,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Internal attach prefix tests (issue #709)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This PR adds an optional `velocity_limit` field to the common `ActuatorCfg` base class.

The field is intended as actuator/joint velocity-limit metadata that downstream terms can read, for example reward terms that penalize joints above an actuator's recommended or hardware velocity limit. It is validated when provided, but it does not change runtime control behavior by itself.

## Motivation

Isaac Lab exposes actuator velocity limits as actuator configuration data, separate from simulation-side solver limits such as `velocity_limit_sim`:

- Reference: https://isaac-sim.github.io/IsaacLab/main/source/api/lab/isaaclab.actuators.html

For mjlab/MuJoCo, this PR keeps the change conservative: MuJoCo/MJWarp does not provide a direct Isaac Lab-style joint velocity solver cap through the same actuator config path, so this field is metadata only. It gives task/reward code a standard place to store the velocity limit without implying that the simulator will clamp joint velocity or actuator commands.

## Scope

Included:

- Add `ActuatorCfg.velocity_limit: float | None = None`.
- Validate that `velocity_limit` is positive when provided.
- Keep `DcMotorActuatorCfg` compatible with the new base field while preserving its existing runtime requirement that DC motor configs provide `velocity_limit`.
- Add actuator tests covering metadata acceptance and validation.
- Confirm that setting this metadata does not clip a velocity actuator command.

Not included in this PR:

- No reward implementation.
- No EntityData plumbing.
- No asset zoo config updates.
- No documentation updates.
- No MuJoCo model/compiler changes.

## Test Plan

- `uv run pyright`
- `uv run ruff check src/mjlab/actuator/actuator.py src/mjlab/actuator/dc_actuator.py tests/test_actuator.py tests/test_dc_actuator.py`
- `uv run python -m py_compile src/mjlab/actuator/actuator.py src/mjlab/actuator/dc_actuator.py tests/test_actuator.py tests/test_dc_actuator.py`
- `uv run ty check src/mjlab/actuator/actuator.py src/mjlab/actuator/dc_actuator.py tests/test_actuator.py tests/test_dc_actuator.py`
- `uv run pytest tests/test_actuator.py tests/test_dc_actuator.py`