### PR TITLE
Fix per-axis domain randomization events clobbering each other

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -38,6 +38,10 @@ Changed
 Fixed
 ^^^^^
 
+- Fixed domain randomization events that target different ``axes`` of the same
+  model field (e.g. two ``dr.geom_size`` events scaling axis 0 and axis 1
+  separately) silently clobbering each other. Each event now writes back only
+  the axes it targeted, so per-axis events compose (:issue:`1042`).
 - Fixed ``select_gpus`` crashing when ``CUDA_VISIBLE_DEVICES`` contains MIG UUIDs instead of numeric indices.
 - Fixed pyramid-stairs terrains (``BoxPyramidStairsTerrainCfg``,
   ``BoxInvertedPyramidStairsTerrainCfg``, and ``BoxOpenStairsTerrainCfg``)

--- a/src/mjlab/envs/mdp/dr/_core.py
+++ b/src/mjlab/envs/mdp/dr/_core.py
@@ -133,7 +133,19 @@ def _randomize_model_field(
       operation,
     )
 
-  model_field[env_grid, entity_grid] = operation.combine(base_values, random_values)
+  combined = operation.combine(base_values, random_values)
+
+  # Only write back the axes we targeted. Non-target axes in ``combined`` hold the
+  # operation identity applied to ``base_values`` (e.g. ``default * 1`` for scale),
+  # so writing the full slice would clobber modifications made by earlier events
+  # that targeted different axes of the same field. We loop with an integer axis
+  # index (basic indexing) rather than a device index tensor to avoid a
+  # per-call host-to-device copy; ``target_axes`` is tiny (at most 4).
+  if combined.ndim > 2:
+    for axis in target_axes:
+      model_field[env_grid, entity_grid, axis] = combined[..., axis]
+  else:
+    model_field[env_grid, entity_grid] = combined
 
 
 def _randomize_with_string_ranges(

--- a/src/mjlab/envs/mdp/dr/_types.py
+++ b/src/mjlab/envs/mdp/dr/_types.py
@@ -22,12 +22,13 @@ class Operation:
   instances. Users can create custom operations by instantiating this class directly
   and passing them wherever an operation string is accepted.
 
-  The DR engine samples random values for each target axis, then writes the final
-  result as::
+  The DR engine samples random values for each target axis, then computes::
 
-      model_field[envs, entities] = operation.combine(base, random)
+      combined = operation.combine(base, random)
 
-  where ``base`` is either the compile-time default or the current model value,
+  and writes back only the targeted axes of ``combined`` (so events targeting
+  different axes of the same field compose instead of clobbering each other).
+  ``base`` is either the compile-time default or the current model value,
   depending on ``uses_defaults``.
 
   Args:

--- a/tests/test_domain_randomization.py
+++ b/tests/test_domain_randomization.py
@@ -1266,6 +1266,41 @@ def test_geom_size_no_accumulation(device):
   assert torch.allclose(result, expected, atol=1e-5)
 
 
+def test_geom_size_separate_axes_dont_clobber(device):
+  """Events targeting different axes of the same geom compose, not clobber."""
+  env = _make_geom_size_env(device, num_envs=2)
+  robot = env.scene["robot"]
+  geom_cfg = SceneEntityCfg("robot", geom_names=("box_geom",))
+  geom_cfg.resolve(env.scene)
+  geom_ids = robot.indexing.geom_ids[geom_cfg.geom_ids]
+
+  default_size = env.sim.get_default_field("geom_size")[geom_ids].clone()
+
+  # Scale axis 0 by 0.1, then axis 1 by 3.0 in a separate event.
+  dr.geom_size(
+    env,
+    env_ids=None,
+    ranges=(0.1, 0.1),
+    operation="scale",
+    axes=[0],
+    asset_cfg=geom_cfg,
+  )
+  dr.geom_size(
+    env,
+    env_ids=None,
+    ranges=(3.0, 3.0),
+    operation="scale",
+    axes=[1],
+    asset_cfg=geom_cfg,
+  )
+
+  result = env.sim.model.geom_size[0, geom_ids]
+  expected = default_size.clone()
+  expected[..., 0] *= 0.1
+  expected[..., 1] *= 3.0
+  assert torch.allclose(result, expected, atol=1e-5)
+
+
 def test_geom_size_partial_env_ids(device):
   """Only specified envs are updated."""
   env = _make_geom_size_env(device, num_envs=4)


### PR DESCRIPTION
dr.geom_size and the other multi-axis randomization functions let you target a subset of axes via the axes argument. Two events targeting different axes of the same field don't compose: the second silently resets the axes the first set.

The shared engine writes the full indexed slice back to the model field every call. For scale and add, base values are the compile-time defaults and non-target axes carry the operation identity, so the write lands default * 1 (or default + 0) on every axis the event didn't target, overwriting any prior event's work.

This restricts the write to the targeted axes. Per-axis events now compose, across every multi-axis DR function.