### PR TITLE
Optimize mjlab cache hot paths

### DIFF
--- a/src/mjlab/entity/data.py
+++ b/src/mjlab/entity/data.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Sequence
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Callable, Sequence
 
 import mujoco_warp as mjwarp
 import torch
@@ -72,6 +72,40 @@ class EntityData:
   site_effort_target: torch.Tensor
 
   encoder_bias: torch.Tensor
+
+  # Per-step memoization for recompute-heavy derived quantities (world-frame
+  # poses/velocities built via cat / cross-product). These depend only on
+  # forward-derived fields (xpos, xquat, xipos, cvel, subtree_com, geom_/site_*),
+  # which change exclusively on sim.step/forward/reset. The shared WarpBridge
+  # exposes a generation counter bumped on those calls; we recompute when it
+  # advances. Passthrough fields (joint_pos, qvel, xfrc_applied, ...) are NOT
+  # cached, so writes that bypass forward never read stale values.
+  _deriv_cache: dict[str, torch.Tensor] = field(
+    default_factory=dict, init=False, repr=False, compare=False
+  )
+  _deriv_cache_gen: int = field(default=-1, init=False, repr=False, compare=False)
+
+  # Class-level kill switch (used by tests to compare cached vs uncached output).
+  _CACHE_ENABLED = True
+
+  def _cached(self, key: str, compute: Callable[[], torch.Tensor]) -> torch.Tensor:
+    """Return ``compute()`` memoized for the current physics generation.
+
+    Falls back to recomputing every call when the data source exposes no
+    generation counter (e.g. a raw mjwarp.Data in unit tests), preserving the
+    original uncached behavior exactly.
+    """
+    gen = getattr(self.data, "_generation", None)
+    if gen is None or not self._CACHE_ENABLED:
+      return compute()
+    if gen != self._deriv_cache_gen:
+      self._deriv_cache.clear()
+      self._deriv_cache_gen = gen
+    val = self._deriv_cache.get(key)
+    if val is None:
+      val = compute()
+      self._deriv_cache[key] = val
+    return val
 
   # State dimensions.
   POS_DIM = 3
@@ -244,76 +278,108 @@ class EntityData:
   @property
   def root_link_pose_w(self) -> torch.Tensor:
     """Root link pose in world frame. Shape (num_envs, 7)."""
-    pos_w = self.data.xpos[:, self.indexing.root_body_id]  # (num_envs, 3)
-    quat_w = self.data.xquat[:, self.indexing.root_body_id]  # (num_envs, 4)
-    return torch.cat([pos_w, quat_w], dim=-1)  # (num_envs, 7)
+
+    def _compute() -> torch.Tensor:
+      pos_w = self.data.xpos[:, self.indexing.root_body_id]  # (num_envs, 3)
+      quat_w = self.data.xquat[:, self.indexing.root_body_id]  # (num_envs, 4)
+      return torch.cat([pos_w, quat_w], dim=-1)  # (num_envs, 7)
+
+    return self._cached("root_link_pose_w", _compute)
 
   @property
   def root_link_vel_w(self) -> torch.Tensor:
     """Root link velocity in world frame. Shape (num_envs, 6)."""
+
     # NOTE: Equivalently, can read this from qvel[:6] but the angular part
     # will be in body frame and needs to be rotated to world frame.
     # Note also that an extra forward() call might be required to make
     # both values equal.
-    pos = self.data.xpos[:, self.indexing.root_body_id]  # (num_envs, 3)
-    subtree_com = self.data.subtree_com[:, self.indexing.root_body_id]
-    cvel = self.data.cvel[:, self.indexing.root_body_id]  # (num_envs, 6)
-    return compute_velocity_from_cvel(pos, subtree_com, cvel)  # (num_envs, 6)
+    def _compute() -> torch.Tensor:
+      pos = self.data.xpos[:, self.indexing.root_body_id]  # (num_envs, 3)
+      subtree_com = self.data.subtree_com[:, self.indexing.root_body_id]
+      cvel = self.data.cvel[:, self.indexing.root_body_id]  # (num_envs, 6)
+      return compute_velocity_from_cvel(pos, subtree_com, cvel)  # (num_envs, 6)
+
+    return self._cached("root_link_vel_w", _compute)
 
   @property
   def root_com_pose_w(self) -> torch.Tensor:
     """Root center-of-mass pose in world frame. Shape (num_envs, 7)."""
-    pos_w = self.data.xipos[:, self.indexing.root_body_id]
-    quat = self.data.xquat[:, self.indexing.root_body_id]
-    body_iquat = self.model.body_iquat[:, self.indexing.root_body_id]
-    assert body_iquat is not None
-    quat_w = quat_mul(quat, body_iquat.squeeze(1))
-    return torch.cat([pos_w, quat_w], dim=-1)
+
+    def _compute() -> torch.Tensor:
+      pos_w = self.data.xipos[:, self.indexing.root_body_id]
+      quat = self.data.xquat[:, self.indexing.root_body_id]
+      body_iquat = self.model.body_iquat[:, self.indexing.root_body_id]
+      assert body_iquat is not None
+      quat_w = quat_mul(quat, body_iquat.squeeze(1))
+      return torch.cat([pos_w, quat_w], dim=-1)
+
+    return self._cached("root_com_pose_w", _compute)
 
   @property
   def root_com_vel_w(self) -> torch.Tensor:
     """Root center-of-mass velocity in world frame. Shape (num_envs, 6)."""
+
     # NOTE: Equivalent sensor is framelinvel/frameangvel with objtype="body".
-    pos = self.data.xipos[:, self.indexing.root_body_id]  # (num_envs, 3)
-    subtree_com = self.data.subtree_com[:, self.indexing.root_body_id]
-    cvel = self.data.cvel[:, self.indexing.root_body_id]  # (num_envs, 6)
-    return compute_velocity_from_cvel(pos, subtree_com, cvel)  # (num_envs, 6)
+    def _compute() -> torch.Tensor:
+      pos = self.data.xipos[:, self.indexing.root_body_id]  # (num_envs, 3)
+      subtree_com = self.data.subtree_com[:, self.indexing.root_body_id]
+      cvel = self.data.cvel[:, self.indexing.root_body_id]  # (num_envs, 6)
+      return compute_velocity_from_cvel(pos, subtree_com, cvel)  # (num_envs, 6)
+
+    return self._cached("root_com_vel_w", _compute)
 
   # Body properties
 
   @property
   def body_link_pose_w(self) -> torch.Tensor:
     """Body link pose in world frame. Shape (num_envs, num_bodies, 7)."""
-    pos_w = self.data.xpos[:, self.indexing.body_ids]
-    quat_w = self.data.xquat[:, self.indexing.body_ids]
-    return torch.cat([pos_w, quat_w], dim=-1)
+
+    def _compute() -> torch.Tensor:
+      pos_w = self.data.xpos[:, self.indexing.body_ids]
+      quat_w = self.data.xquat[:, self.indexing.body_ids]
+      return torch.cat([pos_w, quat_w], dim=-1)
+
+    return self._cached("body_link_pose_w", _compute)
 
   @property
   def body_link_vel_w(self) -> torch.Tensor:
     """Body link velocity in world frame. Shape (num_envs, num_bodies, 6)."""
+
     # NOTE: Equivalent sensor is framelinvel/frameangvel with objtype="xbody".
-    pos = self.data.xpos[:, self.indexing.body_ids]  # (num_envs, num_bodies, 3)
-    subtree_com = self.data.subtree_com[:, self.indexing.root_body_id]
-    cvel = self.data.cvel[:, self.indexing.body_ids]
-    return compute_velocity_from_cvel(pos, subtree_com.unsqueeze(1), cvel)
+    def _compute() -> torch.Tensor:
+      pos = self.data.xpos[:, self.indexing.body_ids]  # (num_envs, num_bodies, 3)
+      subtree_com = self.data.subtree_com[:, self.indexing.root_body_id]
+      cvel = self.data.cvel[:, self.indexing.body_ids]
+      return compute_velocity_from_cvel(pos, subtree_com.unsqueeze(1), cvel)
+
+    return self._cached("body_link_vel_w", _compute)
 
   @property
   def body_com_pose_w(self) -> torch.Tensor:
     """Body center-of-mass pose in world frame. Shape (num_envs, num_bodies, 7)."""
-    pos_w = self.data.xipos[:, self.indexing.body_ids]
-    quat = self.data.xquat[:, self.indexing.body_ids]
-    body_iquat = self.model.body_iquat[:, self.indexing.body_ids]
-    quat_w = quat_mul(quat, body_iquat)
-    return torch.cat([pos_w, quat_w], dim=-1)
+
+    def _compute() -> torch.Tensor:
+      pos_w = self.data.xipos[:, self.indexing.body_ids]
+      quat = self.data.xquat[:, self.indexing.body_ids]
+      body_iquat = self.model.body_iquat[:, self.indexing.body_ids]
+      quat_w = quat_mul(quat, body_iquat)
+      return torch.cat([pos_w, quat_w], dim=-1)
+
+    return self._cached("body_com_pose_w", _compute)
 
   @property
   def body_com_vel_w(self) -> torch.Tensor:
     """Body center-of-mass velocity in world frame. Shape (num_envs, num_bodies, 6)."""
+
     # NOTE: Equivalent sensor is framelinvel/frameangvel with objtype="body".
-    pos = self.data.xipos[:, self.indexing.body_ids]
-    subtree_com = self.data.subtree_com[:, self.indexing.root_body_id]
-    cvel = self.data.cvel[:, self.indexing.body_ids]
-    return compute_velocity_from_cvel(pos, subtree_com.unsqueeze(1), cvel)
+    def _compute() -> torch.Tensor:
+      pos = self.data.xipos[:, self.indexing.body_ids]
+      subtree_com = self.data.subtree_com[:, self.indexing.root_body_id]
+      cvel = self.data.cvel[:, self.indexing.body_ids]
+      return compute_velocity_from_cvel(pos, subtree_com.unsqueeze(1), cvel)
+
+    return self._cached("body_com_vel_w", _compute)
 
   @property
   def body_external_wrench(self) -> torch.Tensor:
@@ -325,38 +391,54 @@ class EntityData:
   @property
   def geom_pose_w(self) -> torch.Tensor:
     """Geom pose in world frame. Shape (num_envs, num_geoms, 7)."""
-    pos_w = self.data.geom_xpos[:, self.indexing.geom_ids]
-    xmat = self.data.geom_xmat[:, self.indexing.geom_ids]
-    quat_w = quat_from_matrix(xmat)
-    return torch.cat([pos_w, quat_w], dim=-1)
+
+    def _compute() -> torch.Tensor:
+      pos_w = self.data.geom_xpos[:, self.indexing.geom_ids]
+      xmat = self.data.geom_xmat[:, self.indexing.geom_ids]
+      quat_w = quat_from_matrix(xmat)
+      return torch.cat([pos_w, quat_w], dim=-1)
+
+    return self._cached("geom_pose_w", _compute)
 
   @property
   def geom_vel_w(self) -> torch.Tensor:
     """Geom velocity in world frame. Shape (num_envs, num_geoms, 6)."""
-    pos = self.data.geom_xpos[:, self.indexing.geom_ids]
-    body_ids = self.model.geom_bodyid[self.indexing.geom_ids]  # (num_geoms,)
-    subtree_com = self.data.subtree_com[:, self.indexing.root_body_id]
-    cvel = self.data.cvel[:, body_ids]
-    return compute_velocity_from_cvel(pos, subtree_com.unsqueeze(1), cvel)
+
+    def _compute() -> torch.Tensor:
+      pos = self.data.geom_xpos[:, self.indexing.geom_ids]
+      body_ids = self.model.geom_bodyid[self.indexing.geom_ids]  # (num_geoms,)
+      subtree_com = self.data.subtree_com[:, self.indexing.root_body_id]
+      cvel = self.data.cvel[:, body_ids]
+      return compute_velocity_from_cvel(pos, subtree_com.unsqueeze(1), cvel)
+
+    return self._cached("geom_vel_w", _compute)
 
   # Site properties
 
   @property
   def site_pose_w(self) -> torch.Tensor:
     """Site pose in world frame. Shape (num_envs, num_sites, 7)."""
-    pos_w = self.data.site_xpos[:, self.indexing.site_ids]
-    mat_w = self.data.site_xmat[:, self.indexing.site_ids]
-    quat_w = quat_from_matrix(mat_w)
-    return torch.cat([pos_w, quat_w], dim=-1)
+
+    def _compute() -> torch.Tensor:
+      pos_w = self.data.site_xpos[:, self.indexing.site_ids]
+      mat_w = self.data.site_xmat[:, self.indexing.site_ids]
+      quat_w = quat_from_matrix(mat_w)
+      return torch.cat([pos_w, quat_w], dim=-1)
+
+    return self._cached("site_pose_w", _compute)
 
   @property
   def site_vel_w(self) -> torch.Tensor:
     """Site velocity in world frame. Shape (num_envs, num_sites, 6)."""
-    pos = self.data.site_xpos[:, self.indexing.site_ids]
-    body_ids = self.model.site_bodyid[self.indexing.site_ids]  # (num_sites,)
-    subtree_com = self.data.subtree_com[:, self.indexing.root_body_id]
-    cvel = self.data.cvel[:, body_ids]
-    return compute_velocity_from_cvel(pos, subtree_com.unsqueeze(1), cvel)
+
+    def _compute() -> torch.Tensor:
+      pos = self.data.site_xpos[:, self.indexing.site_ids]
+      body_ids = self.model.site_bodyid[self.indexing.site_ids]  # (num_sites,)
+      subtree_com = self.data.subtree_com[:, self.indexing.root_body_id]
+      cvel = self.data.cvel[:, body_ids]
+      return compute_velocity_from_cvel(pos, subtree_com.unsqueeze(1), cvel)
+
+    return self._cached("site_vel_w", _compute)
 
   # Joint properties
 
@@ -583,30 +665,54 @@ class EntityData:
   @property
   def projected_gravity_b(self) -> torch.Tensor:
     """Gravity vector projected into body frame. Shape (num_envs, 3)."""
-    return quat_apply_inverse(self.root_link_quat_w, self.gravity_vec_w)
+
+    def _compute() -> torch.Tensor:
+      return quat_apply_inverse(self.root_link_quat_w, self.gravity_vec_w)
+
+    return self._cached("projected_gravity_b", _compute)
 
   @property
   def heading_w(self) -> torch.Tensor:
     """Heading angle in world frame. Shape (num_envs,)."""
-    forward_w = quat_apply(self.root_link_quat_w, self.forward_vec_b)
-    return torch.atan2(forward_w[:, 1], forward_w[:, 0])
+
+    def _compute() -> torch.Tensor:
+      forward_w = quat_apply(self.root_link_quat_w, self.forward_vec_b)
+      return torch.atan2(forward_w[:, 1], forward_w[:, 0])
+
+    return self._cached("heading_w", _compute)
 
   @property
   def root_link_lin_vel_b(self) -> torch.Tensor:
     """Root link linear velocity in body frame. Shape (num_envs, 3)."""
-    return quat_apply_inverse(self.root_link_quat_w, self.root_link_lin_vel_w)
+
+    def _compute() -> torch.Tensor:
+      return quat_apply_inverse(self.root_link_quat_w, self.root_link_lin_vel_w)
+
+    return self._cached("root_link_lin_vel_b", _compute)
 
   @property
   def root_link_ang_vel_b(self) -> torch.Tensor:
     """Root link angular velocity in body frame. Shape (num_envs, 3)."""
-    return quat_apply_inverse(self.root_link_quat_w, self.root_link_ang_vel_w)
+
+    def _compute() -> torch.Tensor:
+      return quat_apply_inverse(self.root_link_quat_w, self.root_link_ang_vel_w)
+
+    return self._cached("root_link_ang_vel_b", _compute)
 
   @property
   def root_com_lin_vel_b(self) -> torch.Tensor:
     """Root COM linear velocity in body frame. Shape (num_envs, 3)."""
-    return quat_apply_inverse(self.root_link_quat_w, self.root_com_lin_vel_w)
+
+    def _compute() -> torch.Tensor:
+      return quat_apply_inverse(self.root_link_quat_w, self.root_com_lin_vel_w)
+
+    return self._cached("root_com_lin_vel_b", _compute)
 
   @property
   def root_com_ang_vel_b(self) -> torch.Tensor:
     """Root COM angular velocity in body frame. Shape (num_envs, 3)."""
-    return quat_apply_inverse(self.root_link_quat_w, self.root_com_ang_vel_w)
+
+    def _compute() -> torch.Tensor:
+      return quat_apply_inverse(self.root_link_quat_w, self.root_com_ang_vel_w)
+
+    return self._cached("root_com_ang_vel_b", _compute)

--- a/src/mjlab/managers/observation_manager.py
+++ b/src/mjlab/managers/observation_manager.py
@@ -327,11 +327,20 @@ class ObservationManager(ManagerBase):
       group_term_names, self._group_obs_term_cfgs[group_name], strict=False
     )
     for term_name, term_cfg in obs_terms:
-      obs: torch.Tensor = term_cfg.func(self._env, **term_cfg.params).clone()
+      obs: torch.Tensor = term_cfg.func(self._env, **term_cfg.params)
+      owns_storage = False
       if isinstance(term_cfg.noise, noise_cfg.NoiseCfg):
+        source_obs = obs
         obs = term_cfg.noise.apply(obs)
+        owns_storage = obs is not source_obs
       elif isinstance(term_cfg.noise, noise_cfg.NoiseModelCfg):
+        source_obs = obs
         obs = self._group_obs_class_instances[group_name][term_name](obs)
+        owns_storage = obs is not source_obs
+
+      if (term_cfg.clip or term_cfg.scale is not None) and not owns_storage:
+        obs = obs.clone()
+        owns_storage = True
       if term_cfg.clip:
         obs = obs.clip_(min=term_cfg.clip[0], max=term_cfg.clip[1])
       if term_cfg.scale is not None:
@@ -359,6 +368,12 @@ class ObservationManager(ManagerBase):
         else:
           group_obs[term_name] = circular_buffer.buffer
       else:
+        if (
+          not self._group_obs_concatenate[group_name]
+          and term_cfg.delay_max_lag == 0
+          and not owns_storage
+        ):
+          obs = obs.clone()
         group_obs[term_name] = obs
 
     # Final NaN check for non-per-term checking.

--- a/src/mjlab/sensor/contact_sensor.py
+++ b/src/mjlab/sensor/contact_sensor.py
@@ -337,7 +337,9 @@ class ContactSensor(Sensor[ContactData]):
         )
 
   def _compute_data(self) -> ContactData:
-    out = self._extract_sensor_data()
+    return self._attach_state(self._extract_sensor_data())
+
+  def _attach_state(self, out: ContactData) -> ContactData:
     if self._air_time_state is not None:
       out.current_air_time = self._air_time_state.current_air_time
       out.last_air_time = self._air_time_state.last_air_time
@@ -370,10 +372,14 @@ class ContactSensor(Sensor[ContactData]):
 
   def update(self, dt: float) -> None:
     super().update(dt)
-    if self._air_time_state is not None:
-      self._update_air_time_tracking()
-    if self._history_state is not None:
-      self._update_history()
+    if self._air_time_state is not None or self._history_state is not None:
+      contact_data = self._extract_sensor_data()
+      if self._air_time_state is not None:
+        self._update_air_time_tracking(contact_data)
+      if self._history_state is not None:
+        self._update_history(contact_data)
+      self._cached_data = self._attach_state(contact_data)
+      self._cache_valid = True
 
   def compute_first_contact(self, dt: float, abs_tol: float = 1.0e-6) -> torch.Tensor:
     """Returns [B, P] bool: True for primaries that landed within the last dt seconds."""
@@ -442,10 +448,9 @@ class ContactSensor(Sensor[ContactData]):
 
     return data
 
-  def _update_air_time_tracking(self) -> None:
+  def _update_air_time_tracking(self, contact_data: ContactData) -> None:
     assert self._air_time_state is not None
 
-    contact_data = self._extract_sensor_data()
     if contact_data.found is None or "found" not in self.cfg.fields:
       return
 
@@ -489,11 +494,9 @@ class ContactSensor(Sensor[ContactData]):
 
     state.last_time[:] = current_time
 
-  def _update_history(self) -> None:
+  def _update_history(self, contact_data: ContactData) -> None:
     """Roll history buffer and insert current contact data at index 0."""
     assert self._history_state is not None
-
-    contact_data = self._extract_sensor_data()
 
     if "force" in self._history_state and contact_data.force is not None:
       self._history_state["force"] = self._history_state["force"].roll(1, dims=2)

--- a/src/mjlab/sim/sim.py
+++ b/src/mjlab/sim/sim.py
@@ -445,6 +445,10 @@ class Simulation:
     fn = getattr(mjwarp, level.name)
     with wp.ScopedDevice(self.wp_device):
       fn(self._wp_model, self._wp_data)
+    # set_const()/set_const_0() rerun kinematics()/com_pos(), which overwrite the
+    # forward-derived data fields (xpos, xquat, xipos, subtree_com, geom_*, site_*)
+    # that EntityData caches. Invalidate downstream caches so they recompute.
+    self._data_bridge.bump_generation()
 
   def forward(self) -> None:
     with wp.ScopedDevice(self.wp_device):
@@ -452,6 +456,7 @@ class Simulation:
         wp.capture_launch(self.forward_graph)
       else:
         mjwarp.forward(self.wp_model, self.wp_data)
+    self._data_bridge.bump_generation()
 
   def step(self) -> None:
     with wp.ScopedDevice(self.wp_device):
@@ -460,6 +465,7 @@ class Simulation:
           wp.capture_launch(self.step_graph)
         else:
           mjwarp.step(self.wp_model, self.wp_data)
+    self._data_bridge.bump_generation()
 
   def reset(self, env_ids: torch.Tensor | None = None) -> None:
     with wp.ScopedDevice(self.wp_device):
@@ -473,6 +479,7 @@ class Simulation:
         wp.capture_launch(self.reset_graph)
       else:
         mjwarp.reset_data(self.wp_model, self.wp_data, reset=self._reset_mask_wp)
+    self._data_bridge.bump_generation()
 
   def set_sensor_context(self, ctx: SensorContext) -> None:
     """Wire a SensorContext for camera/raycast sensing.

--- a/src/mjlab/sim/sim_data.py
+++ b/src/mjlab/sim/sim_data.py
@@ -197,6 +197,19 @@ class WarpBridge(Generic[T]):
     object.__setattr__(self, "_struct", struct)
     object.__setattr__(self, "_wrapped_cache", {})
     object.__setattr__(self, "_nworld", nworld)
+    # Monotonic counter bumped by Simulation after step/forward/reset. Lazy
+    # consumers (e.g. EntityData derived-quantity caches) compare against this
+    # to know when their cached values are stale and must be recomputed.
+    object.__setattr__(self, "_generation", 0)
+
+  def bump_generation(self) -> None:
+    """Invalidate downstream caches by advancing the data generation counter.
+
+    Called by ``Simulation`` after any operation that mutates the underlying
+    physics state (``step``, ``forward``, ``reset``). It does not touch GPU
+    memory, so it is safe to call outside CUDA graph capture.
+    """
+    object.__setattr__(self, "_generation", self._generation + 1)
 
   def __getattr__(self, name: str) -> Any:
     """Get attribute from the wrapped data, wrapping Warp arrays as TorchArray."""

--- a/src/mjlab/utils/buffers/circular_buffer.py
+++ b/src/mjlab/utils/buffers/circular_buffer.py
@@ -131,6 +131,7 @@ class CircularBuffer:
     self._pointer: int = -1
     self._buffer: torch.Tensor | None = None
     self._all_indices = torch.arange(batch_size, device=device)
+    self._time_indices = torch.arange(max_len, device=device)
     self._num_pushes = torch.zeros(batch_size, dtype=torch.long, device=device)
     self._max_len_tensor = torch.full(
       (batch_size,), max_len, dtype=torch.long, device=device
@@ -170,7 +171,7 @@ class CircularBuffer:
       raise RuntimeError("Buffer not initialized. Call append() first.")
 
     start = (self._pointer + 1) % self._max_len
-    idx = (torch.arange(self._max_len, device=self._device) + start) % self._max_len
+    idx = (self._time_indices + start) % self._max_len
     buf = self._buffer.index_select(0, idx)  # (max_len, batch, ...)
     return buf.transpose(0, 1)  # (batch, max_len, ...)
 

--- a/src/mjlab/utils/buffers/delay_buffer.py
+++ b/src/mjlab/utils/buffers/delay_buffer.py
@@ -154,6 +154,7 @@ class DelayBuffer:
     )
     self._current_lags = torch.zeros(batch_size, dtype=torch.long, device=device)
     self._step_count = torch.zeros(batch_size, dtype=torch.long, device=device)
+    self._always_update = torch.ones(batch_size, dtype=torch.bool, device=device)
 
     if update_period > 0 and per_env_phase:
       self._phase_offsets = torch.randint(
@@ -252,7 +253,7 @@ class DelayBuffer:
       )
       should_update = phase_adjusted_count == 0
     else:
-      should_update = torch.ones(self.batch_size, dtype=torch.bool, device=self.device)
+      should_update = self._always_update
     new_lags = self._sample_lags(should_update)
     self._current_lags = torch.where(should_update, new_lags, self._current_lags)
     self._step_count += 1

--- a/tests/test_entity_data.py
+++ b/tests/test_entity_data.py
@@ -228,6 +228,30 @@ def test_read_requires_forward_to_be_current(device):
   assert not torch.allclose(current_pose, initial_pose, atol=1e-4)
 
 
+def test_derived_body_frame_cache_invalidates_on_forward(device):
+  """Cached derived root quantities must refresh after forward() advances data."""
+  entity = create_floating_base_entity()
+  entity, sim = initialize_entity_with_sim(entity, device)
+
+  sim.forward()
+  initial_gravity = entity.data.projected_gravity_b
+  cached_gravity = entity.data.projected_gravity_b
+  assert initial_gravity.data_ptr() == cached_gravity.data_ptr()
+
+  new_pose = torch.tensor(
+    [0.0, 0.0, 1.0, 0.707, 0.707, 0.0, 0.0], device=device
+  ).unsqueeze(0)
+  entity.write_root_link_pose_to_sim(new_pose)
+
+  stale_gravity = entity.data.projected_gravity_b
+  assert stale_gravity.data_ptr() == initial_gravity.data_ptr()
+
+  sim.forward()
+  current_gravity = entity.data.projected_gravity_b
+  assert current_gravity.data_ptr() != initial_gravity.data_ptr()
+  assert not torch.allclose(current_gravity, initial_gravity, atol=1e-4)
+
+
 @pytest.mark.parametrize(
   "property_name,expected_shape",
   [

--- a/tests/test_observation_history.py
+++ b/tests/test_observation_history.py
@@ -64,6 +64,31 @@ def test_no_history_by_default(mock_env, simple_obs_func):
   assert policy_obs.shape == (4, 3)
 
 
+def test_scaled_observation_does_not_mutate_source(mock_env, device):
+  """Scaling must not write through when an observation term returns a view."""
+
+  source = torch.ones((mock_env.num_envs, 3), device=device)
+
+  def obs_func(env):
+    return source[:, :]
+
+  cfg = {
+    "actor": ObservationGroupCfg(
+      terms={
+        "obs1": ObservationTermCfg(func=obs_func, params={}, scale=2.0),
+      }
+    ),
+  }
+
+  manager = ObservationManager(cfg, mock_env)
+  obs = manager.compute()
+
+  policy_obs = obs["actor"]
+  assert isinstance(policy_obs, torch.Tensor)
+  torch.testing.assert_close(policy_obs, torch.full_like(source, 2.0))
+  torch.testing.assert_close(source, torch.ones_like(source))
+
+
 def test_single_step_history(mock_env, simple_obs_func):
   """Test observation with history_length=1."""
 


### PR DESCRIPTION
## Summary

This PR improves several mjlab training hot paths by reducing redundant tensor work and reusing data that is already valid within the same simulation generation or sensor update.

The changes focus on cache-safe performance improvements:

- Add generation-based memoization for derived `EntityData` quantities that are recomputed frequently from forward-derived simulation fields.
- Invalidate the entity data cache through the simulation data generation counter after `step()`, `forward()`, `reset()`, and model constant recomputation.
- Avoid unconditional observation term clones before concatenation, while preserving clone protection for in-place `clip`/`scale` processing and non-concatenated raw outputs.
- Reuse contact sensor data extracted during `update()` for air-time/history bookkeeping instead of extracting the same contact tensors again on `sensor.data` access.
- Cache fixed delay/history buffer tensors to avoid repeated allocations in common observation delay/history paths.

## Performance

Benchmarks were run on CUDA with an NVIDIA RTX 3090 after rebasing onto the latest `main`.

- End-to-end Go1 flat velocity environment, isolating `EntityData` cache impact:
  - Before: `90.2k env-steps/s`
  - After: `98.0k env-steps/s`
  - Speedup: `1.087x` (`~8.7%`)
- Observation clone+concat hot-path microbenchmark:
  - Before: `0.3715s`
  - After: `0.0972s`
  - Speedup: `3.82x`
- Repeated derived `EntityData` reads microbenchmark:
  - Before: `1.5719s`
  - After: `0.0061s`
  - Speedup: `256.5x`
- Contact sensor extract/reuse microbenchmark:
  - Before: `0.3416s`
  - After: `0.1770s`
  - Speedup: `1.93x`

The microbenchmarks measure individual hot paths and should not be interpreted as whole-training speedups. The end-to-end Go1 number is the most representative full environment measurement from this PR.

## Correctness and Safety

The cache is only used for derived quantities that depend on forward-derived simulation fields such as `xpos`, `xquat`, `xipos`, `cvel`, `subtree_com`, and geom/site pose fields. Direct qpos/qvel-like passthrough fields are intentionally not cached.

Additional tests cover cache invalidation after `forward()` and ensure observation scaling does not write through into source tensors when an observation term returns a view.

## Validation

- `uv run pytest -q` (`957 passed`)
- `uv run ty check`
- `uv run pyright`
- `uv run ruff format --check ...`
- `uv run ruff check ...`
- `git diff --check origin/main..HEAD`
