### PR TITLE
Show live cursor values on Viser uPlot charts

### DIFF
--- a/src/mjlab/viewer/viser/term_plotter.py
+++ b/src/mjlab/viewer/viser/term_plotter.py
@@ -184,7 +184,7 @@ class ViserTermPlotter:
           ),
           "y": viser.uplot.Scale(auto=True),
         },
-        legend=viser.uplot.Legend(show=False),
+        legend=viser.uplot.Legend(show=True),
         title=state.name,
         aspect=2.0,
         visible=True,


### PR DESCRIPTION
The legend on Viser reward/metric plots was hidden, so hovering only showed crosshair lines without numeric values. This enables the live legend so you can read exact step and value under the cursor — useful when the axis tick density is too coarse to pinpoint a number. @kevinzakka was there a reason the legend was off? I couldn't find a config flag for it and the extra row seems worth it.