### PR TITLE
Add `reduce="max"` to `MetricsTermCfg`

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,6 +8,8 @@ Upcoming version (not yet released)
 Added
 ^^^^^
 
+- Added ``reduce="max"`` to ``MetricsTermCfg`` for reporting episode-peak values
+  (e.g. peak power, peak contact force) without needing stateful wrapper classes.
 - Added ``BuiltinDcMotorActuator``, a native MuJoCo ``<dcmotor>`` wrapper.
   Supports voltage / position / velocity input modes with back-EMF,
   configurable motor constants, and optional integral, slew, inductance,

--- a/src/mjlab/managers/metrics_manager.py
+++ b/src/mjlab/managers/metrics_manager.py
@@ -27,11 +27,13 @@ class MetricsTermCfg(ManagerTermBaseCfg):
     reduce: How to aggregate per-step values into an episode metric.
     ``"mean"`` (default) reports ``sum / step_count``. ``"last"`` reports
     the value from the final step of the episode, which is useful for binary
-    success metrics that should not be averaged over timesteps.
+    success metrics that should not be averaged over timesteps. ``"max"``
+    reports the highest value seen during the episode, useful for peak
+    metrics like maximum power or contact force.
   """
 
   per_substep: bool = False
-  reduce: Literal["mean", "last"] = "mean"
+  reduce: Literal["mean", "last", "max"] = "mean"
 
 
 class MetricsManager(ManagerBase):
@@ -56,19 +58,26 @@ class MetricsManager(ManagerBase):
     super().__init__(env=env)
 
     self._episode_sums: dict[str, torch.Tensor] = {}
-    for term_name in self._term_names:
+    self._episode_max: dict[str, torch.Tensor] = {}
+    for idx, term_name in enumerate(self._term_names):
       self._episode_sums[term_name] = torch.zeros(
         self.num_envs, dtype=torch.float, device=self.device
       )
+      if self._term_cfgs[idx].reduce == "max":
+        self._episode_max[term_name] = torch.full(
+          (self.num_envs,), float("-inf"), dtype=torch.float, device=self.device
+        )
     # Pre-resolved tensor refs for substep terms to avoid dict lookups in
     # the hot loop.
     self._substep_accum: list[torch.Tensor] = []
     self._substep_episode_sums: list[torch.Tensor] = []
+    self._substep_episode_max: list[torch.Tensor | None] = []
     for idx in self._substep_term_indices:
       name = self._term_names[idx]
       buf = torch.zeros(self.num_envs, dtype=torch.float, device=self.device)
       self._substep_accum.append(buf)
       self._substep_episode_sums.append(self._episode_sums[name])
+      self._substep_episode_max.append(self._episode_max.get(name))
     self._substep_count: int = 0
     self._step_count = torch.zeros(self.num_envs, dtype=torch.long, device=self.device)
     self._step_values = torch.zeros(
@@ -105,7 +114,11 @@ class MetricsManager(ManagerBase):
     # Avoid division by zero for envs that haven't stepped.
     safe_counts = torch.clamp(counts, min=1.0)
     for idx, key in enumerate(self._episode_sums):
-      if self._term_cfgs[idx].reduce == "last":
+      reduce = self._term_cfgs[idx].reduce
+      if reduce == "max":
+        extras["Episode_Metrics/" + key] = torch.mean(self._episode_max[key][env_ids])
+        self._episode_max[key][env_ids] = float("-inf")
+      elif reduce == "last":
         extras["Episode_Metrics/" + key] = torch.mean(self._step_values[env_ids, idx])
       else:
         extras["Episode_Metrics/" + key] = torch.mean(
@@ -138,6 +151,9 @@ class MetricsManager(ManagerBase):
         avg = self._substep_accum[i] / self._substep_count
         self._substep_episode_sums[i] += avg
         self._step_values[:, idx] = avg
+        max_buf = self._substep_episode_max[i]
+        if max_buf is not None:
+          torch.maximum(max_buf, avg, out=max_buf)
         self._substep_accum[i].zero_()
       self._substep_count = 0
     for idx in self._step_term_indices:
@@ -145,6 +161,8 @@ class MetricsManager(ManagerBase):
       value = self._compute_term(idx)
       self._episode_sums[name] += value
       self._step_values[:, idx] = value
+      if name in self._episode_max:
+        torch.maximum(self._episode_max[name], value, out=self._episode_max[name])
 
   def get_active_iterable_terms(
     self, env_idx: int

--- a/tests/test_metrics_manager.py
+++ b/tests/test_metrics_manager.py
@@ -241,6 +241,105 @@ def test_metrics_substep_shape_validation_rejects_bad_compute_output(mock_env):
     manager.compute_substep()
 
 
+def test_reduce_max_reports_episode_peak(mock_env):
+  """reduce='max' reports the highest value seen during the episode."""
+  step = [0]
+
+  def rising_then_falling(env):
+    step[0] += 1
+    val = 5.0 - abs(step[0] - 3)  # values: 3, 4, 5, 4, 3
+    return torch.full((env.num_envs,), val, device=env.device)
+
+  cfg = {"term": MetricsTermCfg(func=rising_then_falling, params={}, reduce="max")}
+  manager = MetricsManager(cfg, mock_env)
+
+  for _ in range(5):
+    manager.compute()
+
+  info = manager.reset(env_ids=torch.tensor([0]))
+
+  assert info["Episode_Metrics/term"].item() == pytest.approx(5.0)
+
+
+def test_reduce_max_reset_clears_to_neg_inf(mock_env):
+  """After reset, max tracking restarts from -inf."""
+  cfg = {
+    "term": MetricsTermCfg(
+      func=lambda env: torch.ones(env.num_envs, device=env.device) * 10.0,
+      params={},
+      reduce="max",
+    )
+  }
+  manager = MetricsManager(cfg, mock_env)
+
+  manager.compute()
+  manager.reset(env_ids=torch.tensor([0]))
+
+  # After reset, the max buffer for env 0 should be -inf.
+  assert manager._episode_max["term"][0].item() == float("-inf")
+  # Env 1 was not reset, so it keeps its max.
+  assert manager._episode_max["term"][1].item() == pytest.approx(10.0)
+
+
+def test_reduce_max_coexists_with_mean_and_last(mock_env):
+  """All three reduce modes work correctly in the same manager."""
+  step = [0]
+
+  def rising_metric(env):
+    step[0] += 1
+    return torch.full((env.num_envs,), float(step[0]), device=env.device)
+
+  cfg = {
+    "mean_term": MetricsTermCfg(func=rising_metric, params={}, reduce="mean"),
+    "last_term": MetricsTermCfg(func=rising_metric, params={}, reduce="last"),
+    "max_term": MetricsTermCfg(func=rising_metric, params={}, reduce="max"),
+  }
+  manager = MetricsManager(cfg, mock_env)
+
+  for _ in range(3):
+    manager.compute()
+
+  info = manager.reset(env_ids=torch.tensor([0]))
+
+  # mean_term sees 1, 4, 7; avg = 4.0
+  assert info["Episode_Metrics/mean_term"].item() == pytest.approx(4.0)
+  # last_term sees 2, 5, 8; last = 8.0
+  assert info["Episode_Metrics/last_term"].item() == pytest.approx(8.0)
+  # max_term sees 3, 6, 9; max = 9.0
+  assert info["Episode_Metrics/max_term"].item() == pytest.approx(9.0)
+
+
+def test_reduce_max_with_per_substep(mock_env):
+  """reduce='max' with per_substep tracks the max of step-averaged values."""
+  substep_call = [0]
+
+  def rising_metric(env):
+    substep_call[0] += 1
+    return torch.full((env.num_envs,), float(substep_call[0]), device=env.device)
+
+  cfg = {
+    "sub_max": MetricsTermCfg(
+      func=rising_metric, params={}, per_substep=True, reduce="max"
+    ),
+  }
+  manager = MetricsManager(cfg, mock_env)
+
+  # Step 0: substeps [1, 2] -> avg = 1.5
+  for _ in range(2):
+    manager.compute_substep()
+  manager.compute()
+
+  # Step 1: substeps [3, 4] -> avg = 3.5
+  for _ in range(2):
+    manager.compute_substep()
+  manager.compute()
+
+  info = manager.reset(env_ids=torch.tensor([0]))
+
+  # Max of step averages: max(1.5, 3.5) = 3.5
+  assert info["Episode_Metrics/sub_max"].item() == pytest.approx(3.5)
+
+
 def test_no_substep_terms_no_overhead(mock_env):
   """When no per_substep terms exist, compute_substep is a no-op."""
   cfg = {


### PR DESCRIPTION
`MetricsTermCfg.reduce` only supported `"mean"` and `"last"`. This adds `"max"`, which reports the episode-peak value — useful for peak power, peak contact force, etc. Without it, users need stateful wrapper classes that maintain a running `torch.maximum` and abuse `reduce="last"`. With `reduce="max"`, a plain function suffices. Works with both step and `per_substep` terms (tracks the max of the step-averaged value). The `_episode_max` buffer is only allocated for terms that use `"max"`.