### PR TITLE
Forward sim after motion resample in tracking command

### DIFF
--- a/src/mjlab/tasks/tracking/mdp/commands.py
+++ b/src/mjlab/tasks/tracking/mdp/commands.py
@@ -409,6 +409,10 @@ class MotionCommand(CommandTerm):
     env_ids = torch.where(self.time_steps >= self.motion.time_step_total)[0]
     if env_ids.numel() > 0:
       self._resample_command(env_ids)
+      # _resample_command writes qpos/qvel but does not refresh derived
+      # quantities; forward() so update_relative_body_poses reads the
+      # post-teleport robot anchor instead of the stale pre-resample pose.
+      self._env.sim.forward()
 
     self.update_relative_body_poses()
 


### PR DESCRIPTION
When a motion clip ends mid-episode, _update_command resamples and teleports the robot (writing qpos/qvel) but then reads robot_anchor_pos_w before the next forward(), so update_relative_body_poses re-anchors to the robot's stale pre-teleport pose. This adds a sim.forward() after the resample, guarded to fire only on steps where an env resampled. Preliminary results on the flat tracking task show improved tracking accuracy and reward overall, at a modest throughput cost from the extra forward.

Fixes #1068.