### PR TITLE
Disable GL in release smoke test to avoid mujoco import crash

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,17 @@ jobs:
         run: uv python install 3.13
       - name: Build
         run: uv build
+      # MUJOCO_GL=disable so `import mujoco` skips its GL backend import. Without
+      # it, mujoco 3.10 eagerly imports the EGL bindings at import time (mjlab
+      # defaults MUJOCO_GL=egl on Linux) and crashes on the runner, which has no
+      # GL libraries. The smoke test does not render, so disabling GL is fine.
       - name: Smoke test (wheel)
         run: uv run --isolated --no-project --with dist/*.whl tests/smoke_test.py
+        env:
+          MUJOCO_GL: disable
       - name: Smoke test (source distribution)
         run: uv run --isolated --no-project --with dist/*.tar.gz tests/smoke_test.py
+        env:
+          MUJOCO_GL: disable
       - name: Publish
         run: uv publish


### PR DESCRIPTION
The release smoke test installs mjlab fresh on a CPU-only runner with no GL libraries and crashes at import. mujoco 3.10 eagerly imports its GL backend at `import mujoco` time, and mjlab defaults MUJOCO_GL=egl on Linux (#1036), so the EGL bindings load at import and fail with no GL libraries present (PyOpenGL raises AttributeError, which mujoco's ImportError guard does not catch). The smoke test does not render, so this sets MUJOCO_GL=disable on the two smoke-test steps, which makes mujoco skip the GL backend import entirely. A follow-up should make mjlab's MUJOCO_GL default robust so plain `import mjlab` does not crash on headless hosts without GL libraries.