### PR TITLE
Add changelog entry for MeshCfg

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,6 +8,10 @@ Upcoming version (not yet released)
 Added
 ^^^^^
 
+- Added ``MeshCfg``, a spec editor that matches mesh assets by name and edits
+  their asset-level attributes. The first attribute is ``maxhullvert``, which
+  caps the collision convex hull's vertex count to lower narrowphase cost.
+
 Changed
 ^^^^^^^
 


### PR DESCRIPTION
Adds the changelog entry for MeshCfg that was missed in #1076.