### PR TITLE
Fix NaN in bad_orientation termination from unclamped acos

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -18,6 +18,12 @@ Changed
 Fixed
 ^^^^^
 
+- Fixed ``mdp.bad_orientation`` returning NaN when float32 rounding in
+  ``quat_apply_inverse`` pushed the projected-gravity z-component slightly
+  outside ``[-1, 1]``, making ``torch.acos`` return NaN and silently
+  suppressing the termination for flipped robots. The argument is now clamped
+  to ``[-1, 1]``.
+
 Version 1.5.0 (June 28, 2026)
 -----------------------------
 

--- a/src/mjlab/envs/mdp/terminations.py
+++ b/src/mjlab/envs/mdp/terminations.py
@@ -29,7 +29,9 @@ def bad_orientation(
   """Terminate when the asset's orientation exceeds the limit angle."""
   asset: Entity = env.scene[asset_cfg.name]
   projected_gravity = asset.data.projected_gravity_b
-  return torch.acos(-projected_gravity[:, 2]).abs() > limit_angle
+  return (
+    torch.acos(torch.clamp(-projected_gravity[:, 2], -1.0, 1.0)).abs() > limit_angle
+  )
 
 
 def root_height_below_minimum(


### PR DESCRIPTION
`torch.acos` returns NaN when the argument drifts outside [-1, 1] due to float32 rounding in `quat_apply_inverse`. This contaminates the termination signal, silently suppressing resets for flipped robots.

The fix clamps the argument to [-1, 1], matching the existing safe pattern in `lab_api/math.py` slerp (line 1722) — this was the only unclamped `acos`/`asin` call in the entire codebase.

## Reproduction

Even with a perfectly normalized MuJoCo quaternion, float32 rounding inside `quat_apply_inverse` can push `projected_gravity_b.z` slightly outside [-1, 1]:

```python
theta = 4.6233205715019130
qpos = [0, cos(theta), sin(theta), 0]    # valid unit quaternion
mujoco.mj_forward()                      # MuJoCo normalizes, norm=1.0 exactly
z = quat_apply_inverse(xquat, [0,0,-1]).z  # float32 computation

# before fix:
z        = -1.000000238418579
acos(z)  = nan                           # termination silently skipped

# after fix:
acos(clamp(z, -1, 1)) = 3.14159          # pi, correctly detects flip
```