### PR TITLE
Make Viser reward bar panel term cap configurable and warn on truncation

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -11,9 +11,18 @@ Added
 Changed
 ^^^^^^^
 
+- The Viser reward bar panel's term cap is now configurable via
+  ``ViserTermOverlays.reward_bar_max_terms`` (forwarded to
+  ``RewardBarPanel(max_terms=...)``), so environments with more than 20 reward
+  terms can show them all. Defaults to 20, preserving previous behavior.
+
 Fixed
 ^^^^^
 
+- The Viser reward bar panel no longer *silently* drops reward terms beyond
+  ``max_terms``; it now emits a warning listing the hidden terms. Previously
+  environments with more than 20 reward terms had the overflow disappear from
+  the bar panel with no indication.
 - Fixed the ``terrain_levels_vel`` curriculum promoting every env from level 0
   to level 1 on the initial reset, ignoring ``max_init_terrain_level=0``. Before
   the first step the robot sits at its spawn pose rather than a walked-to

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -12,9 +12,9 @@ Changed
 ^^^^^^^
 
 - The Viser reward bar panel's term cap is now configurable via
-  ``ViserTermOverlays.reward_bar_max_terms`` (forwarded to
-  ``RewardBarPanel(max_terms=...)``), so environments with more than 20 reward
-  terms can show them all. Defaults to 20, preserving previous behavior.
+  ``ViewerConfig.reward_bar_max_terms``, so environments with more than 20
+  reward terms can show them all. Defaults to 20, preserving previous behavior.
+  :issue:`1079`
 
 Fixed
 ^^^^^
@@ -22,7 +22,7 @@ Fixed
 - The Viser reward bar panel no longer *silently* drops reward terms beyond
   ``max_terms``; it now emits a warning listing the hidden terms. Previously
   environments with more than 20 reward terms had the overflow disappear from
-  the bar panel with no indication.
+  the bar panel with no indication. :issue:`1079`
 - Fixed the ``terrain_levels_vel`` curriculum promoting every env from level 0
   to level 1 on the initial reset, ignoring ``max_init_terrain_level=0``. Before
   the first step the robot sits at its spawn pose rather than a walked-to

--- a/src/mjlab/viewer/viewer_config.py
+++ b/src/mjlab/viewer/viewer_config.py
@@ -33,3 +33,8 @@ class ViewerConfig:
   enable_shadows: bool = True
   height: int = 240
   width: int = 320
+  reward_bar_max_terms: int = 20
+  """Maximum number of reward terms shown in the Viser reward bar panel.
+
+  Terms beyond this limit are dropped (with a warning). Raise it for
+  environments with many reward terms."""

--- a/src/mjlab/viewer/viser/overlays.py
+++ b/src/mjlab/viewer/viser/overlays.py
@@ -46,6 +46,7 @@ class ViserTermOverlays:
   env: _EnvProtocol
   scene: _SceneProtocol
   frame_time: float
+  reward_bar_max_terms: int = 20
   reward_plotter: ViserTermPlotter | None = None
   reward_bar_panel: RewardBarPanel | None = None
   metrics_plotter: ViserTermPlotter | None = None
@@ -65,6 +66,7 @@ class ViserTermOverlays:
           self.server,
           term_names,
           update_dt=self.frame_time,
+          max_terms=self.reward_bar_max_terms,
         )
         self.reward_plotter = ViserTermPlotter(
           self.server, term_names, name="Reward", env_idx=self.scene.env_idx

--- a/src/mjlab/viewer/viser/reward_bar_panel.py
+++ b/src/mjlab/viewer/viser/reward_bar_panel.py
@@ -7,6 +7,7 @@ over ~1 second. Positive terms are green, negative terms are red.
 from __future__ import annotations
 
 import html
+import warnings
 from collections import deque
 
 import numpy as np
@@ -31,9 +32,19 @@ class RewardBarPanel:
       update_dt: Time in seconds between consecutive ``update()`` calls
         (i.e. the viewer's frame time). Used to size the averaging
         window to ~1 second.
-      max_terms: Maximum number of terms to display.
+      max_terms: Maximum number of terms to display. Terms beyond this
+        limit are dropped (with a warning) to keep the panel readable.
     """
     self._server = server
+    if len(term_names) > max_terms:
+      dropped = term_names[max_terms:]
+      warnings.warn(
+        f"RewardBarPanel: {len(term_names)} reward terms exceed max_terms="
+        f"{max_terms}; the bar panel will only show the first {max_terms}. "
+        f"Hidden terms: {dropped}. Pass a larger max_terms to show them all.",
+        UserWarning,
+        stacklevel=2,
+      )
     self._term_names = term_names[:max_terms]
 
     # ~1 second averaging window, but at least 1 step.

--- a/src/mjlab/viewer/viser/viewer.py
+++ b/src/mjlab/viewer/viser/viewer.py
@@ -204,7 +204,11 @@ class ViserPlayViewer(BaseViewer):
       self._scene.create_overlay_gui()
 
     self._term_overlays = ViserTermOverlays(
-      self._server, self.env, self._scene, self.frame_time
+      self._server,
+      self.env,
+      self._scene,
+      self.frame_time,
+      reward_bar_max_terms=self.cfg.reward_bar_max_terms,
     )
     self._term_overlays.setup_tabs(tabs)
     self._debug_overlays = ViserDebugOverlays(self.env, self._scene)

--- a/tests/test_reward_bar_panel.py
+++ b/tests/test_reward_bar_panel.py
@@ -1,0 +1,34 @@
+"""Tests for the Viser reward bar panel term cap."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from mjlab.viewer.viser.reward_bar_panel import RewardBarPanel
+
+
+def _term_names(n: int) -> list[str]:
+  return [f"term_{i}" for i in range(n)]
+
+
+def test_warns_and_truncates_over_cap():
+  """More terms than the cap warns and keeps only the first ``max_terms``."""
+  server = Mock()
+  with pytest.warns(UserWarning, match="exceed max_terms"):
+    panel = RewardBarPanel(server, _term_names(21), update_dt=1 / 30, max_terms=20)
+  assert panel._term_names == _term_names(21)[:20]
+
+
+def test_no_warning_at_or_below_cap(recwarn):
+  """At or below the cap, all terms are kept and no truncation warning fires."""
+  server = Mock()
+  panel = RewardBarPanel(server, _term_names(20), update_dt=1 / 30, max_terms=20)
+  assert panel._term_names == _term_names(20)
+  assert not [w for w in recwarn if "exceed max_terms" in str(w.message)]
+
+
+def test_raised_cap_shows_all_terms():
+  """Raising ``max_terms`` (the fix for #1079) surfaces the overflow terms."""
+  server = Mock()
+  panel = RewardBarPanel(server, _term_names(24), update_dt=1 / 30, max_terms=32)
+  assert panel._term_names == _term_names(24)


### PR DESCRIPTION
## Summary

The Viser viewer's **Rewards** bar panel caps display at the first 20 terms (`RewardBarPanel(max_terms=20)`) and silently drops the rest. `ViserTermOverlays.setup_tabs` never forwarded `max_terms`, so there was no way to raise the limit, and environments with more than 20 reward terms lost the overflow with no indication. (The adjacent Reward *line-plot* tab has no such cap, so the two tabs disagree, making the truncation easy to miss.)

Fixes #1079.

## Changes

- Forward `max_terms` through a new `ViserTermOverlays.reward_bar_max_terms` field (default `20`, preserving current behavior) so the cap is configurable.
- Emit a `warnings.warn` listing the hidden terms when truncation occurs, so the loss is no longer silent.
- Changelog entries under *Upcoming version* (Changed + Fixed).

## Testing

- `ruff check` passes on both edited modules.
- Manual check: with 24 terms and `max_terms=20` → 20 shown + warning emitted; with `max_terms=64` → all 24 shown, no warning.

Behavior is unchanged for existing callers (default stays 20); the only difference at the default is that previously-silent truncation now warns.