### PR TITLE
Expose MuJoCo Warp broadphase settings in MujocoCfg

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -11,6 +11,9 @@ Added
 - Added ``MeshCfg``, a spec editor that matches mesh assets by name and edits
   their asset-level attributes. The first attribute is ``maxhullvert``, which
   caps the collision convex hull's vertex count to lower narrowphase cost.
+- Added ``MujocoCfg.broadphase`` and ``MujocoCfg.broadphase_filter`` to
+  configure MuJoCo Warp's broadphase collision algorithm and bounding-volume
+  filters.
 
 Changed
 ^^^^^^^

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -11,9 +11,9 @@ Added
 - Added ``MeshCfg``, a spec editor that matches mesh assets by name and edits
   their asset-level attributes. The first attribute is ``maxhullvert``, which
   caps the collision convex hull's vertex count to lower narrowphase cost.
-- Added ``MujocoCfg.broadphase`` and ``MujocoCfg.broadphase_filter`` to
-  configure MuJoCo Warp's broadphase collision algorithm and bounding-volume
-  filters.
+- Added ``SimulationCfg.broadphase`` and ``SimulationCfg.broadphase_filter``
+  to configure MuJoCo Warp's broadphase collision algorithm and
+  bounding-volume filters.
 
 Changed
 ^^^^^^^

--- a/src/mjlab/sim/sim.py
+++ b/src/mjlab/sim/sim.py
@@ -73,7 +73,7 @@ _BROADPHASE_MAP = {
   "sap_tile": mjwarp.BroadphaseType.SAP_TILE,
   "sap_segmented": mjwarp.BroadphaseType.SAP_SEGMENTED,
 }
-_BROADPHASE_FILTER_MAP: dict[str, mjwarp.BroadphaseFilter] = {
+_BROADPHASE_FILTER_MAP = {
   "plane": mjwarp.BroadphaseFilter.PLANE,
   "sphere": mjwarp.BroadphaseFilter.SPHERE,
   "aabb": mjwarp.BroadphaseFilter.AABB,
@@ -124,14 +124,6 @@ class MujocoCfg:
   enableflags: tuple[str, ...] = ()
   """Enable flags to set (e.g. ``("energy",)`` to enable energy computation)."""
 
-  # Broadphase settings (MuJoCo Warp only; not part of mujoco.MjOption).
-  broadphase: Literal["nxn", "sap_tile", "sap_segmented"] | None = None
-  """Broadphase collision algorithm. If None, use the MuJoCo Warp default."""
-  broadphase_filter: tuple[Literal["plane", "sphere", "aabb", "obb"], ...] | None = None
-  """Bounding-volume filters applied during broadphase collision checking.
-
-  If None, use the MuJoCo Warp default."""
-
   def apply(self, model: mujoco.MjModel) -> None:
     """Apply configuration settings to a compiled MjModel."""
     model.opt.jacobian = _JACOBIAN_MAP[self.jacobian]
@@ -159,19 +151,6 @@ class MujocoCfg:
         )
       model.opt.enableflags |= _ENABLE_FLAG_MAP[flag]
 
-  def apply_warp(self, wp_opt: mjwarp.Option) -> None:
-    """Apply MuJoCo Warp-only settings to a warp Option (post ``put_model``).
-
-    Fields left as ``None`` retain whatever ``put_model`` already set, i.e.
-    the MuJoCo Warp default.
-    """
-    if self.broadphase is not None:
-      wp_opt.broadphase = _BROADPHASE_MAP[self.broadphase]
-    if self.broadphase_filter is not None:
-      wp_opt.broadphase_filter = mjwarp.BroadphaseFilter(0)
-      for name in self.broadphase_filter:
-        wp_opt.broadphase_filter |= _BROADPHASE_FILTER_MAP[name]
-
 
 @dataclass(kw_only=True)
 class SimulationCfg:
@@ -186,6 +165,12 @@ class SimulationCfg:
   Constraint arrays are batched by world: no world may have more than njmax
   constraints. If None, a heuristic value is used."""
   contact_sensor_maxmatch: int = 64
+  broadphase: Literal["nxn", "sap_tile", "sap_segmented"] | None = None
+  """Broadphase collision algorithm. If None, use the MuJoCo Warp default."""
+  broadphase_filter: tuple[Literal["plane", "sphere", "aabb", "obb"], ...] | None = None
+  """Bounding-volume filters applied during broadphase collision checking.
+
+  If None, use the MuJoCo Warp default."""
   ls_parallel: bool | None = None
   """Deprecated and ignored. Parallel linesearch was removed in MuJoCo Warp 3.10."""
   mujoco: MujocoCfg = field(default_factory=MujocoCfg)
@@ -199,6 +184,16 @@ class SimulationCfg:
         DeprecationWarning,
         stacklevel=2,
       )
+
+  def apply_wp_opt(self, wp_opt: mjwarp.Option) -> None:
+    """Apply MuJoCo Warp-only settings to a warp Option (post ``put_model``)."""
+    wp_opt.contact_sensor_maxmatch = self.contact_sensor_maxmatch
+    if self.broadphase is not None:
+      wp_opt.broadphase = _BROADPHASE_MAP[self.broadphase]
+    if self.broadphase_filter is not None:
+      wp_opt.broadphase_filter = mjwarp.BroadphaseFilter(0)
+      for name in self.broadphase_filter:
+        wp_opt.broadphase_filter |= _BROADPHASE_FILTER_MAP[name]
 
 
 class Simulation:
@@ -271,8 +266,7 @@ class Simulation:
 
     with wp.ScopedDevice(self.wp_device):
       self._wp_model = mjwarp.put_model(self._mj_model)
-      self._wp_model.opt.contact_sensor_maxmatch = self.cfg.contact_sensor_maxmatch
-      self.cfg.mujoco.apply_warp(self._wp_model.opt)
+      self.cfg.apply_wp_opt(self._wp_model.opt)
       self._finish_init()
 
   def _init_with_variants(
@@ -300,8 +294,7 @@ class Simulation:
       mujoco.mj_forward(self._mj_model, self._mj_data)
 
       self._wp_model = result.wp_model
-      self._wp_model.opt.contact_sensor_maxmatch = self.cfg.contact_sensor_maxmatch
-      self.cfg.mujoco.apply_warp(self._wp_model.opt)
+      self.cfg.apply_wp_opt(self._wp_model.opt)
 
       # Snapshot variant-dependent fields as per-world defaults so
       # DR scale/add operations use each variant's base values.

--- a/src/mjlab/sim/sim.py
+++ b/src/mjlab/sim/sim.py
@@ -68,6 +68,17 @@ _SOLVER_MAP = {
   "cg": mujoco.mjtSolver.mjSOL_CG,
   "pgs": mujoco.mjtSolver.mjSOL_PGS,
 }
+_BROADPHASE_MAP = {
+  "nxn": mjwarp.BroadphaseType.NXN,
+  "sap_tile": mjwarp.BroadphaseType.SAP_TILE,
+  "sap_segmented": mjwarp.BroadphaseType.SAP_SEGMENTED,
+}
+_BROADPHASE_FILTER_MAP: dict[str, mjwarp.BroadphaseFilter] = {
+  "plane": mjwarp.BroadphaseFilter.PLANE,
+  "sphere": mjwarp.BroadphaseFilter.SPHERE,
+  "aabb": mjwarp.BroadphaseFilter.AABB,
+  "obb": mjwarp.BroadphaseFilter.OBB,
+}
 
 # Maps short flag names to MuJoCo enum values.
 # Names match the XML <flag> attribute names (e.g. <flag contact="disable"/>).
@@ -113,6 +124,14 @@ class MujocoCfg:
   enableflags: tuple[str, ...] = ()
   """Enable flags to set (e.g. ``("energy",)`` to enable energy computation)."""
 
+  # Broadphase settings (MuJoCo Warp only; not part of mujoco.MjOption).
+  broadphase: Literal["nxn", "sap_tile", "sap_segmented"] | None = None
+  """Broadphase collision algorithm. If None, use the MuJoCo Warp default."""
+  broadphase_filter: tuple[Literal["plane", "sphere", "aabb", "obb"], ...] | None = None
+  """Bounding-volume filters applied during broadphase collision checking.
+
+  If None, use the MuJoCo Warp default."""
+
   def apply(self, model: mujoco.MjModel) -> None:
     """Apply configuration settings to a compiled MjModel."""
     model.opt.jacobian = _JACOBIAN_MAP[self.jacobian]
@@ -139,6 +158,19 @@ class MujocoCfg:
           f"Unknown enable flag {flag!r}. Valid flags: {sorted(_ENABLE_FLAG_MAP)}"
         )
       model.opt.enableflags |= _ENABLE_FLAG_MAP[flag]
+
+  def apply_warp(self, wp_opt: mjwarp.Option) -> None:
+    """Apply MuJoCo Warp-only settings to a warp Option (post ``put_model``).
+
+    Fields left as ``None`` retain whatever ``put_model`` already set, i.e.
+    the MuJoCo Warp default.
+    """
+    if self.broadphase is not None:
+      wp_opt.broadphase = _BROADPHASE_MAP[self.broadphase]
+    if self.broadphase_filter is not None:
+      wp_opt.broadphase_filter = mjwarp.BroadphaseFilter(0)
+      for name in self.broadphase_filter:
+        wp_opt.broadphase_filter |= _BROADPHASE_FILTER_MAP[name]
 
 
 @dataclass(kw_only=True)
@@ -240,6 +272,7 @@ class Simulation:
     with wp.ScopedDevice(self.wp_device):
       self._wp_model = mjwarp.put_model(self._mj_model)
       self._wp_model.opt.contact_sensor_maxmatch = self.cfg.contact_sensor_maxmatch
+      self.cfg.mujoco.apply_warp(self._wp_model.opt)
       self._finish_init()
 
   def _init_with_variants(
@@ -268,6 +301,7 @@ class Simulation:
 
       self._wp_model = result.wp_model
       self._wp_model.opt.contact_sensor_maxmatch = self.cfg.contact_sensor_maxmatch
+      self.cfg.mujoco.apply_warp(self._wp_model.opt)
 
       # Snapshot variant-dependent fields as per-world defaults so
       # DR scale/add operations use each variant's base values.

--- a/tests/test_sim.py
+++ b/tests/test_sim.py
@@ -48,6 +48,8 @@ def test_simulation_config_is_piped(robot_xml, device):
 
   cfg = SimulationCfg(
     contact_sensor_maxmatch=128,
+    broadphase="sap_tile",
+    broadphase_filter=("plane", "aabb"),
     mujoco=MujocoCfg(
       timestep=0.02,
       integrator="euler",
@@ -57,8 +59,6 @@ def test_simulation_config_is_piped(robot_xml, device):
       ccd_iterations=20,
       gravity=(0, 0, 7.5),
       enableflags=("energy",),
-      broadphase="sap_tile",
-      broadphase_filter=("plane", "aabb"),
     ),
   )
 
@@ -86,14 +86,23 @@ def test_simulation_config_is_piped(robot_xml, device):
   assert sim.model.opt.iterations == cfg.mujoco.iterations
   assert sim.model.opt.enableflags & mujoco.mjtEnableBit.mjENBL_ENERGY
 
-  # SimulationCfg should be applied to wp_model.
+  # SimulationCfg's warp-only settings should be applied to wp_model.opt.
   assert sim.wp_model.opt.contact_sensor_maxmatch == cfg.contact_sensor_maxmatch
-
-  # Broadphase settings are warp-only, applied directly to wp_model.opt.
   assert sim.wp_model.opt.broadphase == mjwarp.BroadphaseType.SAP_TILE
   assert sim.wp_model.opt.broadphase_filter == (
     mjwarp.BroadphaseFilter.PLANE | mjwarp.BroadphaseFilter.AABB
   )
+
+
+def test_default_broadphase_keeps_put_model_heuristic(robot_xml, device):
+  """Unset broadphase settings should not override put_model's own heuristic."""
+  model = mujoco.MjModel.from_xml_string(robot_xml)
+  heuristic_opt = mjwarp.put_model(model).opt
+
+  sim = Simulation(num_envs=1, cfg=SimulationCfg(), model=model, device=device)
+
+  assert sim.wp_model.opt.broadphase == heuristic_opt.broadphase
+  assert sim.wp_model.opt.broadphase_filter == heuristic_opt.broadphase_filter
 
 
 def test_ls_parallel_is_deprecated():

--- a/tests/test_sim.py
+++ b/tests/test_sim.py
@@ -1,6 +1,7 @@
 """Tests for sim.py."""
 
 import mujoco
+import mujoco_warp as mjwarp
 import numpy as np
 import pytest
 import torch
@@ -56,6 +57,8 @@ def test_simulation_config_is_piped(robot_xml, device):
       ccd_iterations=20,
       gravity=(0, 0, 7.5),
       enableflags=("energy",),
+      broadphase="sap_tile",
+      broadphase_filter=("plane", "aabb"),
     ),
   )
 
@@ -85,6 +88,12 @@ def test_simulation_config_is_piped(robot_xml, device):
 
   # SimulationCfg should be applied to wp_model.
   assert sim.wp_model.opt.contact_sensor_maxmatch == cfg.contact_sensor_maxmatch
+
+  # Broadphase settings are warp-only, applied directly to wp_model.opt.
+  assert sim.wp_model.opt.broadphase == mjwarp.BroadphaseType.SAP_TILE
+  assert sim.wp_model.opt.broadphase_filter == (
+    mjwarp.BroadphaseFilter.PLANE | mjwarp.BroadphaseFilter.AABB
+  )
 
 
 def test_ls_parallel_is_deprecated():


### PR DESCRIPTION
Mujoco warp has broadphase algorithm options that do not exist in `mjOption` as documented here: https://mujoco.readthedocs.io/en/latest/mjwarp/#options

These are set based on some heuristic thresholds in `mujoco_warp` here: https://github.com/google-deepmind/mujoco_warp/blob/af9d54ad63476e1f88118e5971f08835c3b15b62/mujoco_warp/_src/io.py#L601-L606

This PR exposes the settings in mjlab so that they can be tuned for per-task performance. These options default to `None` in which case we fallback to the `mujoco_warp` heuristics