### PR TITLE
Add material id randomization 

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -186,6 +186,8 @@ Added
   prefixed and scattered via ``geom_matid`` alongside the existing
   ``geom_dataid`` table. Variants without a material get ``matid = -1``.
   Contribution by @omarrayyann.
+- Added ``dr.geom_matid`` to randomize which baked material each geom uses
+  per environment, sampling uniformly from ``asset_cfg.material_names``.
 
 Changed
 ^^^^^^^

--- a/docs/source/randomization.rst
+++ b/docs/source/randomization.rst
@@ -821,9 +821,11 @@ per-environment values.
    * - Category
      - Field(s)
      - Notes
-   * - Texture ID swapping
+   * - Texture-role swapping
      - ``mat_texid``
-     - Integer IDs that need a swapping API, not continuous sampling.
+     - Not implemented for now because mujoco's viewer doesn't reread 
+       ``mat_taxid`` after context creation; use ``geom_matid`` with one baked 
+       material per texture to randomize textures instead.
    * - Mesh
      - ``mesh_vert``, ``mesh_normal``, ``mesh_face``, etc.
      - Shape variation for manipulation objects. These fields

--- a/docs/source/randomization.rst
+++ b/docs/source/randomization.rst
@@ -87,6 +87,10 @@ and ``dr.body_ipos`` are the same function).
      - ``geom_size``
      - Geom-specific size parameters (radius, half-lengths, etc.)
      - Automatically recomputes ``geom_rbound`` and ``geom_aabb``
+   * - ``dr.geom_matid``
+     - ``geom_matid``
+     - Which baked material the geom renders with
+     - Samples uniformly from ``asset_cfg.material_names``
 
 .. rubric:: Body fields
 
@@ -817,10 +821,9 @@ per-environment values.
    * - Category
      - Field(s)
      - Notes
-   * - Material / texture swapping
-     - ``geom_matid``, ``mat_texid``
-     - Integer IDs that need a swapping API, not continuous
-       sampling. Requires material-level entity indexing.
+   * - Texture ID swapping
+     - ``mat_texid``
+     - Integer IDs that need a swapping API, not continuous sampling.
    * - Mesh
      - ``mesh_vert``, ``mesh_normal``, ``mesh_face``, etc.
      - Shape variation for manipulation objects. These fields
@@ -1328,7 +1331,8 @@ The native viewer syncs per-world model fields from the GPU to a local
 ``MjModel`` before each render. All of MuJoCo's built-in visualization
 toggles then work correctly against the randomized model:
 
-- Geom appearance (``geom_rgba``, ``geom_size``, ``geom_pos``, ``geom_quat``)
+- Geom appearance (``geom_rgba``, ``geom_size``, ``geom_pos``, ``geom_quat``,
+  ``geom_matid``)
 - Material appearance (``mat_rgba``, ``mat_emission``, ``mat_specular``,
   ``mat_shininess``, ``mat_texrepeat``)
 - Body and site poses (``body_pos``, ``body_quat``, ``body_ipos``,

--- a/docs/source/randomization.rst
+++ b/docs/source/randomization.rst
@@ -824,7 +824,7 @@ per-environment values.
    * - Texture-role swapping
      - ``mat_texid``
      - Not implemented for now because mujoco's viewer doesn't reread 
-       ``mat_taxid`` after context creation; use ``geom_matid`` with one baked 
+       ``mat_texid`` after context creation; use ``geom_matid`` with one baked 
        material per texture to randomize textures instead.
    * - Mesh
      - ``mesh_vert``, ``mesh_normal``, ``mesh_face``, etc.

--- a/docs/source/randomization.rst
+++ b/docs/source/randomization.rst
@@ -823,8 +823,8 @@ per-environment values.
      - Notes
    * - Texture-role swapping
      - ``mat_texid``
-     - Not implemented for now because mujoco's viewer doesn't reread 
-       ``mat_texid`` after context creation; use ``geom_matid`` with one baked 
+     - Not implemented for now because mujoco's viewer doesn't reread
+       ``mat_texid`` after context creation; use ``geom_matid`` with one baked
        material per texture to randomize textures instead.
    * - Mesh
      - ``mesh_vert``, ``mesh_normal``, ``mesh_face``, etc.

--- a/src/mjlab/envs/mdp/dr/__init__.py
+++ b/src/mjlab/envs/mdp/dr/__init__.py
@@ -14,6 +14,7 @@ from ._types import uniform as uniform
 # Geom.
 # isort: split
 from .geom import geom_friction as geom_friction
+from .geom import geom_matid as geom_matid
 from .geom import geom_pos as geom_pos
 from .geom import geom_quat as geom_quat
 from .geom import geom_rgba as geom_rgba

--- a/src/mjlab/envs/mdp/dr/_core.py
+++ b/src/mjlab/envs/mdp/dr/_core.py
@@ -312,6 +312,38 @@ def _generate_random_values(
   return result
 
 
+# Categorical engine.
+
+
+def _randomize_categorical_field(
+  env: ManagerBasedRlEnv,
+  env_ids: torch.Tensor | None,
+  field: str,
+  *,
+  entity_type: str,
+  pool: torch.Tensor,
+  asset_cfg: SceneEntityCfg,
+  shared_random: bool = False,
+) -> None:
+  """Core engine for categorical fields: assign each entry a value from ``pool``."""
+  asset = env.scene[asset_cfg.name]
+
+  if env_ids is None:
+    env_ids = torch.arange(env.num_envs, device=env.device, dtype=torch.int)
+  else:
+    env_ids = env_ids.to(env.device, dtype=torch.int)
+
+  entity_indices = _get_entity_indices(asset.indexing, asset_cfg, entity_type, False)
+  env_grid, entity_grid = torch.meshgrid(env_ids, entity_indices, indexing="ij")
+
+  sample_shape = (env_ids.numel(), 1) if shared_random else env_grid.shape
+  pick = torch.randint(0, int(pool.numel()), sample_shape, device=env.device)
+  pick = pick.expand(env_grid.shape)
+
+  model_field = getattr(env.sim.model, field)
+  model_field[env_grid, entity_grid] = pool[pick]
+
+
 # Quaternion helpers.
 
 

--- a/src/mjlab/envs/mdp/dr/geom.py
+++ b/src/mjlab/envs/mdp/dr/geom.py
@@ -14,6 +14,7 @@ from ._core import (
   _DEFAULT_ASSET_CFG,
   Ranges,
   _get_entity_indices,
+  _randomize_categorical_field,
   _randomize_model_field,
   _randomize_quat_field,
 )
@@ -283,3 +284,42 @@ def geom_size(
     default_axes=[0, 1, 2],
   )
   _recompute_geom_bounds(env, env_ids, asset_cfg)
+
+
+@requires_model_fields("geom_matid")
+def geom_matid(
+  env: ManagerBasedRlEnv,
+  env_ids: torch.Tensor | None,
+  asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
+  shared_random: bool = False,
+) -> None:
+  """Randomize which baked material each selected geom uses.
+
+  Each geom is assigned a material drawn uniformly from ``asset_cfg.material_names``.
+  Assigning a material to a geom that had none (``matid < 0``) switches its color
+  source from ``geom_rgba`` to the material's ``mat_rgba``/texture.
+
+  Args:
+    env: The environment instance.
+    env_ids: Environment indices to randomize. ``None`` means all.
+    asset_cfg: Entity, geom, and material selection.
+    shared_random: If ``True``, all selected geoms receive the same sampled value per
+      environment.
+  """
+  asset = env.scene[asset_cfg.name]
+  mat_ids = _get_entity_indices(asset.indexing, asset_cfg, "material", False)
+  if mat_ids.numel() == 0:
+    raise ValueError(
+      f"No materials selected for entity '{asset_cfg.name}'. Set "
+      "SceneEntityCfg.material_names to a non-empty selection."
+    )
+
+  _randomize_categorical_field(
+    env,
+    env_ids,
+    "geom_matid",
+    entity_type="geom",
+    pool=mat_ids,
+    asset_cfg=asset_cfg,
+    shared_random=shared_random,
+  )

--- a/tests/test_domain_randomization.py
+++ b/tests/test_domain_randomization.py
@@ -1819,20 +1819,27 @@ def matid_env(device):
 
 
 def test_geom_matid_draws_from_pool(matid_env):
-  """Assigned matids come from the selected pool; diversity across envs."""
+  """Assigned matids come from the pool and actually change from the defaults."""
   torch.manual_seed(42)
   env = matid_env
   robot = env.scene["robot"]
   asset_cfg = SceneEntityCfg("robot", geom_names=(".*",), material_names=(".*",))
   asset_cfg.resolve(env.scene)
 
-  dr.geom_matid(env, env_ids=None, asset_cfg=asset_cfg)
-
   geom_ids = robot.indexing.geom_ids[asset_cfg.geom_ids]
   mat_ids = robot.indexing.mat_ids[asset_cfg.material_ids]
+  original = env.sim.model.geom_matid[:, geom_ids].clone()
+
+  dr.geom_matid(env, env_ids=None, asset_cfg=asset_cfg)
+
   assigned = env.sim.model.geom_matid[:, geom_ids]
+  # Every assignment is a valid member of the selected pool.
   assert torch.all(torch.isin(assigned, mat_ids))
-  assert len(torch.unique(assigned)) >= 2
+  # Randomization is not a no-op: values differ from the baked defaults, and at
+  # least one geom draws a material it did not start with (proving the full pool
+  # is sampled, not just the compile-time defaults).
+  assert not torch.equal(assigned, original)
+  assert torch.isin(assigned, torch.unique(original), invert=True).any()
 
 
 def test_geom_matid_partial_env_ids(matid_env):
@@ -1856,7 +1863,7 @@ def test_geom_matid_partial_env_ids(matid_env):
 
 
 def test_geom_matid_invalid_material_name(matid_env):
-  """ValueError for unknown material name."""
+  """Unknown material name is rejected during config resolution."""
   env = matid_env
 
   with pytest.raises(ValueError, match="nonexistent_material"):
@@ -1864,6 +1871,16 @@ def test_geom_matid_invalid_material_name(matid_env):
       "robot", geom_names=(".*",), material_names=("nonexistent_material",)
     )
     cfg.resolve(env.scene)
+    dr.geom_matid(env, env_ids=None, asset_cfg=cfg)
+
+
+def test_geom_matid_empty_material_selection(matid_env):
+  """geom_matid raises when the resolved material pool is empty."""
+  env = matid_env
+  cfg = SceneEntityCfg("robot", geom_names=(".*",), material_names=())
+  cfg.resolve(env.scene)
+
+  with pytest.raises(ValueError, match="No materials selected"):
     dr.geom_matid(env, env_ids=None, asset_cfg=cfg)
 
 

--- a/tests/test_domain_randomization.py
+++ b/tests/test_domain_randomization.py
@@ -1782,6 +1782,110 @@ def test_mat_rgba_invalid_name(mat_env):
     )
 
 
+# geom_matid DR tests.
+
+GEOM_MATID_XML = """
+<mujoco>
+  <asset>
+    <material name="mat_a" rgba="1 0 0 1"/>
+    <material name="mat_b" rgba="0 1 0 1"/>
+    <material name="mat_c" rgba="0 0 1 1"/>
+  </asset>
+  <worldbody>
+    <body name="base" pos="0 0 1">
+      <freejoint name="free_joint"/>
+      <geom name="geom1" type="box" size="0.1 0.1 0.1" mass="1.0" material="mat_a"/>
+      <geom name="geom2" type="sphere" size="0.05" mass="0.3" material="mat_b"/>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+
+def _make_matid_env(device, num_envs=NUM_ENVS):
+  entity_cfg = EntityCfg(spec_fn=lambda: mujoco.MjSpec.from_string(GEOM_MATID_XML))
+  scene_cfg = SceneCfg(num_envs=num_envs, entities={"robot": entity_cfg})
+  scene = Scene(scene_cfg, device)
+  model = scene.compile()
+  sim = Simulation(num_envs=num_envs, cfg=SimulationCfg(), model=model, device=device)
+  scene.initialize(model, sim.model, sim.data)
+  sim.expand_model_fields(("geom_matid",))
+  return Env(scene, sim, device)
+
+
+@pytest.fixture(scope="module")
+def matid_env(device):
+  return _make_matid_env(device)
+
+
+def test_geom_matid_draws_from_pool(matid_env):
+  """Assigned matids come from the selected pool; diversity across envs."""
+  torch.manual_seed(42)
+  env = matid_env
+  robot = env.scene["robot"]
+  asset_cfg = SceneEntityCfg("robot", geom_names=(".*",), material_names=(".*",))
+  asset_cfg.resolve(env.scene)
+
+  dr.geom_matid(env, env_ids=None, asset_cfg=asset_cfg)
+
+  geom_ids = robot.indexing.geom_ids[asset_cfg.geom_ids]
+  mat_ids = robot.indexing.mat_ids[asset_cfg.material_ids]
+  assigned = env.sim.model.geom_matid[:, geom_ids]
+  assert torch.all(torch.isin(assigned, mat_ids))
+  assert len(torch.unique(assigned)) >= 2
+
+
+def test_geom_matid_partial_env_ids(matid_env):
+  """Randomizing subset of envs leaves others unchanged."""
+  torch.manual_seed(42)
+  env = matid_env
+  robot = env.scene["robot"]
+  asset_cfg = SceneEntityCfg("robot", geom_names=(".*",), material_names=(".*",))
+  asset_cfg.resolve(env.scene)
+  geom_ids = robot.indexing.geom_ids[asset_cfg.geom_ids]
+
+  original = env.sim.model.geom_matid[:, geom_ids].clone()
+
+  dr.geom_matid(
+    env, env_ids=torch.tensor([0, 2], device=env.device), asset_cfg=asset_cfg
+  )
+
+  result = env.sim.model.geom_matid[:, geom_ids]
+  assert torch.all(result[1] == original[1])
+  assert torch.all(result[3] == original[3])
+
+
+def test_geom_matid_invalid_material_name(matid_env):
+  """ValueError for unknown material name."""
+  env = matid_env
+
+  with pytest.raises(ValueError, match="nonexistent_material"):
+    cfg = SceneEntityCfg(
+      "robot", geom_names=(".*",), material_names=("nonexistent_material",)
+    )
+    cfg.resolve(env.scene)
+    dr.geom_matid(env, env_ids=None, asset_cfg=cfg)
+
+
+def test_geom_matid_shared_random(matid_env):
+  """All geoms within same env get same material, envs differ."""
+  torch.manual_seed(42)
+  env = matid_env
+  robot = env.scene["robot"]
+  asset_cfg = SceneEntityCfg("robot", geom_names=(".*",), material_names=(".*",))
+  asset_cfg.resolve(env.scene)
+  geom_ids = robot.indexing.geom_ids[asset_cfg.geom_ids]
+
+  dr.geom_matid(env, env_ids=None, asset_cfg=asset_cfg, shared_random=True)
+
+  assigned = env.sim.model.geom_matid[:, geom_ids]
+  for env_idx in range(env.num_envs):
+    env_matids = assigned[env_idx]
+    assert torch.all(env_matids == env_matids[0])
+
+  assert len(torch.unique(assigned[:, 0])) > 1
+
+
 # pair_friction tests.
 
 PAIR_XML = """


### PR DESCRIPTION
This PR adds material randomization. It's implemented as a thin wrapper around a new `_randomize_categorical_field` similar to `_randomize_model_field` and `_randomize_quat_field` but for uniform sampling of integer fields. I originally also implemented mat_texid randomization this way, but it turns out mujoco's renderer bakes the texture ID mapping into the render context and never rereads mat_texid live (even though the warp renderer _does_ reread it correctly). Since it's not supported by MujocoViewer currently I decided to leave it out to avoid inconsistent behavior between the viewer and the warp renderer. 