### PR TITLE
Enable skybox rendering in camera sensors

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -18,6 +18,7 @@ Added
 Changed
 ^^^^^^^
 
+- Enabled skybox rendering for camera sensors.
 - Command delay on fusable actuators (ideal PD, DC motor) now applies one shared
   lag per environment across all fused actuators sharing a delay config, matching
   the built-in actuator path, rather than an independent lag per actuator group

--- a/src/mjlab/sensor/sensor_context.py
+++ b/src/mjlab/sensor/sensor_context.py
@@ -325,6 +325,7 @@ class SensorContext:
         cam_active=cam_active,
         use_precomputed_rays=not self._disable_precomputed_rays,
         render_seg=render_seg,
+        render_skybox=True,
       )
 
     # Cache address arrays from the render context. An adr value of -1 means that data


### PR DESCRIPTION
mujoco_warp recently [added](https://github.com/google-deepmind/mujoco_warp/pull/1308) skybox rendering support, this PR just sets that flag to true during sensor context creation