### PR TITLE
Fix TorchArray world-dim expansion for mujoco_warp 3.10.0.2

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -27,6 +27,10 @@ Changed
 Fixed
 ^^^^^
 
+- Fixed ``TorchArray`` not expanding world-shared model fields to ``nworld``
+  with mujoco_warp 3.10.0.2, which allocates them as real size-1 arrays
+  instead of stride-0 broadcast views. Multi-env indexing of fields like
+  ``soft_joint_pos_limits`` raised ``IndexError`` during resets.
 - Fixed ``mdp.bad_orientation`` returning NaN when float32 rounding in
   ``quat_apply_inverse`` pushed the projected-gravity z-component slightly
   outside ``[-1, 1]``, making ``torch.acos`` return NaN and silently

--- a/src/mjlab/sim/sim_data.py
+++ b/src/mjlab/sim/sim_data.py
@@ -30,8 +30,8 @@ class TorchArray:
       nworld is not None
       and nworld > 1
       and len(self._tensor.shape) > 0
-      and self._tensor.stride(0) == 0
       and self._tensor.shape[0] == 1
+      and (self._tensor.stride(0) == 0 or getattr(wp_array, "_is_batched", False))
     ):
       new_shape = (nworld,) + self._tensor.shape[1:]
       self._tensor = self._tensor.expand(new_shape)

--- a/tests/test_sim_data.py
+++ b/tests/test_sim_data.py
@@ -46,6 +46,23 @@ def test_torch_array_ops_work(device):
   assert torch.sum(torch_arr).item() == 3.0  # type: ignore
 
 
+def test_torch_array_expands_batched_singleton_world_dim(device):
+  """Size-1 world dim expands to nworld when mjwarp marks the array batched."""
+  with wp.ScopedDevice(device):
+    wp_arr = wp.array([[1.0, 2.0]], dtype=wp.float32)
+  setattr(wp_arr, "_is_batched", True)  # noqa: B010
+  torch_arr = TorchArray(wp_arr, nworld=4)
+  assert torch_arr.shape == (4, 2)
+
+
+def test_torch_array_keeps_unbatched_singleton_dim(device):
+  """A real size-1 leading dim without the batched marker is not expanded."""
+  with wp.ScopedDevice(device):
+    wp_arr = wp.array([[1.0, 2.0]], dtype=wp.float32)
+  torch_arr = TorchArray(wp_arr, nworld=4)
+  assert torch_arr.shape == (1, 2)
+
+
 def test_bridge_wraps_arrays(mock_data):
   """WarpBridge wraps warp arrays as TorchArray."""
   bridge = WarpBridge(mock_data)


### PR DESCRIPTION
mujoco_warp 3.10.0.2 (released July 13) allocates world-shared model fields as real size-1 arrays instead of stride-0 broadcast views. TorchArray detected shared fields via `stride(0) == 0`, so it stopped expanding them to nworld, and any multi-env indexing of fields like `soft_joint_pos_limits` raised `IndexError: index 1 is out of bounds for dimension 0 with size 1` during resets. This currently breaks the latest-deps CI job (7 failures in test_auto_reset.py and test_entity_data.py) on any push, and the next nightly will hit it too.

The fix accepts mjwarp's `_is_batched` marker in addition to the stride-0 check when deciding to expand a size-1 leading dim. The marker is set on all world-batched Model/Data arrays since mujoco_warp PR #1465; the stride check is kept for older versions that don't mark all arrays. Non-batched fields whose leading dim happens to be 1 (e.g. `jnt_type` of a single-joint model) carry neither signal and are still left alone.

Verified locally: with mujoco-warp 3.10.0.2 the previously failing suites pass (47 passed), and the full fast suite passes on locked 3.10.0.1 (976 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)