### PR TITLE
Prepare for 1.5.1

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -33,9 +33,9 @@ keywords:
   - reinforcement-learning
   - robotics
 license: Apache-2.0
-commit: f2e3e86d36bcfd6414f0f6b8c9b05b639e04262a
-version: 1.5.0
-date-released: '2026-06-28'
+commit: 0a39c574e376b12f423bc22f1e0463ee481a4ef3
+version: 1.5.1
+date-released: '2026-07-15'
 preferred-citation:
   type: article
   title: >-

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![GitHub Actions](https://img.shields.io/github/actions/workflow/status/mujocolab/mjlab/ci.yml?branch=main)](https://github.com/mujocolab/mjlab/actions/workflows/ci.yml?query=branch%3Amain)
 [![Documentation](https://github.com/mujocolab/mjlab/actions/workflows/docs.yml/badge.svg)](https://mujocolab.github.io/mjlab/)
 [![License](https://img.shields.io/github/license/mujocolab/mjlab)](https://github.com/mujocolab/mjlab/blob/main/LICENSE)
+[![MuJoCo Warp](https://img.shields.io/badge/MuJoCo_Warp-3.10.0.2-blue)](https://github.com/google-deepmind/mujoco_warp/releases/tag/v3.10.0.2)
 [![Nightly Benchmarks](https://img.shields.io/badge/Nightly-Benchmarks-blue)](https://mujocolab.github.io/mjlab/nightly/)
 [![PyPI](https://img.shields.io/pypi/v/mjlab)](https://pypi.org/project/mjlab/)
 [![PyPI downloads](https://img.shields.io/pypi/dm/mjlab?color=blue)](https://pypistats.org/packages/mjlab)

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,6 +8,18 @@ Upcoming version (not yet released)
 Added
 ^^^^^
 
+Changed
+^^^^^^^
+
+Fixed
+^^^^^
+
+Version 1.5.1 (July 15, 2026)
+-----------------------------
+
+Added
+^^^^^
+
 - Added ``MeshCfg``, a spec editor that matches mesh assets by name and edits
   their asset-level attributes. The first attribute is ``maxhullvert``, which
   caps the collision convex hull's vertex count to lower narrowphase cost.
@@ -19,6 +31,9 @@ Changed
 ^^^^^^^
 
 - Enabled skybox rendering for camera sensors.
+- Bumped the minimum ``mujoco-warp`` to 3.10.0.2, which fixes ``qfrc_constraint``
+  being populated incorrectly across vectorized environments (:issue:`1086`).
+  Earlier 3.10.0.x releases are no longer supported.
 - Command delay on fusable actuators (ideal PD, DC motor) now applies one shared
   lag per environment across all fused actuators sharing a delay config, matching
   the built-in actuator path, rather than an independent lag per actuator group
@@ -27,10 +42,13 @@ Changed
 Fixed
 ^^^^^
 
+- Fixed ``TerrainGenerator`` overwriting custom geom names set by sub-terrain
+  functions with the default ``terrain_{i}`` name. Only unnamed geoms are now
+  auto-named.
 - Fixed ``TorchArray`` not expanding world-shared model fields to ``nworld``
   with mujoco_warp 3.10.0.2, which allocates them as real size-1 arrays
   instead of stride-0 broadcast views. Multi-env indexing of fields like
-  ``soft_joint_pos_limits`` raised ``IndexError`` during resets.
+  ``soft_joint_pos_limits`` raised ``IndexError`` during resets (:issue:`1093`).
 - Fixed ``mdp.bad_orientation`` returning NaN when float32 rounding in
   ``quat_apply_inverse`` pushed the projected-gravity z-component slightly
   outside ``[-1, 1]``, making ``torch.acos`` return NaN and silently
@@ -251,9 +269,6 @@ Changed
 Fixed
 ^^^^^
 
-- Fixed ``TerrainGenerator`` overwriting custom geom names set by sub-terrain
-  functions with the default ``terrain_{i}`` name. Only unnamed geoms are now
-  auto-named.
 - Removed use of deprecated ``warp-lang`` symbols (``wp.context.runtime``
   and ``wp.context.Device``) that were dropped in newer ``warp-lang``
   releases, causing ``AttributeError: module 'warp' has no attribute

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "mjlab"
-version = "1.5.0"
+version = "1.5.1"
 license = "Apache-2.0"
 license-files = ["LICENSE"]
 readme = { file = "README.md", content-type = "text/markdown" }
@@ -37,7 +37,7 @@ dependencies = [
   "torch>=2.7.0",
   "torchrunx>=0.3.4",
   "warp-lang>=1.14.0",
-  "mujoco-warp>=3.10.0.1,~=3.10.0",
+  "mujoco-warp>=3.10.0.2,~=3.10.0",
   "mujoco~=3.10.0",
   "trimesh>=4.8.3",
   "scipy>=1.15",

--- a/src/mjlab/tasks/cartpole/cartpole.xml
+++ b/src/mjlab/tasks/cartpole/cartpole.xml
@@ -1,6 +1,4 @@
 <mujoco model="cartpole">
-  <option timestep="0.01"/>
-
   <default>
     <default class="pole">
       <joint type="hinge" axis="0 1 0" damping="2e-6"/>

--- a/uv.lock
+++ b/uv.lock
@@ -1644,7 +1644,7 @@ wheels = [
 
 [[package]]
 name = "mjlab"
-version = "1.5.0"
+version = "1.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "imageio-ffmpeg" },
@@ -1719,7 +1719,7 @@ requires-dist = [
     { name = "mediapy", specifier = ">=1.2.6" },
     { name = "mjviser", specifier = ">=0.0.14" },
     { name = "mujoco", specifier = "~=3.10.0" },
-    { name = "mujoco-warp", specifier = "~=3.10.0,>=3.10.0.1" },
+    { name = "mujoco-warp", specifier = "~=3.10.0,>=3.10.0.2" },
     { name = "numpy", specifier = "<2.5" },
     { name = "onnxscript", specifier = ">=0.5.4" },
     { name = "prettytable" },
@@ -1971,7 +1971,7 @@ wheels = [
 
 [[package]]
 name = "mujoco-warp"
-version = "3.10.0.1"
+version = "3.10.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "absl-py" },
@@ -1982,9 +1982,9 @@ dependencies = [
     { name = "warp-lang", version = "1.14.0", source = { registry = "https://pypi.nvidia.com/" }, marker = "sys_platform != 'darwin' or (extra == 'extra-5-mjlab-cpu' and extra == 'extra-5-mjlab-cu128')" },
     { name = "warp-lang", version = "1.14.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin' or (extra == 'extra-5-mjlab-cpu' and extra == 'extra-5-mjlab-cu128')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/e5/37d982ba8bdbad8455fb74da827aa4e8ea1b984db66171d4b66c458da985/mujoco_warp-3.10.0.1.tar.gz", hash = "sha256:adca3e740112bca1aaaa732556aad0f36fb3dea99f86abd22ee1232dc5e2b28d", size = 2046299, upload-time = "2026-06-26T15:59:41.217Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/b1/edd8743786263d756bb1ffded28ae211289334bbb1ad9729c40e6163b376/mujoco_warp-3.10.0.2.tar.gz", hash = "sha256:3fe8b5c68bd30eda31af45d1cbee42480a7d1c6e69a35733c5538445375fc570", size = 2066036, upload-time = "2026-07-13T18:24:40.645Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/32/9adafac9cf8133cebe5825b306be01ab9209ab0fb5a057cb29e4f5b23bd5/mujoco_warp-3.10.0.1-py3-none-any.whl", hash = "sha256:7a5871a5522796fa36ec5614dc214a180d4fc7de861e413ee1559d2cc4ec79f9", size = 2123960, upload-time = "2026-06-26T15:59:39.77Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/dc/928040ff3b95b2156dada9b4388a96fb423385c091663bb7f49f662a2d62/mujoco_warp-3.10.0.2-py3-none-any.whl", hash = "sha256:9245c952cd49761dea3f7fdb4060ee816dca0db3f2f63b561a80a02d20c40464", size = 2147055, upload-time = "2026-07-13T18:24:39.203Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Cuts v1.5.1. The main change is raising the minimum `mujoco-warp` to 3.10.0.2, which fixes `qfrc_constraint` across vectorized environments (#1086); 3.10.0.1 is dropped since it carries that bug. The rest is release bookkeeping.