### PR TITLE
Expand actuator acceleration for recomputation

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -14,6 +14,10 @@ Changed
 Fixed
 ^^^^^
 
+- Fixed CUDA illegal memory accesses when domain randomization triggers
+  ``set_const`` with multiple environments. ``actuator_acc0`` is now expanded
+  per environment before MuJoCo Warp recomputes it.
+
 Version 1.5.1 (July 15, 2026)
 -----------------------------
 

--- a/docs/source/randomization.rst
+++ b/docs/source/randomization.rst
@@ -1248,7 +1248,8 @@ The three recomputation levels, from cheapest to most expensive:
      - After changing ``body_gravcomp``
    * - ``set_const_0``
      - ``dof_invweight0``, ``body_invweight0``, ``tendon_length0``,
-       ``tendon_invweight0``, plus camera and light references
+       ``tendon_invweight0``, ``actuator_acc0``, plus camera and light
+       references
      - After changing ``dof_armature``, ``tendon_armature``,
        ``body_inertia``, ``body_pos``, ``body_quat``, or ``qpos0``
    * - ``set_const``

--- a/src/mjlab/managers/event_manager.py
+++ b/src/mjlab/managers/event_manager.py
@@ -42,8 +42,8 @@ class RecomputeLevel(enum.IntEnum):
 
   set_const_0 = 2
   """Recompute ``dof_invweight0``, ``body_invweight0``, ``tendon_length0``,
-  ``tendon_invweight0``. Use after modifying ``dof_armature``, ``body_inertia``,
-  ``body_pos``, ``body_quat``, or ``qpos0``."""
+  ``tendon_invweight0``, and ``actuator_acc0``. Use after modifying
+  ``dof_armature``, ``body_inertia``, ``body_pos``, ``body_quat``, or ``qpos0``."""
 
   set_const = 3
   """Full recomputation (superset of all lower levels). Use after modifying
@@ -58,6 +58,7 @@ _DERIVED_FIELDS: dict[RecomputeLevel, tuple[str, ...]] = {
     "body_invweight0",
     "tendon_length0",
     "tendon_invweight0",
+    "actuator_acc0",
   ),
 }
 _DERIVED_FIELDS[RecomputeLevel.set_const] = (

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -130,6 +130,35 @@ def test_dr_fields_registered_in_event_manager(device):
   assert len(manager.domain_randomization_fields) == 7
 
 
+def test_recompute_fields_registered_in_event_manager(device):
+  """Recomputed model fields are expanded per environment."""
+  env = Mock()
+  env.num_envs = 4
+  env.device = device
+  env.scene = {}
+  env.sim = Mock()
+
+  cfg = {
+    "body_com": EventTermCfg(
+      mode="startup",
+      func=dr.body_com_offset,
+      params={"ranges": (-0.01, 0.01)},
+    ),
+  }
+
+  manager = EventManager(cfg, env)
+
+  assert manager.domain_randomization_fields == (
+    "body_ipos",
+    "body_subtreemass",
+    "dof_invweight0",
+    "body_invweight0",
+    "tendon_length0",
+    "tendon_invweight0",
+    "actuator_acc0",
+  )
+
+
 def test_recompute_level_ordering():
   """IntEnum max() gives strongest level."""
   L = RecomputeLevel


### PR DESCRIPTION
MuJoCo Warp recomputes actuator_acc0 per world during set_const, but MjLab did not expand that field before per-environment domain randomization. Large vectorized runs could therefore write beyond the single-world allocation and fail with CUDA illegal memory accesses. This change expands actuator_acc0 with the other set_const-derived fields, documents the behavior, and adds regression coverage for the registered fields. Validated with the event-manager tests, make check, make test, and a 4,096-environment G1 training iteration with COM randomization enabled.