### PR TITLE
Fix reflectance not getting passed to add_material

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -17,6 +17,8 @@ Fixed
 - Fixed CUDA illegal memory accesses when domain randomization triggers
   ``set_const`` with multiple environments. ``actuator_acc0`` is now expanded
   per environment before MuJoCo Warp recomputes it.
+- Fixed ``MaterialCfg.reflectance`` being ignored when building the MuJoCo
+  spec. Contribution by @bd-pmorais.
 
 Version 1.5.1 (July 15, 2026)
 -----------------------------
@@ -34,7 +36,7 @@ Added
 Changed
 ^^^^^^^
 
-- Enabled skybox rendering for camera sensors.
+- Enabled skybox rendering for camera sensors. Contribution by @bd-pmorais.
 - Bumped the minimum ``mujoco-warp`` to 3.10.0.2, which fixes ``qfrc_constraint``
   being populated incorrectly across vectorized environments (:issue:`1086`).
   Earlier 3.10.0.x releases are no longer supported.
@@ -215,6 +217,7 @@ Added
   Contribution by @omarrayyann.
 - Added ``dr.geom_matid`` to randomize which baked material each geom uses
   per environment, sampling uniformly from ``asset_cfg.material_names``.
+  Contribution by @bd-pmorais.
 
 Changed
 ^^^^^^^

--- a/src/mjlab/utils/spec_config.py
+++ b/src/mjlab/utils/spec_config.py
@@ -137,6 +137,7 @@ class MaterialCfg(SpecCfg):
       rgba=self.rgba,
       texuniform=self.texuniform,
       texrepeat=self.texrepeat,
+      reflectance=self.reflectance,
     )
     if self.texture is not None:
       mat.textures[mujoco.mjtTextureRole.mjTEXROLE_RGB.value] = self.texture


### PR DESCRIPTION
This PR fixes a bug where the reflectance field in `MaterialCfg` wasn't getting passed to add_material and was therefore silently ignored. Also retroactively adds attribution to my other PRs :)