### PR TITLE
Prepare for 1.5.2

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -33,9 +33,9 @@ keywords:
   - reinforcement-learning
   - robotics
 license: Apache-2.0
-commit: 0a39c574e376b12f423bc22f1e0463ee481a4ef3
-version: 1.5.1
-date-released: '2026-07-15'
+commit: 7a09f6e8c03defd789474a92b112a91360d94268
+version: 1.5.2
+date-released: '2026-07-17'
 preferred-citation:
   type: article
   title: >-

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -14,6 +14,12 @@ Changed
 Fixed
 ^^^^^
 
+Version 1.5.2 (July 17, 2026)
+-----------------------------
+
+Fixed
+^^^^^
+
 - Fixed CUDA illegal memory accesses when domain randomization triggers
   ``set_const`` with multiple environments. ``actuator_acc0`` is now expanded
   per environment before MuJoCo Warp recomputes it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "mjlab"
-version = "1.5.1"
+version = "1.5.2"
 license = "Apache-2.0"
 license-files = ["LICENSE"]
 readme = { file = "README.md", content-type = "text/markdown" }

--- a/uv.lock
+++ b/uv.lock
@@ -1644,7 +1644,7 @@ wheels = [
 
 [[package]]
 name = "mjlab"
-version = "1.5.1"
+version = "1.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "imageio-ffmpeg" },


### PR DESCRIPTION
Cuts a 1.5.2 patch release. The 1.5.1 tag was created before the actuator_acc0 recomputation fix (#1098) and the MaterialCfg.reflectance fix (#1099) landed, so the published 1.5.1 still crashes with CUDA illegal memory accesses under multi-environment domain randomization. This bumps the version, regenerates the lockfile, updates CITATION.cff, and moves both fixes into a Version 1.5.2 changelog section.