### PR TITLE
Accumulate exact substep dt for contact air-time

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -14,6 +14,11 @@ Changed
 Fixed
 ^^^^^
 
+- Fixed ``ContactSensor`` air-time tracking accumulating float32 sim-clock
+  differences, whose quantization error grows with the clock magnitude and made
+  ``compute_first_contact`` / ``compute_first_air`` miss touchdowns on long runs.
+  The exact float64 substep ``dt`` is now accumulated instead. :issue:`1101`
+
 Version 1.5.2 (July 17, 2026)
 -----------------------------
 

--- a/src/mjlab/sensor/contact_sensor.py
+++ b/src/mjlab/sensor/contact_sensor.py
@@ -179,7 +179,6 @@ class _AirTimeState:
   last_air_time: torch.Tensor
   current_contact_time: torch.Tensor
   last_contact_time: torch.Tensor
-  last_time: torch.Tensor
 
 
 @dataclass
@@ -315,7 +314,6 @@ class ContactSensor(Sensor[ContactData]):
         last_air_time=torch.zeros((n_envs, n_primary), device=device),
         current_contact_time=torch.zeros((n_envs, n_primary), device=device),
         last_contact_time=torch.zeros((n_envs, n_primary), device=device),
-        last_time=torch.zeros((n_envs,), device=device),
       )
 
     if self.cfg.history_length > 0:
@@ -360,8 +358,6 @@ class ContactSensor(Sensor[ContactData]):
       self._air_time_state.last_air_time[env_ids] = 0.0
       self._air_time_state.current_contact_time[env_ids] = 0.0
       self._air_time_state.last_contact_time[env_ids] = 0.0
-      if self._data is not None:
-        self._air_time_state.last_time[env_ids] = self._data.time[env_ids]
 
     # Reset history state for specified envs.
     if self._history_state is not None:
@@ -371,7 +367,7 @@ class ContactSensor(Sensor[ContactData]):
   def update(self, dt: float) -> None:
     super().update(dt)
     if self._air_time_state is not None:
-      self._update_air_time_tracking()
+      self._update_air_time_tracking(dt)
     if self._history_state is not None:
       self._update_history()
 
@@ -442,17 +438,18 @@ class ContactSensor(Sensor[ContactData]):
 
     return data
 
-  def _update_air_time_tracking(self) -> None:
+  def _update_air_time_tracking(self, dt: float) -> None:
     assert self._air_time_state is not None
 
     contact_data = self._extract_sensor_data()
     if contact_data.found is None or "found" not in self.cfg.fields:
       return
 
-    assert self._data is not None
-    current_time = self._data.time
-    elapsed_time = current_time - self._air_time_state.last_time
-    elapsed_time = elapsed_time.unsqueeze(-1)
+    # Accumulate the exact float64 substep dt rather than differencing the
+    # float32 sim clock (`data.time`). The clock's quantization error grows with
+    # its magnitude (ULP ~= time * 1.2e-7) and, since `data.time` is never reset
+    # on env reset, it eventually swamps the abs_tol in compute_first_contact.
+    elapsed_time = dt
 
     # Reduce `found` from [B, P*num_slots] to [B, P]: a primary is in contact
     # if any of its slots reports a match. Air-time is tracked per primary.
@@ -486,8 +483,6 @@ class ContactSensor(Sensor[ContactData]):
       state.current_contact_time + elapsed_time,
       torch.zeros_like(state.current_contact_time),
     )
-
-    state.last_time[:] = current_time
 
   def _update_history(self) -> None:
     """Roll history buffer and insert current contact data at index 0."""

--- a/tests/test_contact_sensor.py
+++ b/tests/test_contact_sensor.py
@@ -591,6 +591,80 @@ def test_air_time_tracking(device):
   assert torch.any(data3.found > 0)
 
 
+def test_air_time_exact_at_large_sim_clock(device):
+  """Air-time accumulation is independent of the sim-clock magnitude.
+
+  Regression for issue #1101: `_update_air_time_tracking` used to accumulate
+  differences of the float32 sim clock (`data.time`), so the tracked values
+  inherited the clock's quantization error (ULP ~= time * 1.2e-7). That error
+  grows without bound as `data.time` grows (it is never reset on env reset) and
+  eventually exceeds the abs_tol in compute_first_contact, silently missing
+  first-substep touchdowns.
+
+  The fix accumulates the exact float64 substep dt instead, so `data.time` is
+  never read. We advance the clock to a large value and confirm the first
+  contact substep still reads exactly dt and first-contact fires. Against the
+  old code this asserts hard: the tracked time picks up the clock magnitude.
+  """
+  cfg = ContactSensorCfg(
+    name="feet_contact",
+    primary=ContactMatch(
+      mode="geom",
+      pattern=("left_foot_geom", "right_foot_geom"),
+      entity="biped",
+    ),
+    secondary=None,
+    fields=("found",),
+    track_air_time=True,
+  )
+
+  scene, sim = create_scene_with_sensor(BIPED_XML, "biped", cfg, device)
+  sensor = scene["feet_contact"]
+  dt = sim.cfg.mujoco.timestep
+
+  ground_state = torch.zeros((2, 13), device=sim.device)
+  ground_state[:, 2] = 0.25
+  ground_state[:, 3] = 1.0
+  air_state = ground_state.clone()
+  air_state[:, 2] = 1.0
+
+  # Settle the biped onto the ground so both feet are in stable contact, then
+  # lift it clear so the feet are airborne (current_air_time > 0, found == 0).
+  scene["biped"].write_root_state_to_sim(ground_state)
+  for _ in range(20):
+    sim.step()
+    scene.update(dt=dt)
+  scene["biped"].write_root_state_to_sim(air_state)
+  for _ in range(15):
+    sim.step()
+    scene.update(dt=dt)
+  assert torch.all(sensor.data.found == 0), "expected feet airborne before landing"
+
+  # Advance the sim clock far past the regime where float32 quantization exceeds
+  # the default abs_tol. The old code differenced this clock, so the first
+  # contact substep would inherit its magnitude; the fix ignores `data.time`.
+  sim.data.time[:] = 20_000.0
+
+  # Land: a single update in contact should read exactly one dt of contact time.
+  scene["biped"].write_root_state_to_sim(ground_state)
+  sim.step()
+  scene.update(dt=dt)
+
+  data = sensor.data
+  assert data.current_contact_time is not None
+  feet_landed = data.found.view(2, len(sensor.primary_names), -1).any(dim=-1)
+  assert torch.any(feet_landed), "expected at least one foot to land"
+
+  # The first contact substep reads exactly dt, independent of the huge clock.
+  assert torch.all(torch.abs(data.current_contact_time[feet_landed] - dt) < 1e-6), (
+    data.current_contact_time
+  )
+
+  # And first-contact detection at dt=step_dt fires for the feet that landed.
+  first_contact = sensor.compute_first_contact(dt=dt)
+  assert torch.all(first_contact[feet_landed])
+
+
 ##
 # Multi-sensor integration tests.
 ##


### PR DESCRIPTION
`ContactSensor` air-time tracking accumulated differences of the float32 sim clock (`data.time`), so the tracked contact/air times inherited the clock's quantization error, which grows with the clock magnitude and is never reset by env resets. Past ~16 s of sim time that error exceeds the abs_tol in `compute_first_contact`/`compute_first_air` and silently misses first-substep touchdowns. The fix accumulates the exact float64 substep `dt` that `update` already receives, making air-time independent of the clock, and drops the now-unused `last_time` state.