### PR TITLE
Fix Go1 velocity training crashes and velocity-task curriculum/observation bugs

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -14,6 +14,11 @@ Changed
 Fixed
 ^^^^^
 
+- Enabled ``obs_normalization`` on the Go1 velocity actor and critic to match
+  the other velocity tasks. Without it, extreme-but-finite observations on rough
+  terrain drove value/policy divergence that eventually surfaced as a
+  ``normal expects all elements of std >= 0.0`` crash. :issue:`870` :issue:`1044`
+  :issue:`1053`
 - Fixed ``ContactSensor`` air-time tracking accumulating float32 sim-clock
   differences, whose quantization error grows with the clock magnitude and made
   ``compute_first_contact`` / ``compute_first_air`` miss touchdowns on long runs.

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -27,13 +27,16 @@ Fixed
   See `discussion #1065 <https://github.com/mujocolab/mjlab/discussions/1065>`_.
 - Hardened ``fit_terrain_normal`` against non-finite raycast hits. A single env
   with a diverged state produced a NaN/Inf covariance that made
-  ``torch.linalg.eigh`` raise and crash the whole batch; such rows now fall back
-  to the up vector. :issue:`912`
+  ``torch.linalg.eigh`` raise and abort the whole batch; such rows now fall back
+  to the up vector. This stops the hard crash so a diverged env can be reset
+  normally; it does not by itself make a diverged env's downstream reward finite.
+  :issue:`912`
 - Enabled ``obs_normalization`` on the Go1 velocity actor and critic to match
   the other velocity tasks. Without it, extreme-but-finite observations on rough
   terrain drove value/policy divergence that eventually surfaced as a
-  ``normal expects all elements of std >= 0.0`` crash. :issue:`870` :issue:`1044`
-  :issue:`1053`
+  ``normal expects all elements of std >= 0.0`` crash. Note that Go1 velocity
+  checkpoints trained before this change carry no normalizer buffers and will no
+  longer load; retrain from scratch. :issue:`870` :issue:`1044` :issue:`1053`
 - Fixed ``ContactSensor`` air-time tracking accumulating float32 sim-clock
   differences, whose quantization error grows with the clock magnitude and made
   ``compute_first_contact`` / ``compute_first_air`` miss touchdowns on long runs.

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -14,6 +14,12 @@ Changed
 Fixed
 ^^^^^
 
+- Fixed the velocity task's actor ``joint_pos`` observation not being biased by
+  the ``encoder_bias`` domain randomization, so the encoder bias only affected
+  actions and never the observed joint positions. The actor now observes biased
+  joint positions while the critic keeps the true (unbiased) values as
+  privileged information, matching the tracking task.
+  See `discussion #1065 <https://github.com/mujocolab/mjlab/discussions/1065>`_.
 - Hardened ``fit_terrain_normal`` against non-finite raycast hits. A single env
   with a diverged state produced a NaN/Inf covariance that made
   ``torch.linalg.eigh`` raise and crash the whole batch; such rows now fall back

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -14,6 +14,10 @@ Changed
 Fixed
 ^^^^^
 
+- Hardened ``fit_terrain_normal`` against non-finite raycast hits. A single env
+  with a diverged state produced a NaN/Inf covariance that made
+  ``torch.linalg.eigh`` raise and crash the whole batch; such rows now fall back
+  to the up vector. :issue:`912`
 - Enabled ``obs_normalization`` on the Go1 velocity actor and critic to match
   the other velocity tasks. Without it, extreme-but-finite observations on rough
   terrain drove value/policy divergence that eventually surfaced as a

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -14,6 +14,11 @@ Changed
 Fixed
 ^^^^^
 
+- Fixed the ``terrain_levels_vel`` curriculum promoting every env from level 0
+  to level 1 on the initial reset, ignoring ``max_init_terrain_level=0``. Before
+  the first step the robot sits at its spawn pose rather than a walked-to
+  position, so the distance check was spurious; terrain levels are now frozen on
+  that first reset. :issue:`1094`
 - Fixed the velocity task's actor ``joint_pos`` observation not being biased by
   the ``encoder_bias`` domain randomization, so the encoder bias only affected
   actions and never the observed joint positions. The actor now observes biased

--- a/src/mjlab/tasks/velocity/config/go1/rl_cfg.py
+++ b/src/mjlab/tasks/velocity/config/go1/rl_cfg.py
@@ -13,7 +13,7 @@ def unitree_go1_ppo_runner_cfg() -> RslRlOnPolicyRunnerCfg:
     actor=RslRlModelCfg(
       hidden_dims=(512, 256, 128),
       activation="elu",
-      obs_normalization=False,
+      obs_normalization=True,
       distribution_cfg={
         "class_name": "GaussianDistribution",
         "init_std": 1.0,
@@ -23,7 +23,7 @@ def unitree_go1_ppo_runner_cfg() -> RslRlOnPolicyRunnerCfg:
     critic=RslRlModelCfg(
       hidden_dims=(512, 256, 128),
       activation="elu",
-      obs_normalization=False,
+      obs_normalization=True,
     ),
     algorithm=RslRlPpoAlgorithmCfg(
       value_loss_coef=1.0,

--- a/src/mjlab/tasks/velocity/mdp/curriculums.py
+++ b/src/mjlab/tasks/velocity/mdp/curriculums.py
@@ -54,6 +54,14 @@ def terrain_levels_vel(
   )
   move_down *= ~move_up
 
+  # On the initial reset (before any env step) the robot is still at its spawn
+  # pose rather than a walked-to position, so ``distance`` is meaningless and
+  # would spuriously promote every env from level 0 to 1, ignoring
+  # ``max_init_terrain_level``. Freeze levels on that first reset.
+  if env.common_step_counter == 0:
+    move_up = torch.zeros_like(move_up)
+    move_down = torch.zeros_like(move_down)
+
   # Update terrain levels.
   terrain.update_env_origins(env_ids, move_up, move_down)
 

--- a/src/mjlab/tasks/velocity/mdp/terrain_utils.py
+++ b/src/mjlab/tasks/velocity/mdp/terrain_utils.py
@@ -39,6 +39,16 @@ def fit_terrain_normal(
   centered = (points - centroid.unsqueeze(1)) * mask_f
 
   cov = torch.einsum("bni,bnj->bij", centered, centered)
+
+  # ``torch.linalg.eigh`` raises when given non-finite input, so a single env
+  # with a diverged state (NaN/Inf raycast hits) would take down the whole
+  # batch. Replace non-finite covariances with the identity so the decomposition
+  # stays well-defined; these rows fail the reliability check below and fall
+  # back to the up vector.
+  finite = torch.isfinite(cov).all(dim=(-2, -1))
+  eye = torch.eye(3, device=device, dtype=cov.dtype)
+  cov = torch.where(finite.view(-1, 1, 1), cov, eye)
+
   eigenvalues, eigenvectors = torch.linalg.eigh(cov)
   normal = eigenvectors[:, :, 0]  # Smallest eigenvalue = plane normal.
   normal = normal / normal.norm(dim=-1, keepdim=True).clamp(min=1e-8)
@@ -52,7 +62,7 @@ def fit_terrain_normal(
   eps = torch.finfo(eigenvalues.dtype).eps
   plane_like = (eigenvalues[:, 0] / eigenvalues[:, 1].clamp(min=eps)) < 0.1
   has_spread = eigenvalues[:, 1] > eigenvalues[:, 2].clamp(min=eps) * 1e-6
-  reliable = enough & plane_like & has_spread
+  reliable = enough & plane_like & has_spread & finite
 
   up = torch.tensor([0.0, 0.0, 1.0], device=device).expand(B, 3)
   return torch.where(reliable.unsqueeze(-1), normal, up)

--- a/src/mjlab/tasks/velocity/velocity_env_cfg.py
+++ b/src/mjlab/tasks/velocity/velocity_env_cfg.py
@@ -90,6 +90,7 @@ def make_velocity_env_cfg() -> ManagerBasedRlEnvCfg:
     ),
     "joint_pos": ObservationTermCfg(
       func=mdp.joint_pos_rel,
+      params={"biased": True},
       noise=Unoise(n_min=-0.01, n_max=0.01),
     ),
     "joint_vel": ObservationTermCfg(
@@ -111,6 +112,8 @@ def make_velocity_env_cfg() -> ManagerBasedRlEnvCfg:
 
   critic_terms = {
     **actor_terms,
+    # Critic sees the true (unbiased) joint positions as privileged information.
+    "joint_pos": ObservationTermCfg(func=mdp.joint_pos_rel),
     "height_scan": ObservationTermCfg(
       func=envs_mdp.height_scan,
       params={"sensor_name": "terrain_scan"},

--- a/tests/test_terrain_utils.py
+++ b/tests/test_terrain_utils.py
@@ -101,6 +101,30 @@ def test_collinear_points_fallback():
     torch.testing.assert_close(normal[b], expected, atol=1e-6, rtol=1e-6)
 
 
+def test_non_finite_points_fallback():
+  """Non-finite hits (from a diverged env) must not crash eigh; fall back to up."""
+  B, N = 3, 10
+  points = torch.zeros(B, N, 3)
+  # Batch 0: a valid tilted plane.
+  points[0, :, 0] = torch.linspace(0, 1, N)
+  points[0, :, 1] = torch.linspace(0, 1, N)
+  points[0, :, 2] = 0.2 * points[0, :, 0]
+  # Batch 1: all NaN. Batch 2: all Inf.
+  points[1] = float("nan")
+  points[2] = float("inf")
+  valid_mask = torch.ones(B, N, dtype=torch.bool)
+
+  normal = fit_terrain_normal(points, valid_mask)
+
+  assert torch.isfinite(normal).all()
+  expected_up = torch.tensor([0.0, 0.0, 1.0])
+  torch.testing.assert_close(normal[1], expected_up, atol=1e-6, rtol=1e-6)
+  torch.testing.assert_close(normal[2], expected_up, atol=1e-6, rtol=1e-6)
+  # The valid plane is still fit and points upward.
+  assert normal[0, 2] > 0
+  torch.testing.assert_close(normal[0].norm(), torch.tensor(1.0), atol=1e-4, rtol=0)
+
+
 def test_small_valid_plane_still_fits():
   """A tiny but planar patch should not be rejected as degenerate."""
   x_vals = torch.linspace(0.0, 1e-4, 4)

--- a/tests/test_velocity_terrain_curriculum.py
+++ b/tests/test_velocity_terrain_curriculum.py
@@ -1,0 +1,70 @@
+"""Tests for the velocity terrain-level curriculum."""
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import torch
+
+from mjlab.managers.scene_entity_config import SceneEntityCfg
+from mjlab.tasks.velocity.mdp.curriculums import terrain_levels_vel
+
+
+class _FakeTerrain:
+  """Minimal terrain stub implementing the real level-update arithmetic."""
+
+  def __init__(self, num_envs: int, size: float = 8.0):
+    self.terrain_levels = torch.zeros(num_envs, dtype=torch.long)
+    self.terrain_types = torch.zeros(num_envs, dtype=torch.long)
+    self.max_terrain_level = 10
+    # [num_rows, num_cols, 3]. One column, enough rows for promotion.
+    self.terrain_origins = torch.zeros(self.max_terrain_level, 1, 3)
+    self.env_origins = torch.zeros(num_envs, 3)
+    self.cfg = SimpleNamespace(
+      terrain_generator=SimpleNamespace(size=(size, size), sub_terrains={})
+    )
+
+  def update_env_origins(self, env_ids, move_up, move_down):
+    self.terrain_levels[env_ids] += 1 * move_up - 1 * move_down
+    self.terrain_levels[env_ids] = torch.clip(self.terrain_levels[env_ids], 0)
+
+
+def _make_env(terrain: _FakeTerrain, common_step_counter: int, walked: float):
+  num_envs = terrain.terrain_levels.shape[0]
+  # Robot has "walked" `walked` meters in x from its origin.
+  asset = Mock()
+  asset.data.root_link_pos_w = torch.tensor([[walked, 0.0, 0.0]] * num_envs)
+
+  env = Mock()
+  env.common_step_counter = common_step_counter
+  env.max_episode_length_s = 20.0
+  env.scene.__getitem__ = Mock(return_value=asset)
+  env.scene.terrain = terrain
+  env.scene.env_origins = torch.zeros(num_envs, 3)
+  # Zero command so move_down stays inactive; isolates move_up behavior.
+  env.command_manager.get_command = Mock(return_value=torch.zeros(num_envs, 2))
+  return env
+
+
+def test_first_reset_does_not_promote_levels():
+  """On the initial reset the far spawn/origin gap must not bump levels."""
+  terrain = _FakeTerrain(num_envs=4, size=8.0)
+  # walked >> size/2 (=4.0), which would normally trigger move_up.
+  env = _make_env(terrain, common_step_counter=0, walked=100.0)
+
+  terrain_levels_vel(
+    env, torch.arange(4), command_name="twist", asset_cfg=SceneEntityCfg("robot")
+  )
+
+  assert torch.all(terrain.terrain_levels == 0)
+
+
+def test_subsequent_reset_promotes_on_long_walk():
+  """After stepping, a long walk still promotes the level as before."""
+  terrain = _FakeTerrain(num_envs=4, size=8.0)
+  env = _make_env(terrain, common_step_counter=1, walked=100.0)
+
+  terrain_levels_vel(
+    env, torch.arange(4), command_name="twist", asset_cfg=SceneEntityCfg("robot")
+  )
+
+  assert torch.all(terrain.terrain_levels == 1)

--- a/tests/test_velocity_terrain_curriculum.py
+++ b/tests/test_velocity_terrain_curriculum.py
@@ -24,8 +24,17 @@ class _FakeTerrain:
     )
 
   def update_env_origins(self, env_ids, move_up, move_down):
+    # Mirror TerrainEntity.update_env_origins exactly, including the cap-wrap
+    # branch and the env_origins write, so the fake can't pass vacuously.
     self.terrain_levels[env_ids] += 1 * move_up - 1 * move_down
-    self.terrain_levels[env_ids] = torch.clip(self.terrain_levels[env_ids], 0)
+    self.terrain_levels[env_ids] = torch.where(
+      self.terrain_levels[env_ids] >= self.max_terrain_level,
+      torch.randint_like(self.terrain_levels[env_ids], self.max_terrain_level),
+      torch.clip(self.terrain_levels[env_ids], 0),
+    )
+    self.env_origins[env_ids] = self.terrain_origins[
+      self.terrain_levels[env_ids], self.terrain_types[env_ids]
+    ]
 
 
 def _make_env(terrain: _FakeTerrain, common_step_counter: int, walked: float):


### PR DESCRIPTION
A few independent fixes to the velocity tasks.

- Enable `obs_normalization` on the Go1 velocity actor and critic to match the other velocity tasks, fixing the recurring `normal expects all elements of std >= 0.0` training crash (old Go1 checkpoints won't load and must be retrained).
- Harden `fit_terrain_normal` against non-finite raycast hits so a single diverged env no longer makes `torch.linalg.eigh` abort the whole batch.
- Bias the velocity actor's `joint_pos` observation by the `encoder_bias` domain randomization (the critic keeps the true value), so the randomization actually reaches observations (discussion #1065).
- Freeze terrain levels on the initial reset so `max_init_terrain_level=0` is respected instead of every env being promoted to level 1.

Closes #870, #1044, #1053, #912, #1094.