### PR TITLE
Fix ONNX upload with current W&B logger

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -19,6 +19,8 @@ Changed
 Fixed
 ^^^^^
 
+- Restored ONNX uploads and W&B run metadata for velocity and manipulation
+  training when using RSL-RL's current ``WandbLogWriter`` logger name.
 - The Viser reward bar panel no longer *silently* drops reward terms beyond
   ``max_terms``; it now emits a warning listing the hidden terms. Previously
   environments with more than 20 reward terms had the overflow disappear from

--- a/src/mjlab/tasks/manipulation/rl/runner.py
+++ b/src/mjlab/tasks/manipulation/rl/runner.py
@@ -17,11 +17,16 @@ class ManipulationOnPolicyRunner(MjlabOnPolicyRunner):
     try:
       self.export_policy_to_onnx(str(policy_dir), filename)
       run_name: str = (
-        wandb.run.name if self.logger.logger_type == "wandb" and wandb.run else "local"
+        wandb.run.name
+        if self.logger.logger_type in ("wandb", "WandbLogWriter") and wandb.run
+        else "local"
       )  # type: ignore[assignment]
       metadata = get_base_metadata(self.env.unwrapped, run_name)
       attach_metadata_to_onnx(str(onnx_path), metadata)
-      if self.logger.logger_type in ["wandb"] and self.cfg["upload_model"]:
+      if (
+        self.logger.logger_type in ("wandb", "WandbLogWriter")
+        and self.cfg["upload_model"]
+      ):
         wandb.save(
           str(onnx_path),
           base_path=str(policy_dir),

--- a/src/mjlab/tasks/velocity/rl/runner.py
+++ b/src/mjlab/tasks/velocity/rl/runner.py
@@ -17,11 +17,16 @@ class VelocityOnPolicyRunner(MjlabOnPolicyRunner):
     try:
       self.export_policy_to_onnx(str(policy_dir), filename)
       run_name: str = (
-        wandb.run.name if self.logger.logger_type == "wandb" and wandb.run else "local"
+        wandb.run.name
+        if self.logger.logger_type in ("wandb", "WandbLogWriter") and wandb.run
+        else "local"
       )  # type: ignore[assignment]
       metadata = get_base_metadata(self.env.unwrapped, run_name)
       attach_metadata_to_onnx(str(onnx_path), metadata)
-      if self.logger.logger_type in ["wandb"] and self.cfg["upload_model"]:
+      if (
+        self.logger.logger_type in ("wandb", "WandbLogWriter")
+        and self.cfg["upload_model"]
+      ):
         wandb.save(str(onnx_path), base_path=str(policy_dir))
     except Exception as e:
       print(f"[WARN] ONNX export failed (training continues): {e}")

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -524,6 +524,49 @@ def test_onnx_motion_model_clamps_out_of_bounds_time_step():
   torch.testing.assert_close(joint_pos, motion.joint_pos[num_steps - 1 : num_steps])
 
 
+@pytest.mark.parametrize(
+  ("runner_module", "runner_class"),
+  [
+    ("mjlab.tasks.velocity.rl.runner", "VelocityOnPolicyRunner"),
+    ("mjlab.tasks.manipulation.rl.runner", "ManipulationOnPolicyRunner"),
+  ],
+)
+@pytest.mark.parametrize("logger_type", ["wandb", "WandbLogWriter"])
+def test_task_runner_uploads_onnx_for_wandb_logger_types(
+  runner_module, runner_class, logger_type, monkeypatch, tmp_path
+):
+  """ONNX upload supports both legacy and current RSL-RL W&B logger names."""
+  import importlib
+
+  runner_mod = importlib.import_module(runner_module)
+  runner_cls = getattr(runner_mod, runner_class)
+  runner = runner_cls.__new__(runner_cls)
+  runner.cfg = {"upload_model": True}
+  runner.logger = MagicMock()
+  runner.logger.logger_type = logger_type
+  runner.env = MagicMock()
+  runner.export_policy_to_onnx = MagicMock()
+
+  monkeypatch.setattr(MjlabOnPolicyRunner, "save", lambda *a, **kw: None)
+  monkeypatch.setattr(runner_mod, "get_base_metadata", lambda *a: {})
+  monkeypatch.setattr(runner_mod, "attach_metadata_to_onnx", lambda *a: None)
+
+  checkpoint = tmp_path / "run-dir" / "model_100.pt"
+  checkpoint.parent.mkdir()
+  checkpoint.touch()
+  onnx_path = checkpoint.parent / f"{checkpoint.parent.name}.onnx"
+
+  mock_run = MagicMock()
+  mock_run.name = "test-run"
+  with patch.object(runner_mod, "wandb") as mock_wandb:
+    mock_wandb.run = mock_run
+    runner.save(str(checkpoint))
+
+  mock_wandb.save.assert_called_once_with(
+    str(onnx_path), base_path=str(checkpoint.parent)
+  )
+
+
 def _make_tracking_runner_shell(registry_name, logger_type, upload_model=True):
   """Build a MotionTrackingOnPolicyRunner with all heavy parts mocked out."""
   from mjlab.tasks.tracking.rl.runner import MotionTrackingOnPolicyRunner


### PR DESCRIPTION
RSL-RL normalizes the deprecated `wandb` logger alias to `WandbLogWriter`, but the velocity and manipulation runners only recognized the old name. As a result, ONNX export still ran locally while upload and W&B run metadata were silently skipped. This accepts both logger identifiers, matching the tracking runner, and adds regression coverage for both task runners and both identifiers.