### PR TITLE
Change mjwarp renderer background color to match mujoco native

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -11,6 +11,10 @@ Added
 Changed
 ^^^^^^^
 
+- Changed the default MuJoCo Warp render background to solid black
+  (``0, 0, 0, 1``), matching MuJoCo's native renderer. Contribution by
+  @bd-pmorais.
+
 Fixed
 ^^^^^
 

--- a/src/mjlab/sensor/sensor_context.py
+++ b/src/mjlab/sensor/sensor_context.py
@@ -326,6 +326,7 @@ class SensorContext:
         use_precomputed_rays=not self._disable_precomputed_rays,
         render_seg=render_seg,
         render_skybox=True,
+        background_color=(0.0, 0.0, 0.0, 1.0),
       )
 
     # Cache address arrays from the render context. An adr value of -1 means that data


### PR DESCRIPTION
This branch just changes the mujoco warp renderer background color to the color hardcoded by mujoco's native renderer (i.e. solid black) so the two renderers agree. 