### PR TITLE
Add support for texid randomization

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -35,6 +35,10 @@ Added
 - Added ``reduce="sum"`` to ``MetricsTermCfg`` for reporting the accumulated
   episode total (e.g. episodic reward, total distance traveled) instead of a
   per-step average. Contribution by @bd-mlutter
+- Added ``dr.mat_texid`` to randomize which texture fills a given
+  ``mjtTextureRole`` slot (RGB by default) of each selected material,
+  sampling uniformly from ``asset_cfg.texture_names``. Contribution by
+  @bd-pmorais.
 
 Changed
 ^^^^^^^

--- a/docs/source/randomization.rst
+++ b/docs/source/randomization.rst
@@ -1416,12 +1416,13 @@ world-space positions directly from GPU simulation data (``cam_xpos``,
 
 .. note::
 
-   ``geom_rgba`` and ``geom_size`` DR are **not** reflected in viser. Geom
-   colors and sizes are baked into the scene's GLB meshes at construction
-   time. The underlying viser API (``add_batched_meshes_simple``) supports
-   per-instance color updates via ``batched_colors``, but this requires
-   routing color-only geoms through a different handle type than the current
-   ``add_batched_meshes_trimesh`` path. Deferred for a future update.
+   ``geom_rgba``, ``geom_size`` and ``mat_texid`` DR are **not** reflected
+   in viser. Geom colors, sizes and textures are baked into the scene's
+   GLB meshes at construction time. The underlying viser API
+   (``add_batched_meshes_simple``) supports per-instance color updates via
+   ``batched_colors``, but this requires routing color-only geoms through
+   a different handle type than the current ``add_batched_meshes_trimesh``
+   path. Deferred for a future update.
 
 
 Migrating from Isaac Lab

--- a/docs/source/randomization.rst
+++ b/docs/source/randomization.rst
@@ -274,6 +274,12 @@ and ``dr.body_ipos`` are the same function).
      - ``mat_texrepeat``
      - Texture repeat in the S/T directions
      - Only affects textured materials; values should stay positive
+   * - ``dr.mat_texid``
+     - ``mat_texid``
+     - Texture assigned to a material's ``mjtTextureRole`` slot (RGB by
+       default)
+     - Samples uniformly from ``asset_cfg.texture_names``. Use ``role`` to
+       target a different texture role.
 
 .. rubric:: Contact pair fields
 
@@ -845,11 +851,6 @@ per-environment values.
    * - Category
      - Field(s)
      - Notes
-   * - Texture-role swapping
-     - ``mat_texid``
-     - Not implemented for now because mujoco's viewer doesn't reread
-       ``mat_texid`` after context creation; use ``geom_matid`` with one baked
-       material per texture to randomize textures instead.
    * - Mesh
      - ``mesh_vert``, ``mesh_normal``, ``mesh_face``, etc.
      - Shape variation for manipulation objects. These fields
@@ -1363,7 +1364,7 @@ toggles then work correctly against the randomized model:
 - Geom appearance (``geom_rgba``, ``geom_size``, ``geom_pos``, ``geom_quat``,
   ``geom_matid``)
 - Material appearance (``mat_rgba``, ``mat_emission``, ``mat_specular``,
-  ``mat_shininess``, ``mat_texrepeat``)
+  ``mat_shininess``, ``mat_texrepeat``, ``mat_texid``)
 - Body and site poses (``body_pos``, ``body_quat``, ``body_ipos``,
   ``site_pos``, ``site_quat``)
 - Inertia (``body_inertia``, ``body_iquat``, ``body_mass``): press ``I``

--- a/src/mjlab/entity/entity.py
+++ b/src/mjlab/entity/entity.py
@@ -39,6 +39,7 @@ class EntityIndexing:
   cameras: tuple[mujoco.MjsCamera, ...]
   lights: tuple[mujoco.MjsLight, ...]
   materials: tuple[mujoco.MjsMaterial, ...]
+  textures: tuple[mujoco.MjsTexture, ...]
   pairs: tuple[mujoco.MjsPair, ...]
   actuators: tuple[mujoco.MjsActuator, ...] | None
 
@@ -50,6 +51,7 @@ class EntityIndexing:
   cam_ids: torch.Tensor
   light_ids: torch.Tensor
   mat_ids: torch.Tensor
+  tex_ids: torch.Tensor
   pair_ids: torch.Tensor
   ctrl_ids: torch.Tensor
   joint_ids: torch.Tensor
@@ -459,6 +461,10 @@ class Entity:
     return tuple(m.name.split("/")[-1] for m in self.spec.materials)
 
   @property
+  def texture_names(self) -> tuple[str, ...]:
+    return tuple(t.name.split("/")[-1] for t in self.spec.textures)
+
+  @property
   def pair_names(self) -> tuple[str, ...]:
     return tuple(p.name.split("/")[-1] for p in self.spec.pairs)
 
@@ -499,6 +505,10 @@ class Entity:
   @property
   def num_materials(self) -> int:
     return len(self.material_names)
+
+  @property
+  def num_textures(self) -> int:
+    return len(self.texture_names)
 
   @property
   def num_pairs(self) -> int:
@@ -612,6 +622,16 @@ class Entity:
     if material_subset is None:
       material_subset = self.material_names
     return resolve_matching_names(name_keys, material_subset, preserve_order)
+
+  def find_textures(
+    self,
+    name_keys: str | Sequence[str],
+    texture_subset: Sequence[str] | None = None,
+    preserve_order: bool = False,
+  ) -> tuple[list[int], list[str]]:
+    if texture_subset is None:
+      texture_subset = self.texture_names
+    return resolve_matching_names(name_keys, texture_subset, preserve_order)
 
   def find_pairs(
     self,
@@ -1198,6 +1218,7 @@ class Entity:
     cameras = tuple(self.spec.cameras)
     lights = tuple(self.spec.lights)
     materials = tuple(self.spec.materials)
+    textures = tuple(self.spec.textures)
     pairs = tuple(self.spec.pairs)
 
     body_ids = torch.tensor([b.id for b in bodies], dtype=torch.int, device=device)
@@ -1207,6 +1228,7 @@ class Entity:
     cam_ids = torch.tensor([c.id for c in cameras], dtype=torch.int, device=device)
     light_ids = torch.tensor([lt.id for lt in lights], dtype=torch.int, device=device)
     mat_ids = torch.tensor([m.id for m in materials], dtype=torch.int, device=device)
+    tex_ids = torch.tensor([t.id for t in textures], dtype=torch.int, device=device)
     pair_ids = torch.tensor([p.id for p in pairs], dtype=torch.int, device=device)
     joint_ids = torch.tensor([j.id for j in joints], dtype=torch.int, device=device)
 
@@ -1251,6 +1273,7 @@ class Entity:
       cameras=cameras,
       lights=lights,
       materials=materials,
+      textures=textures,
       pairs=pairs,
       actuators=actuators,
       body_ids=body_ids,
@@ -1260,6 +1283,7 @@ class Entity:
       cam_ids=cam_ids,
       light_ids=light_ids,
       mat_ids=mat_ids,
+      tex_ids=tex_ids,
       pair_ids=pair_ids,
       ctrl_ids=ctrl_ids,
       joint_ids=joint_ids,

--- a/src/mjlab/envs/mdp/dr/__init__.py
+++ b/src/mjlab/envs/mdp/dr/__init__.py
@@ -82,6 +82,7 @@ from .material import mat_emission as mat_emission
 from .material import mat_rgba as mat_rgba
 from .material import mat_shininess as mat_shininess
 from .material import mat_specular as mat_specular
+from .material import mat_texid as mat_texid
 from .material import mat_texrepeat as mat_texrepeat
 
 # Pair.

--- a/src/mjlab/envs/mdp/dr/_core.py
+++ b/src/mjlab/envs/mdp/dr/_core.py
@@ -39,6 +39,7 @@ _ENTITY_NAMES_ATTR: dict[str, str] = {
   "camera": "camera_names",
   "light": "light_names",
   "material": "material_names",
+  "texture": "texture_names",
   "pair": "pair_names",
 }
 
@@ -226,6 +227,8 @@ def _get_entity_indices(
       return indexing.light_ids[asset_cfg.light_ids]
     case "material":
       return indexing.mat_ids[asset_cfg.material_ids]
+    case "texture":
+      return indexing.tex_ids[asset_cfg.texture_ids]
     case "pair":
       return indexing.pair_ids[asset_cfg.pair_ids]
     case _:
@@ -324,8 +327,8 @@ def _randomize_categorical_field(
   pool: torch.Tensor,
   asset_cfg: SceneEntityCfg,
   shared_random: bool = False,
+  axis: int | None = None,
 ) -> None:
-  """Core engine for categorical fields: assign each entry a value from ``pool``."""
   asset = env.scene[asset_cfg.name]
 
   if env_ids is None:
@@ -341,7 +344,10 @@ def _randomize_categorical_field(
   pick = pick.expand(env_grid.shape)
 
   model_field = getattr(env.sim.model, field)
-  model_field[env_grid, entity_grid] = pool[pick]
+  if axis is None:
+    model_field[env_grid, entity_grid] = pool[pick]
+  else:
+    model_field[env_grid, entity_grid, axis] = pool[pick]
 
 
 # Quaternion helpers.

--- a/src/mjlab/envs/mdp/dr/material.py
+++ b/src/mjlab/envs/mdp/dr/material.py
@@ -205,6 +205,11 @@ def mat_texid(
   role: int = mujoco.mjtTextureRole.mjTEXROLE_RGB.value,
   shared_random: bool = False,
 ) -> None:
+  """Randomize which texture each selected material uses.
+
+  A material stores one texture per ``mjtTextureRole`` slot; only the ``role``
+  slot is modified, drawn uniformly from ``asset_cfg.texture_names``.
+  """
   asset = env.scene[asset_cfg.name]
   tex_ids = _get_entity_indices(asset.indexing, asset_cfg, "texture", False)
   if tex_ids.numel() == 0:

--- a/src/mjlab/envs/mdp/dr/material.py
+++ b/src/mjlab/envs/mdp/dr/material.py
@@ -4,10 +4,18 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import mujoco
+
 from mjlab.managers.event_manager import requires_model_fields
 from mjlab.managers.scene_entity_config import SceneEntityCfg
 
-from ._core import _DEFAULT_ASSET_CFG, Ranges, _randomize_model_field
+from ._core import (
+  _DEFAULT_ASSET_CFG,
+  Ranges,
+  _get_entity_indices,
+  _randomize_categorical_field,
+  _randomize_model_field,
+)
 from ._types import Distribution, Operation
 
 if TYPE_CHECKING:
@@ -186,4 +194,32 @@ def mat_texrepeat(
     axes=axes,
     shared_random=shared_random,
     default_axes=[0, 1],
+  )
+
+
+@requires_model_fields("mat_texid")
+def mat_texid(
+  env: ManagerBasedRlEnv,
+  env_ids: torch.Tensor | None,
+  asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
+  role: int = mujoco.mjtTextureRole.mjTEXROLE_RGB.value,
+  shared_random: bool = False,
+) -> None:
+  asset = env.scene[asset_cfg.name]
+  tex_ids = _get_entity_indices(asset.indexing, asset_cfg, "texture", False)
+  if tex_ids.numel() == 0:
+    raise ValueError(
+      f"No textures selected for entity '{asset_cfg.name}'. Set "
+      "SceneEntityCfg.texture_names to a non-empty selection."
+    )
+
+  _randomize_categorical_field(
+    env,
+    env_ids,
+    "mat_texid",
+    entity_type="material",
+    pool=tex_ids,
+    asset_cfg=asset_cfg,
+    shared_random=shared_random,
+    axis=role,
   )

--- a/src/mjlab/managers/scene_entity_config.py
+++ b/src/mjlab/managers/scene_entity_config.py
@@ -47,6 +47,13 @@ _FIELD_CONFIGS = [
     "num_materials",
     "material",
   ),
+  _FieldConfig(
+    "texture_names",
+    "texture_ids",
+    "find_textures",
+    "num_textures",
+    "texture",
+  ),
   _FieldConfig("pair_names", "pair_ids", "find_pairs", "num_pairs", "pair"),
 ]
 
@@ -116,6 +123,10 @@ class SceneEntityCfg:
 
   material_ids: list[int] | slice = field(default_factory=lambda: slice(None))
   """IDs of materials to include. Can be a list or slice."""
+
+  texture_names: str | tuple[str, ...] | None = None
+
+  texture_ids: list[int] | slice = field(default_factory=lambda: slice(None))
 
   pair_names: str | tuple[str, ...] | None = None
   """Names of contact pairs to include. Can be a single string or tuple."""

--- a/src/mjlab/managers/scene_entity_config.py
+++ b/src/mjlab/managers/scene_entity_config.py
@@ -125,8 +125,10 @@ class SceneEntityCfg:
   """IDs of materials to include. Can be a list or slice."""
 
   texture_names: str | tuple[str, ...] | None = None
+  """Names of textures to include. Can be a single string or tuple."""
 
   texture_ids: list[int] | slice = field(default_factory=lambda: slice(None))
+  """IDs of textures to include. Can be a list or slice."""
 
   pair_names: str | tuple[str, ...] | None = None
   """Names of contact pairs to include. Can be a single string or tuple."""

--- a/src/mjlab/viewer/model_sync.py
+++ b/src/mjlab/viewer/model_sync.py
@@ -34,6 +34,7 @@ VIEWER_MODEL_FIELDS = frozenset(
     "mat_rgba",
     "mat_shininess",
     "mat_specular",
+    "mat_texid",
     "mat_texrepeat",
     "site_pos",
     "site_quat",

--- a/tests/test_domain_randomization.py
+++ b/tests/test_domain_randomization.py
@@ -1981,6 +1981,7 @@ MAT_TEXID_XML = """
     <texture name="tex_a" type="2d" builtin="flat" rgb1="1 0 0" width="4" height="4"/>
     <texture name="tex_b" type="2d" builtin="flat" rgb1="0 1 0" width="4" height="4"/>
     <texture name="tex_c" type="2d" builtin="flat" rgb1="0 0 1" width="4" height="4"/>
+    <texture name="tex_d" type="2d" builtin="flat" rgb1="1 1 0" width="4" height="4"/>
     <material name="mat_a" texture="tex_a"/>
     <material name="mat_b" texture="tex_b"/>
   </asset>
@@ -2006,8 +2007,9 @@ def _make_texid_env(device, num_envs=NUM_ENVS):
   return Env(scene, sim, device)
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def texid_env(device):
+  # Function-scoped so tests compare against pristine mat_texid defaults.
   return _make_texid_env(device)
 
 
@@ -2032,14 +2034,41 @@ def test_mat_texid_draws_from_pool(texid_env):
   assert torch.isin(assigned, torch.unique(original), invert=True).any()
 
 
+def test_mat_texid_respects_texture_subset(texid_env):
+  """Textures outside the selection are never sampled."""
+  torch.manual_seed(42)
+  env = texid_env
+  robot = env.scene["robot"]
+  # The pool excludes tex_a and tex_b, which are the two materials' defaults.
+  asset_cfg = SceneEntityCfg(
+    "robot", material_names=(".*",), texture_names=("tex_c", "tex_d")
+  )
+  asset_cfg.resolve(env.scene)
+
+  mat_ids = robot.indexing.mat_ids[asset_cfg.material_ids]
+  tex_ids = robot.indexing.tex_ids[asset_cfg.texture_ids]
+  role = mujoco.mjtTextureRole.mjTEXROLE_RGB.value
+  excluded = torch.unique(env.sim.model.mat_texid[:, mat_ids, role])
+
+  dr.mat_texid(env, env_ids=None, asset_cfg=asset_cfg)
+
+  assigned = env.sim.model.mat_texid[:, mat_ids, role]
+  assert torch.all(torch.isin(assigned, tex_ids))
+  assert not torch.isin(assigned, excluded).any()
+  assert len(torch.unique(assigned)) >= 2
+
+
 def test_mat_texid_partial_env_ids(texid_env):
   """Randomizing subset of envs leaves others unchanged."""
   torch.manual_seed(42)
   env = texid_env
   robot = env.scene["robot"]
-  asset_cfg = SceneEntityCfg("robot", material_names=(".*",), texture_names=(".*",))
+  asset_cfg = SceneEntityCfg(
+    "robot", material_names=(".*",), texture_names=("tex_c", "tex_d")
+  )
   asset_cfg.resolve(env.scene)
   mat_ids = robot.indexing.mat_ids[asset_cfg.material_ids]
+  tex_ids = robot.indexing.tex_ids[asset_cfg.texture_ids]
   role = mujoco.mjtTextureRole.mjTEXROLE_RGB.value
 
   original = env.sim.model.mat_texid[:, mat_ids, role].clone()
@@ -2049,6 +2078,12 @@ def test_mat_texid_partial_env_ids(texid_env):
   )
 
   result = env.sim.model.mat_texid[:, mat_ids, role]
+  # Envs 0, 2 changed, the pool excludes their defaults.
+  assert torch.all(torch.isin(result[0], tex_ids))
+  assert torch.all(torch.isin(result[2], tex_ids))
+  assert not torch.equal(result[0], original[0])
+  assert not torch.equal(result[2], original[2])
+  # Envs 1, 3 unchanged.
   assert torch.all(result[1] == original[1])
   assert torch.all(result[3] == original[3])
 

--- a/tests/test_domain_randomization.py
+++ b/tests/test_domain_randomization.py
@@ -1973,6 +1973,128 @@ def test_geom_matid_shared_random(matid_env):
   assert len(torch.unique(assigned[:, 0])) > 1
 
 
+# mat_texid DR tests.
+
+MAT_TEXID_XML = """
+<mujoco>
+  <asset>
+    <texture name="tex_a" type="2d" builtin="flat" rgb1="1 0 0" width="4" height="4"/>
+    <texture name="tex_b" type="2d" builtin="flat" rgb1="0 1 0" width="4" height="4"/>
+    <texture name="tex_c" type="2d" builtin="flat" rgb1="0 0 1" width="4" height="4"/>
+    <material name="mat_a" texture="tex_a"/>
+    <material name="mat_b" texture="tex_b"/>
+  </asset>
+  <worldbody>
+    <body name="base" pos="0 0 1">
+      <freejoint name="free_joint"/>
+      <geom name="geom1" type="box" size="0.1 0.1 0.1" mass="1.0" material="mat_a"/>
+      <geom name="geom2" type="sphere" size="0.05" mass="0.3" material="mat_b"/>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+
+def _make_texid_env(device, num_envs=NUM_ENVS):
+  entity_cfg = EntityCfg(spec_fn=lambda: mujoco.MjSpec.from_string(MAT_TEXID_XML))
+  scene_cfg = SceneCfg(num_envs=num_envs, entities={"robot": entity_cfg})
+  scene = Scene(scene_cfg, device)
+  model = scene.compile()
+  sim = Simulation(num_envs=num_envs, cfg=SimulationCfg(), model=model, device=device)
+  scene.initialize(model, sim.model, sim.data)
+  sim.expand_model_fields(("mat_texid",))
+  return Env(scene, sim, device)
+
+
+@pytest.fixture(scope="module")
+def texid_env(device):
+  return _make_texid_env(device)
+
+
+def test_mat_texid_draws_from_pool(texid_env):
+  """Assigned texids come from the pool and actually change from the defaults."""
+  torch.manual_seed(42)
+  env = texid_env
+  robot = env.scene["robot"]
+  asset_cfg = SceneEntityCfg("robot", material_names=(".*",), texture_names=(".*",))
+  asset_cfg.resolve(env.scene)
+
+  mat_ids = robot.indexing.mat_ids[asset_cfg.material_ids]
+  tex_ids = robot.indexing.tex_ids[asset_cfg.texture_ids]
+  role = mujoco.mjtTextureRole.mjTEXROLE_RGB.value
+  original = env.sim.model.mat_texid[:, mat_ids, role].clone()
+
+  dr.mat_texid(env, env_ids=None, asset_cfg=asset_cfg)
+
+  assigned = env.sim.model.mat_texid[:, mat_ids, role]
+  assert torch.all(torch.isin(assigned, tex_ids))
+  assert not torch.equal(assigned, original)
+  assert torch.isin(assigned, torch.unique(original), invert=True).any()
+
+
+def test_mat_texid_partial_env_ids(texid_env):
+  """Randomizing subset of envs leaves others unchanged."""
+  torch.manual_seed(42)
+  env = texid_env
+  robot = env.scene["robot"]
+  asset_cfg = SceneEntityCfg("robot", material_names=(".*",), texture_names=(".*",))
+  asset_cfg.resolve(env.scene)
+  mat_ids = robot.indexing.mat_ids[asset_cfg.material_ids]
+  role = mujoco.mjtTextureRole.mjTEXROLE_RGB.value
+
+  original = env.sim.model.mat_texid[:, mat_ids, role].clone()
+
+  dr.mat_texid(
+    env, env_ids=torch.tensor([0, 2], device=env.device), asset_cfg=asset_cfg
+  )
+
+  result = env.sim.model.mat_texid[:, mat_ids, role]
+  assert torch.all(result[1] == original[1])
+  assert torch.all(result[3] == original[3])
+
+
+def test_mat_texid_invalid_texture_name(texid_env):
+  """Unknown texture name is rejected during config resolution."""
+  env = texid_env
+
+  with pytest.raises(ValueError, match="nonexistent_texture"):
+    cfg = SceneEntityCfg(
+      "robot", material_names=(".*",), texture_names=("nonexistent_texture",)
+    )
+    cfg.resolve(env.scene)
+    dr.mat_texid(env, env_ids=None, asset_cfg=cfg)
+
+
+def test_mat_texid_empty_texture_selection(texid_env):
+  """mat_texid raises when the resolved texture pool is empty."""
+  env = texid_env
+  cfg = SceneEntityCfg("robot", material_names=(".*",), texture_names=())
+  cfg.resolve(env.scene)
+
+  with pytest.raises(ValueError, match="No textures selected"):
+    dr.mat_texid(env, env_ids=None, asset_cfg=cfg)
+
+
+def test_mat_texid_shared_random(texid_env):
+  """All materials within same env get same texture, envs differ."""
+  torch.manual_seed(42)
+  env = texid_env
+  robot = env.scene["robot"]
+  asset_cfg = SceneEntityCfg("robot", material_names=(".*",), texture_names=(".*",))
+  asset_cfg.resolve(env.scene)
+  mat_ids = robot.indexing.mat_ids[asset_cfg.material_ids]
+  role = mujoco.mjtTextureRole.mjTEXROLE_RGB.value
+
+  dr.mat_texid(env, env_ids=None, asset_cfg=asset_cfg, shared_random=True)
+
+  assigned = env.sim.model.mat_texid[:, mat_ids, role]
+  for env_idx in range(env.num_envs):
+    env_texids = assigned[env_idx]
+    assert torch.all(env_texids == env_texids[0])
+
+  assert len(torch.unique(assigned[:, 0])) > 1
+
+
 # pair_friction tests.
 
 PAIR_XML = """


### PR DESCRIPTION
Similar in principle to #1087. Now that [#3387](https://github.com/google-deepmind/mujoco/pull/3387) is merged into mujoco this implementation of dr.mat_texid will randomize textures consistently in the mujoco native, filament and mujoco_warp renderers. 