### PR TITLE
Invalidate raycast sensor cache after sense to fix stale debug rays

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -21,8 +21,12 @@ Fixed
 
 - Bumped ``pillow`` (12.3.0), ``onnx`` (1.22.0), and ``soupsieve`` (2.9.1) in the
   lockfile to pick up security fixes.
-- Bumped ``GitPython`` (3.1.54) and ``setuptools`` (83.0.0) to pick up security
-  fixes.
+- Fixed raycast sensor debug visualization and observations lagging one step
+  behind the sensed hits. ``sense()`` rebinds the hit tensors after the cache had
+  already been repopulated by a pre-sense reward read, so ``.data`` returned the
+  previous step's hits; the cache is now invalidated after ``postprocess_rays``.
+  With ``ray_alignment="yaw"`` this made debug rays appear tilted by the foot's
+  per-step motion instead of vertical. :issue:`998`
 - Restored ONNX uploads and W&B run metadata for velocity and manipulation
   training when using RSL-RL's current ``WandbLogWriter`` logger name.
 - The Viser reward bar panel no longer *silently* drops reward terms beyond

--- a/src/mjlab/sensor/raycast_sensor.py
+++ b/src/mjlab/sensor/raycast_sensor.py
@@ -807,6 +807,14 @@ class RayCastSensor(Sensor[RayCastData]):
     self._pos_w = self._frame_pos_w[:, 0]
     self._quat_w = self._frame_quat_w[:, 0]
 
+    # ``sense()`` runs after the decimation loop (which invalidates the cache)
+    # and after rewards may have already read ``.data``, repopulating the cache
+    # with pre-sense hit positions. Rebinding the tensors above leaves that
+    # cache pointing at the previous step's data, so invalidate here to force a
+    # recompute on the next ``.data`` access. Otherwise observations and debug
+    # visualization would lag one step behind the freshly sensed hits (#998).
+    self._invalidate_cache()
+
   def _compute_alignment_rotation(self, frame_mat: torch.Tensor) -> torch.Tensor:
     """Compute rotation matrix based on ray_alignment setting."""
     if self.cfg.ray_alignment == "base":


### PR DESCRIPTION
Debug rays for `foot_height_scan` looked tilted with `ray_alignment="yaw"` because the sensor's `.data` cache went stale after `sense()`, so `debug_vis()` paired a fresh ray origin with the previous step's hit. Invalidate the cache after `postprocess_rays()` so reads pick up the fresh hits.

Fixes #998