### PR TITLE
Prepare for 1.5.3

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -33,9 +33,9 @@ keywords:
   - reinforcement-learning
   - robotics
 license: Apache-2.0
-commit: 7a09f6e8c03defd789474a92b112a91360d94268
-version: 1.5.2
-date-released: '2026-07-17'
+commit: d247f38de798a5c3238d19ff4c5897382357cf7c
+version: 1.5.3
+date-released: '2026-07-22'
 preferred-citation:
   type: article
   title: >-

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -11,6 +11,15 @@ Added
 Changed
 ^^^^^^^
 
+Fixed
+^^^^^
+
+Version 1.5.3 (July 22, 2026)
+-----------------------------
+
+Changed
+^^^^^^^
+
 - The Viser reward bar panel's term cap is now configurable via
   ``ViewerConfig.reward_bar_max_terms``, so environments with more than 20
   reward terms can show them all. Defaults to 20, preserving previous behavior.
@@ -60,6 +69,9 @@ Fixed
   differences, whose quantization error grows with the clock magnitude and made
   ``compute_first_contact`` / ``compute_first_air`` miss touchdowns on long runs.
   The exact float64 substep ``dt`` is now accumulated instead. :issue:`1101`
+- Bumped ``mujoco-warp`` to 3.10.0.3, fixing a CUDA 700 illegal memory access in
+  ``smooth.crb`` triggered by startup mass domain randomization (via
+  ``set_const``) once ``num_envs >= 128`` on consumer Ada GPUs. :issue:`1108`
 
 Version 1.5.2 (July 17, 2026)
 -----------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "mjlab"
-version = "1.5.2"
+version = "1.5.3"
 license = "Apache-2.0"
 license-files = ["LICENSE"]
 readme = { file = "README.md", content-type = "text/markdown" }
@@ -37,7 +37,7 @@ dependencies = [
   "torch>=2.7.0",
   "torchrunx>=0.3.4",
   "warp-lang>=1.14.0",
-  "mujoco-warp>=3.10.0.2,~=3.10.0",
+  "mujoco-warp>=3.10.0.3,~=3.10.0",
   "mujoco~=3.10.0",
   "trimesh>=4.8.3",
   "scipy>=1.15",

--- a/uv.lock
+++ b/uv.lock
@@ -1644,7 +1644,7 @@ wheels = [
 
 [[package]]
 name = "mjlab"
-version = "1.5.2"
+version = "1.5.3"
 source = { editable = "." }
 dependencies = [
     { name = "imageio-ffmpeg" },
@@ -1719,7 +1719,7 @@ requires-dist = [
     { name = "mediapy", specifier = ">=1.2.6" },
     { name = "mjviser", specifier = ">=0.0.14" },
     { name = "mujoco", specifier = "~=3.10.0" },
-    { name = "mujoco-warp", specifier = "~=3.10.0,>=3.10.0.2" },
+    { name = "mujoco-warp", specifier = "~=3.10.0,>=3.10.0.3" },
     { name = "numpy", specifier = "<2.5" },
     { name = "onnxscript", specifier = ">=0.5.4" },
     { name = "prettytable" },
@@ -1905,7 +1905,7 @@ wheels = [
 
 [[package]]
 name = "mujoco-warp"
-version = "3.10.0.2"
+version = "3.10.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "absl-py" },
@@ -1916,9 +1916,9 @@ dependencies = [
     { name = "warp-lang", version = "1.14.0", source = { registry = "https://pypi.nvidia.com/" }, marker = "sys_platform != 'darwin' or (extra == 'extra-5-mjlab-cpu' and extra == 'extra-5-mjlab-cu128')" },
     { name = "warp-lang", version = "1.14.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin' or (extra == 'extra-5-mjlab-cpu' and extra == 'extra-5-mjlab-cu128')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/00/b1/edd8743786263d756bb1ffded28ae211289334bbb1ad9729c40e6163b376/mujoco_warp-3.10.0.2.tar.gz", hash = "sha256:3fe8b5c68bd30eda31af45d1cbee42480a7d1c6e69a35733c5538445375fc570", size = 2066036, upload-time = "2026-07-13T18:24:40.645Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/02/1687ee928ea468345546af79dcfd65da9cd5840e16d1e71a244223494e54/mujoco_warp-3.10.0.3.tar.gz", hash = "sha256:f22196465cb1350677f66d8b65aa23bf37d95e150ce3ba3c68ea934ba35e3070", size = 2074757, upload-time = "2026-07-22T15:28:01.367Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/dc/928040ff3b95b2156dada9b4388a96fb423385c091663bb7f49f662a2d62/mujoco_warp-3.10.0.2-py3-none-any.whl", hash = "sha256:9245c952cd49761dea3f7fdb4060ee816dca0db3f2f63b561a80a02d20c40464", size = 2147055, upload-time = "2026-07-13T18:24:39.203Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/a1/a8e616daafb219fccc2d23367894d305e442e2e18bc5e0dd855d9986d979/mujoco_warp-3.10.0.3-py3-none-any.whl", hash = "sha256:9435e5d6a7061af32aecc8da38124bfccceea27fc85176b33b66b7c4b76b4c1a", size = 2152650, upload-time = "2026-07-22T15:27:59.463Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Bumps mujoco-warp to 3.10.0.3 to pick up the fix for the CUDA 700 illegal memory access reported in #1108. The crash fired from mujoco-warp's smooth.crb kernel when startup mass domain randomization recomputed constants via set_const, and only reproduced once num_envs reached 128 on consumer Ada GPUs. Along with the dependency floor this bumps the mjlab version to 1.5.3, refreshes the lockfile, and updates the citation metadata so the tag can be cut.

Fixes #1108