### PR TITLE
Update MuJoCo Warp badge to 3.10.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![GitHub Actions](https://img.shields.io/github/actions/workflow/status/mujocolab/mjlab/ci.yml?branch=main)](https://github.com/mujocolab/mjlab/actions/workflows/ci.yml?query=branch%3Amain)
 [![Documentation](https://github.com/mujocolab/mjlab/actions/workflows/docs.yml/badge.svg)](https://mujocolab.github.io/mjlab/)
 [![License](https://img.shields.io/github/license/mujocolab/mjlab)](https://github.com/mujocolab/mjlab/blob/main/LICENSE)
-[![MuJoCo Warp](https://img.shields.io/badge/MuJoCo_Warp-3.10.0.2-blue)](https://github.com/google-deepmind/mujoco_warp/releases/tag/v3.10.0.2)
+[![MuJoCo Warp](https://img.shields.io/badge/MuJoCo_Warp-3.10.0.3-blue)](https://github.com/google-deepmind/mujoco_warp/releases/tag/v3.10.0.3)
 [![Nightly Benchmarks](https://img.shields.io/badge/Nightly-Benchmarks-blue)](https://mujocolab.github.io/mjlab/nightly/)
 [![PyPI](https://img.shields.io/pypi/v/mjlab)](https://pypi.org/project/mjlab/)
 [![PyPI downloads](https://img.shields.io/pypi/dm/mjlab?color=blue)](https://pypistats.org/packages/mjlab)


### PR DESCRIPTION
The README's MuJoCo Warp badge is hardcoded rather than derived from the dependency pin, so the 1.5.3 release left it stuck at 3.10.0.2. This bumps the badge label and its release link to 3.10.0.3 to match the dependency floor.