### PR TITLE
Add missing LightCfg fields and domain randomization

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,6 +8,13 @@ Upcoming version (not yet released)
 Added
 ^^^^^
 
+- Added ``diffuse``, ``specular``, ``ambient``, ``active``, and
+  ``attenuation`` fields to ``LightCfg`` for configuring light color and
+  falloff. Contribution by @bd-pmorais.
+- Added light domain randomization functions: ``dr.light_diffuse``,
+  ``dr.light_specular``, ``dr.light_ambient``, and ``dr.light_attenuation``.
+  Contribution by @bd-pmorais.
+
 Changed
 ^^^^^^^
 

--- a/docs/source/randomization.rst
+++ b/docs/source/randomization.rst
@@ -219,6 +219,22 @@ and ``dr.body_ipos`` are the same function).
      - ``light_dir``
      - Light direction vector
      -
+   * - ``dr.light_diffuse``
+     - ``light_diffuse``
+     - Diffuse RGB color
+     -
+   * - ``dr.light_specular``
+     - ``light_specular``
+     - Specular RGB color
+     -
+   * - ``dr.light_ambient``
+     - ``light_ambient``
+     - Ambient RGB color
+     -
+   * - ``dr.light_attenuation``
+     - ``light_attenuation``
+     - Constant, linear, and quadratic attenuation coefficients
+     -
 
 .. rubric:: Material fields
 

--- a/src/mjlab/envs/mdp/dr/__init__.py
+++ b/src/mjlab/envs/mdp/dr/__init__.py
@@ -67,8 +67,12 @@ from .camera import cam_quat as cam_quat
 
 # Light.
 # isort: split
+from .light import light_ambient as light_ambient
+from .light import light_attenuation as light_attenuation
+from .light import light_diffuse as light_diffuse
 from .light import light_dir as light_dir
 from .light import light_pos as light_pos
+from .light import light_specular as light_specular
 
 # Material.
 # isort: split

--- a/src/mjlab/envs/mdp/dr/light.py
+++ b/src/mjlab/envs/mdp/dr/light.py
@@ -72,3 +72,111 @@ def light_dir(
     shared_random=shared_random,
     default_axes=[0, 1, 2],
   )
+
+
+@requires_model_fields("light_diffuse")
+def light_diffuse(
+  env: ManagerBasedRlEnv,
+  env_ids: torch.Tensor | None,
+  ranges: Ranges,
+  asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
+  distribution: Distribution | str = "uniform",
+  operation: Operation | str = "abs",
+  axes: list[int] | None = None,
+  shared_random: bool = False,
+) -> None:
+  """Randomize light diffuse RGB color."""
+  _randomize_model_field(
+    env,
+    env_ids,
+    "light_diffuse",
+    entity_type="light",
+    ranges=ranges,
+    distribution=distribution,
+    operation=operation,
+    asset_cfg=asset_cfg,
+    axes=axes,
+    shared_random=shared_random,
+    default_axes=[0, 1, 2],
+  )
+
+
+@requires_model_fields("light_specular")
+def light_specular(
+  env: ManagerBasedRlEnv,
+  env_ids: torch.Tensor | None,
+  ranges: Ranges,
+  asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
+  distribution: Distribution | str = "uniform",
+  operation: Operation | str = "abs",
+  axes: list[int] | None = None,
+  shared_random: bool = False,
+) -> None:
+  """Randomize light specular RGB color."""
+  _randomize_model_field(
+    env,
+    env_ids,
+    "light_specular",
+    entity_type="light",
+    ranges=ranges,
+    distribution=distribution,
+    operation=operation,
+    asset_cfg=asset_cfg,
+    axes=axes,
+    shared_random=shared_random,
+    default_axes=[0, 1, 2],
+  )
+
+
+@requires_model_fields("light_ambient")
+def light_ambient(
+  env: ManagerBasedRlEnv,
+  env_ids: torch.Tensor | None,
+  ranges: Ranges,
+  asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
+  distribution: Distribution | str = "uniform",
+  operation: Operation | str = "abs",
+  axes: list[int] | None = None,
+  shared_random: bool = False,
+) -> None:
+  """Randomize light ambient RGB color."""
+  _randomize_model_field(
+    env,
+    env_ids,
+    "light_ambient",
+    entity_type="light",
+    ranges=ranges,
+    distribution=distribution,
+    operation=operation,
+    asset_cfg=asset_cfg,
+    axes=axes,
+    shared_random=shared_random,
+    default_axes=[0, 1, 2],
+  )
+
+
+@requires_model_fields("light_attenuation")
+def light_attenuation(
+  env: ManagerBasedRlEnv,
+  env_ids: torch.Tensor | None,
+  ranges: Ranges,
+  asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
+  distribution: Distribution | str = "uniform",
+  operation: Operation | str = "abs",
+  axes: list[int] | None = None,
+  shared_random: bool = False,
+) -> None:
+  """Randomize light attenuation coefficients."""
+  _randomize_model_field(
+    env,
+    env_ids,
+    "light_attenuation",
+    entity_type="light",
+    ranges=ranges,
+    distribution=distribution,
+    operation=operation,
+    asset_cfg=asset_cfg,
+    axes=axes,
+    shared_random=shared_random,
+    default_axes=[0, 1, 2],
+  )

--- a/src/mjlab/utils/spec_config.py
+++ b/src/mjlab/utils/spec_config.py
@@ -377,6 +377,16 @@ class LightCfg(SpecCfg):
   """Spot light cutoff angle in degrees."""
   exponent: float = 10.0
   """Spot light exponent."""
+  diffuse: tuple[float, float, float] | None = None
+  """Diffuse RGB color. ``None`` keeps MuJoCo's default."""
+  specular: tuple[float, float, float] | None = None
+  """Specular RGB color. ``None`` keeps MuJoCo's default."""
+  ambient: tuple[float, float, float] | None = None
+  """Ambient RGB color. ``None`` keeps MuJoCo's default."""
+  active: bool = True
+  """Whether the light is on."""
+  attenuation: tuple[float, float, float] = (1.0, 0.0, 0.0)
+  """Constant, linear, and quadratic attenuation coefficients."""
 
   def edit_spec(self, spec: mujoco.MjSpec) -> None:
     self.validate()
@@ -393,6 +403,11 @@ class LightCfg(SpecCfg):
       dir=self.dir,
       cutoff=self.cutoff,
       exponent=self.exponent,
+      diffuse=self.diffuse,
+      specular=self.specular,
+      ambient=self.ambient,
+      active=self.active,
+      attenuation=self.attenuation,
     )
     if self.name is not None:
       light.name = self.name

--- a/tests/test_domain_randomization.py
+++ b/tests/test_domain_randomization.py
@@ -972,6 +972,10 @@ def _make_cam_light_env(device, num_envs=NUM_ENVS):
       "cam_intrinsic",
       "light_pos",
       "light_dir",
+      "light_diffuse",
+      "light_specular",
+      "light_ambient",
+      "light_attenuation",
     ),
   )
 
@@ -1093,6 +1097,39 @@ def test_light_dir_add(cam_light_env):
     lo = default_dir[..., ax] - 0.5 - 1e-5
     hi = default_dir[..., ax] + 0.5 + 1e-5
     assert torch.all((result[..., ax] >= lo) & (result[..., ax] <= hi))
+
+
+@pytest.mark.parametrize(
+  ("func_name", "field", "ranges"),
+  [
+    ("light_diffuse", "light_diffuse", (0.2, 0.8)),
+    ("light_specular", "light_specular", (0.0, 1.0)),
+    ("light_ambient", "light_ambient", (0.1, 0.5)),
+    ("light_attenuation", "light_attenuation", (0.0, 1.0)),
+  ],
+)
+def test_light_vec3_fields_abs(cam_light_env, func_name, field, ranges):
+  """Vec3 light fields randomize per selected light."""
+  torch.manual_seed(42)
+  env = cam_light_env
+  robot = env.scene["robot"]
+  light_cfg = SceneEntityCfg("robot", light_names=(".*",))
+  light_cfg.resolve(env.scene)
+  light_ids = robot.indexing.light_ids[light_cfg.light_ids]
+  func = getattr(dr, func_name)
+
+  func(
+    env,
+    env_ids=None,
+    ranges=ranges,
+    operation="abs",
+    asset_cfg=light_cfg,
+  )
+
+  values = getattr(env.sim.model, field)[:, light_ids, :]
+  lower, upper = ranges
+  assert torch.all((values >= lower - 1e-5) & (values <= upper + 1e-5))
+  assert len(torch.unique(values[:, 0, 0])) >= 2
 
 
 def test_camera_partial_env_ids(cam_light_env):

--- a/tests/test_spec_config.py
+++ b/tests/test_spec_config.py
@@ -353,6 +353,27 @@ def test_light_cfg():
   assert light.name == "test_light"
 
 
+def test_light_cfg_color_and_attenuation():
+  """LightCfg should set diffuse, specular, ambient, active, attenuation."""
+  spec = mujoco.MjSpec()
+  light_cfg = LightCfg(
+    name="test_light",
+    diffuse=(1.0, 0.0, 0.0),
+    specular=(0.0, 1.0, 0.0),
+    ambient=(0.0, 0.0, 1.0),
+    active=False,
+    attenuation=(1.0, 0.5, 0.25),
+  )
+  light_cfg.edit_spec(spec)
+
+  light = spec.light("test_light")
+  assert tuple(light.diffuse) == pytest.approx((1.0, 0.0, 0.0))
+  assert tuple(light.specular) == pytest.approx((0.0, 1.0, 0.0))
+  assert tuple(light.ambient) == pytest.approx((0.0, 0.0, 1.0))
+  assert not light.active
+  assert tuple(light.attenuation) == pytest.approx((1.0, 0.5, 0.25))
+
+
 def test_camera_cfg():
   """CameraCfg should add cameras to spec."""
   spec = mujoco.MjSpec()


### PR DESCRIPTION
This PR adds some fields to LightCfg that were missing but supported by both mujoco and mjwarp and adds basic domain randomization functions for them. 