### PR TITLE
Add dr.light_cutoff, dr.light_exponent and add light fields to model_sync

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -12,8 +12,8 @@ Added
   ``attenuation`` fields to ``LightCfg`` for configuring light color and
   falloff. Contribution by @bd-pmorais.
 - Added light domain randomization functions: ``dr.light_diffuse``,
-  ``dr.light_specular``, ``dr.light_ambient``, and ``dr.light_attenuation``.
-  Contribution by @bd-pmorais.
+  ``dr.light_specular``, ``dr.light_ambient``, ``dr.light_attenuation``,
+  ``dr.light_cutoff``, and ``dr.light_exponent``. Contribution by @bd-pmorais.
 
 Changed
 ^^^^^^^

--- a/docs/source/randomization.rst
+++ b/docs/source/randomization.rst
@@ -235,6 +235,14 @@ and ``dr.body_ipos`` are the same function).
      - ``light_attenuation``
      - Constant, linear, and quadratic attenuation coefficients
      -
+   * - ``dr.light_cutoff``
+     - ``light_cutoff``
+     - Spot light half-cone angle in degrees
+     - Ignored for directional lights
+   * - ``dr.light_exponent``
+     - ``light_exponent``
+     - Spot light angular falloff exponent
+     - Ignored for directional lights
 
 .. rubric:: Material fields
 
@@ -1360,7 +1368,9 @@ toggles then work correctly against the randomized model:
   to toggle inertia boxes
 - Camera parameters (``cam_pos``, ``cam_quat``, ``cam_fovy``,
   ``cam_intrinsic``): press ``Q`` to toggle camera frustums
-- Lights (``light_pos``, ``light_dir``)
+- Lights (``light_pos``, ``light_dir``, ``light_diffuse``, ``light_specular``,
+  ``light_ambient``, ``light_attenuation``, ``light_cutoff``,
+  ``light_exponent``)
 
 .. grid:: 2
 

--- a/src/mjlab/envs/mdp/dr/__init__.py
+++ b/src/mjlab/envs/mdp/dr/__init__.py
@@ -69,8 +69,10 @@ from .camera import cam_quat as cam_quat
 # isort: split
 from .light import light_ambient as light_ambient
 from .light import light_attenuation as light_attenuation
+from .light import light_cutoff as light_cutoff
 from .light import light_diffuse as light_diffuse
 from .light import light_dir as light_dir
+from .light import light_exponent as light_exponent
 from .light import light_pos as light_pos
 from .light import light_specular as light_specular
 

--- a/src/mjlab/envs/mdp/dr/light.py
+++ b/src/mjlab/envs/mdp/dr/light.py
@@ -180,3 +180,55 @@ def light_attenuation(
     shared_random=shared_random,
     default_axes=[0, 1, 2],
   )
+
+
+@requires_model_fields("light_cutoff")
+def light_cutoff(
+  env: ManagerBasedRlEnv,
+  env_ids: torch.Tensor | None,
+  ranges: Ranges,
+  asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
+  distribution: Distribution | str = "uniform",
+  operation: Operation | str = "abs",
+  axes: list[int] | None = None,
+  shared_random: bool = False,
+) -> None:
+  """Randomize spot light cutoff angles in degrees."""
+  _randomize_model_field(
+    env,
+    env_ids,
+    "light_cutoff",
+    entity_type="light",
+    ranges=ranges,
+    distribution=distribution,
+    operation=operation,
+    asset_cfg=asset_cfg,
+    axes=axes,
+    shared_random=shared_random,
+  )
+
+
+@requires_model_fields("light_exponent")
+def light_exponent(
+  env: ManagerBasedRlEnv,
+  env_ids: torch.Tensor | None,
+  ranges: Ranges,
+  asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
+  distribution: Distribution | str = "uniform",
+  operation: Operation | str = "abs",
+  axes: list[int] | None = None,
+  shared_random: bool = False,
+) -> None:
+  """Randomize spot light angular falloff exponents."""
+  _randomize_model_field(
+    env,
+    env_ids,
+    "light_exponent",
+    entity_type="light",
+    ranges=ranges,
+    distribution=distribution,
+    operation=operation,
+    asset_cfg=asset_cfg,
+    axes=axes,
+    shared_random=shared_random,
+  )

--- a/src/mjlab/viewer/model_sync.py
+++ b/src/mjlab/viewer/model_sync.py
@@ -54,6 +54,12 @@ VIEWER_MODEL_FIELDS = frozenset(
     "cam_intrinsic",
     "light_pos",
     "light_dir",
+    "light_ambient",
+    "light_diffuse",
+    "light_specular",
+    "light_attenuation",
+    "light_cutoff",
+    "light_exponent",
   }
 )
 

--- a/tests/test_domain_randomization.py
+++ b/tests/test_domain_randomization.py
@@ -976,6 +976,8 @@ def _make_cam_light_env(device, num_envs=NUM_ENVS):
       "light_specular",
       "light_ambient",
       "light_attenuation",
+      "light_cutoff",
+      "light_exponent",
     ),
   )
 
@@ -1130,6 +1132,37 @@ def test_light_vec3_fields_abs(cam_light_env, func_name, field, ranges):
   lower, upper = ranges
   assert torch.all((values >= lower - 1e-5) & (values <= upper + 1e-5))
   assert len(torch.unique(values[:, 0, 0])) >= 2
+
+
+@pytest.mark.parametrize(
+  ("func_name", "field", "ranges"),
+  [
+    ("light_cutoff", "light_cutoff", (20.0, 60.0)),
+    ("light_exponent", "light_exponent", (1.0, 20.0)),
+  ],
+)
+def test_light_scalar_fields_abs(cam_light_env, func_name, field, ranges):
+  """Scalar light fields randomize per selected light."""
+  torch.manual_seed(42)
+  env = cam_light_env
+  robot = env.scene["robot"]
+  light_cfg = SceneEntityCfg("robot", light_names=(".*",))
+  light_cfg.resolve(env.scene)
+  light_ids = robot.indexing.light_ids[light_cfg.light_ids]
+  func = getattr(dr, func_name)
+
+  func(
+    env,
+    env_ids=None,
+    ranges=ranges,
+    operation="abs",
+    asset_cfg=light_cfg,
+  )
+
+  values = getattr(env.sim.model, field)[:, light_ids]
+  lower, upper = ranges
+  assert torch.all((values >= lower - 1e-5) & (values <= upper + 1e-5))
+  assert len(torch.unique(values[:, 0])) >= 2
 
 
 def test_camera_partial_env_ids(cam_light_env):


### PR DESCRIPTION
Extends #1118 by adding the final two missing randomizations (`dr.light_cutoff` and `dr.light_exponent`) and also adds all the randomizable fields to `model_sync` so they show up in the native viewer. 