### PR TITLE
Add GeomGroupCfg as a way to overwrite geom group without spec_fn

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,6 +8,9 @@ Upcoming version (not yet released)
 Added
 ^^^^^
 
+- Added ``GeomGroupCfg``, exposed as the ``geom_groups`` field on
+  ``EntityCfg``, for setting the visualization group per geom, so a geom can
+  collide without being drawn. Contribution by @bd-pmorais.
 - Added ``diffuse``, ``specular``, ``ambient``, ``active``, and
   ``attenuation`` fields to ``LightCfg`` for configuring light color and
   falloff. Contribution by @bd-pmorais.

--- a/docs/source/entity/index.rst
+++ b/docs/source/entity/index.rst
@@ -191,6 +191,8 @@ modify the ``MjSpec`` before compilation:
      - Add procedural textures (checker, gradient, etc.).
    * - ``materials``
      - Add materials and optionally assign them to geoms by regex.
+   * - ``geom_groups``
+     - Set the visualization group per geom.
 
 Each editor accepts regex patterns to target specific elements. For
 example, a ``CollisionCfg`` with ``geom_names_expr=(".*_foot.*",)``

--- a/src/mjlab/entity/entity.py
+++ b/src/mjlab/entity/entity.py
@@ -98,6 +98,7 @@ class EntityCfg:
   textures: tuple[spec_cfg.TextureCfg, ...] = field(default_factory=tuple)
   materials: tuple[spec_cfg.MaterialCfg, ...] = field(default_factory=tuple)
   meshes: tuple[spec_cfg.MeshCfg, ...] = field(default_factory=tuple)
+  geom_groups: tuple[spec_cfg.GeomGroupCfg, ...] = field(default_factory=tuple)
   collisions: tuple[spec_cfg.CollisionCfg, ...] = field(default_factory=tuple)
 
   def build(self) -> Entity:
@@ -193,6 +194,7 @@ class Entity:
       self.cfg.textures,
       self.cfg.materials,
       self.cfg.meshes,
+      self.cfg.geom_groups,
       self.cfg.collisions,
     ]:
       for cfg in cfg_list:

--- a/src/mjlab/utils/spec_config.py
+++ b/src/mjlab/utils/spec_config.py
@@ -207,6 +207,50 @@ class MeshCfg(SpecCfg):
 
 
 @dataclass
+class GeomGroupCfg(SpecCfg):
+  """Configuration to set the visualization group of geoms in the MuJoCo spec.
+
+  Supports regex pattern matching for geom names and dict-based field resolution
+  for per-geom group assignment.
+  """
+
+  geom_names_expr: tuple[str, ...]
+  """Tuple of regex patterns to match geom names."""
+  group: int | dict[str, int]
+  """Visualization group (int or dict mapping patterns to values). Must be in
+  [0, mjNGROUP). Groups 3-5 are hidden by default in viewers and sensors."""
+
+  def validate(self) -> None:
+    """Validate group configuration parameters."""
+    # Validate group (must be in [0, mjNGROUP)).
+    if isinstance(self.group, dict):
+      for pattern, value in self.group.items():
+        if not 0 <= value < mujoco.mjNGROUP:
+          raise ValueError(
+            f"group must be in [0, {mujoco.mjNGROUP}), got {value} for "
+            f"pattern '{pattern}'"
+          )
+    elif not 0 <= self.group < mujoco.mjNGROUP:
+      raise ValueError(f"group must be in [0, {mujoco.mjNGROUP}), got {self.group}")
+
+  def edit_spec(self, spec: mujoco.MjSpec) -> None:
+    from mjlab.utils.string import filter_exp, resolve_field
+
+    self.validate()
+
+    all_geoms: list[mujoco.MjsGeom] = spec.geoms
+    all_geom_names = tuple(g.name for g in all_geoms)
+    matched_names = set(filter_exp(self.geom_names_expr, all_geom_names))
+    geom_subset = [g for g in all_geoms if g.name in matched_names]
+
+    group = resolve_field(self.group, tuple(g.name for g in geom_subset))
+
+    for geom, value in zip(geom_subset, group, strict=True):
+      if value is not None:
+        geom.group = value
+
+
+@dataclass
 class CollisionCfg(SpecCfg):
   """Configuration to modify collision properties of geoms in the MuJoCo spec.
 

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -12,6 +12,7 @@ from mjlab.actuator import BuiltinPositionActuatorCfg, XmlActuatorCfg
 from mjlab.entity import Entity, EntityArticulationInfoCfg, EntityCfg
 from mjlab.scene import Scene, SceneCfg
 from mjlab.sim.sim import Simulation, SimulationCfg
+from mjlab.utils.spec_config import GeomGroupCfg
 
 FIXED_BASE_XML = """
 <mujoco>
@@ -262,6 +263,19 @@ def test_multiple_freejoints_raises():
   cfg = EntityCfg(spec_fn=lambda: mujoco.MjSpec.from_string(xml))
   with pytest.raises(ValueError, match="2 freejoints"):
     Entity(cfg)
+
+
+def test_geom_groups_editor_applied():
+  """Test that geom_groups editors are applied during entity init."""
+  cfg = EntityCfg(
+    spec_fn=lambda: mujoco.MjSpec.from_string(FIXED_BASE_ARTICULATED_XML),
+    geom_groups=(GeomGroupCfg(geom_names_expr=("link.*_geom",), group=3),),
+  )
+  entity = Entity(cfg)
+
+  assert entity.spec.geom("link1_geom").group == 3
+  assert entity.spec.geom("link2_geom").group == 3
+  assert entity.spec.geom("base_geom").group == 0
 
 
 def test_find_methods():

--- a/tests/test_spec_config.py
+++ b/tests/test_spec_config.py
@@ -8,6 +8,7 @@ import pytest
 from mjlab.utils.spec_config import (
   CameraCfg,
   CollisionCfg,
+  GeomGroupCfg,
   LightCfg,
   MaterialCfg,
   MeshCfg,
@@ -417,3 +418,50 @@ def test_material_cfg_geom_assignment():
   assert spec.geom("link1_visual").material == "my_mat"
   assert spec.geom("link2_visual").material == "my_mat"
   assert spec.geom("arm_collision").material == ""
+
+
+def test_geom_group_basic(multi_geom_spec):
+  """GeomGroupCfg should set the group of matching geoms."""
+  group_cfg = GeomGroupCfg(
+    geom_names_expr=(r"^(left|right)_foot\d_collision$",), group=3
+  )
+  group_cfg.edit_spec(multi_geom_spec)
+
+  assert multi_geom_spec.geom("left_foot1_collision").group == 3
+  assert multi_geom_spec.geom("right_foot3_collision").group == 3
+
+  arm = multi_geom_spec.geom("arm_collision")
+  assert arm.group == 0  # Default unchanged.
+
+
+def test_geom_group_dict_field_resolution(multi_geom_spec):
+  """GeomGroupCfg should support dict-based field resolution."""
+  group_cfg = GeomGroupCfg(
+    geom_names_expr=(r".*_foot\d_collision$", "arm_collision"),
+    group={r".*_foot\d_collision$": 3, "arm_collision": 4},
+  )
+  group_cfg.edit_spec(multi_geom_spec)
+
+  assert multi_geom_spec.geom("left_foot1_collision").group == 3
+  assert multi_geom_spec.geom("arm_collision").group == 4
+
+
+def test_geom_group_unnamed_geoms():
+  """GeomGroupCfg should update every matching geom, including unnamed ones."""
+  spec = mujoco.MjSpec()
+  body = spec.worldbody.add_body(name="test_body")
+  for _ in range(3):
+    body.add_geom(type=mujoco.mjtGeom.mjGEOM_BOX, size=[0.1, 0.1, 0.1])
+
+  group_cfg = GeomGroupCfg(geom_names_expr=(".*",), group=3)
+  group_cfg.edit_spec(spec)
+
+  assert [g.group for g in spec.geoms] == [3, 3, 3]
+
+
+@pytest.mark.parametrize("value", [-1, mujoco.mjNGROUP, {"arm_collision": -1}])
+def test_geom_group_validation(value):
+  """GeomGroupCfg should validate the group."""
+  with pytest.raises(ValueError, match="group must be in"):
+    cfg = GeomGroupCfg(geom_names_expr=("test",), group=value)
+    cfg.validate()


### PR DESCRIPTION
Currently (AFAIK) in mjlab there's no way to change a geom's `group` without spec_fn (and `group` is actually fairly important since currently it's the only way to hide things from the warp renderer, which doesn't support alpha <1). This adds a `GeomGroupCfg` and `geom_groups` field to `EntityCfg` to accomplish that. Added as a separate config since semantically it's not well grouped with the existing cfgs. 