### PR TITLE
Handle out-of-range geom groups instead of silently dropping them

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -25,6 +25,9 @@ Changed
 Fixed
 ^^^^^
 
+- ``RayCastSensorCfg.include_geom_groups`` now raises on values outside
+  ``[0, mjNGROUP)`` instead of silently excluding every geom.
+
 Version 1.5.3 (July 22, 2026)
 -----------------------------
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -27,6 +27,8 @@ Fixed
 
 - ``RayCastSensorCfg.include_geom_groups`` now raises on values outside
   ``[0, mjNGROUP)`` instead of silently excluding every geom.
+- Geoms with a negative group no longer pick up group 5's visibility toggle in
+  the Viser viewer.
 
 Version 1.5.3 (July 22, 2026)
 -----------------------------

--- a/src/mjlab/sensor/raycast_sensor.py
+++ b/src/mjlab/sensor/raycast_sensor.py
@@ -44,8 +44,11 @@ def _geom_groups_to_vec6(groups: tuple[int, ...] | None):  # -> _vec6
     return _ALL_GROUPS
   out = [0, 0, 0, 0, 0, 0]
   for g in groups:
-    if 0 <= g <= 5:
-      out[g] = -1
+    if not 0 <= g < mujoco.mjNGROUP:
+      raise ValueError(
+        f"include_geom_groups must be in [0, {mujoco.mjNGROUP}), got {g}"
+      )
+    out[g] = -1
   return _vec6(*out)
 
 

--- a/src/mjlab/viewer/viser/scene.py
+++ b/src/mjlab/viewer/viser/scene.py
@@ -490,7 +490,9 @@ class MjlabViserScene(ViserMujocoScene, DebugVisualizer):
         batch_count = len(variant.env_ids)
         lod_ratio = 1000.0 / variant.mesh.vertices.shape[0]
         suffix = f"/sub{variant.sub_idx}" if variant.sub_idx > 0 else ""
-        visible = variant.group_id < 6 and self.geom_groups_visible[variant.group_id]
+        visible = (
+          0 <= variant.group_id < 6 and self.geom_groups_visible[variant.group_id]
+        )
 
         handle = self.server.scene.add_batched_meshes_trimesh(
           f"/bodies/{variant.body_name}/group{variant.group_id}"
@@ -708,7 +710,7 @@ class MjlabViserScene(ViserMujocoScene, DebugVisualizer):
       body_xquat = vtf.SO3.from_matrix(body_xmat).wxyz
       for mg in self._mesh_groups:
         if isinstance(mg, _PerWorldMeshGroup):
-          visible = mg.group_id < 6 and self.geom_groups_visible[mg.group_id]
+          visible = 0 <= mg.group_id < 6 and self.geom_groups_visible[mg.group_id]
           if visible and any(body_id in hidden_bodies for body_id in mg.body_ids):
             visible = False
           if not visible:

--- a/tests/test_raycast_sensor.py
+++ b/tests/test_raycast_sensor.py
@@ -17,6 +17,7 @@ from mjlab.sensor import (
   RayCastSensorCfg,
   RingPatternCfg,
 )
+from mjlab.sensor.raycast_sensor import _geom_groups_to_vec6
 from mjlab.sim import MujocoCfg, SimulationCfg
 
 
@@ -1234,3 +1235,10 @@ def test_site_origin_is_physical_with_world_alignment(device):
 
   assert data.pos_w[0, 2].item() == pytest.approx(1.0, abs=0.1)
   assert data.distances[0, 0].item() == pytest.approx(1.0, abs=0.1)
+
+
+@pytest.mark.parametrize("groups", [(6,), (-1,), (0, 7)])
+def test_include_geom_groups_out_of_range_raises(groups):
+  """Out-of-range geom groups should raise rather than silently exclude."""
+  with pytest.raises(ValueError, match="include_geom_groups must be in"):
+    _geom_groups_to_vec6(groups)


### PR DESCRIPTION
Two small fixes to how out-of-range geom groups are handled, found while reviewing #1120.

MuJoCo does not range-check `geom_group`: a geom with group 99 or -1 compiles fine, and consumers then disagree about what it means. `mj_ray` and mujoco_warp's ray clamp the group into `[0, mjNGROUP)`, while mujoco_warp's renderer matches exactly via `np.isin` and drops it. That inconsistency is upstream and not something we can fix here, but two places on our side make it worse.

`_geom_groups_to_vec6` silently skipped any group outside 0-5, so `include_geom_groups=(7,)` built an all-exclude mask and the sensor returned no hits at all with no indication anything was wrong. It now raises.

The Viser scene guarded the group index with `group_id < 6` but no lower bound, so a geom with a negative group indexed `geom_groups_visible[-1]` and silently picked up group 5's visibility toggle. Now bounded on both ends. The same pattern exists upstream in mjviser and is left alone here.
