### PR TITLE
Add GeomCfg spec editor for setting geom visualization group

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,6 +8,10 @@ Upcoming version (not yet released)
 Added
 ^^^^^
 
+- Added ``GeomCfg``, exposed as the ``geoms`` field on ``EntityCfg``, a spec
+  editor that matches geoms by name and edits their attributes. Currently
+  supports ``group``, so a geom can collide without being drawn.
+  Contribution by @bd-pmorais.
 - Added ``diffuse``, ``specular``, ``ambient``, ``active``, and
   ``attenuation`` fields to ``LightCfg`` for configuring light color and
   falloff. Contribution by @bd-pmorais.

--- a/docs/source/entity/index.rst
+++ b/docs/source/entity/index.rst
@@ -191,6 +191,8 @@ modify the ``MjSpec`` before compilation:
      - Add procedural textures (checker, gradient, etc.).
    * - ``materials``
      - Add materials and optionally assign them to geoms by regex.
+   * - ``geoms``
+     - Edit attributes of existing geoms, such as the visualization group.
 
 Each editor accepts regex patterns to target specific elements. For
 example, a ``CollisionCfg`` with ``geom_names_expr=(".*_foot.*",)``

--- a/src/mjlab/entity/entity.py
+++ b/src/mjlab/entity/entity.py
@@ -98,6 +98,7 @@ class EntityCfg:
   textures: tuple[spec_cfg.TextureCfg, ...] = field(default_factory=tuple)
   materials: tuple[spec_cfg.MaterialCfg, ...] = field(default_factory=tuple)
   meshes: tuple[spec_cfg.MeshCfg, ...] = field(default_factory=tuple)
+  geoms: tuple[spec_cfg.GeomCfg, ...] = field(default_factory=tuple)
   collisions: tuple[spec_cfg.CollisionCfg, ...] = field(default_factory=tuple)
 
   def build(self) -> Entity:
@@ -193,6 +194,7 @@ class Entity:
       self.cfg.textures,
       self.cfg.materials,
       self.cfg.meshes,
+      self.cfg.geoms,
       self.cfg.collisions,
     ]:
       for cfg in cfg_list:

--- a/src/mjlab/utils/spec_config.py
+++ b/src/mjlab/utils/spec_config.py
@@ -4,6 +4,8 @@ from typing import Literal
 
 import mujoco
 
+from mjlab.utils.string import filter_exp, resolve_field
+
 _TYPE_MAP = {
   "2d": mujoco.mjtTexture.mjTEXTURE_2D,
   "cube": mujoco.mjtTexture.mjTEXTURE_CUBE,
@@ -143,8 +145,6 @@ class MaterialCfg(SpecCfg):
       mat.textures[mujoco.mjtTextureRole.mjTEXROLE_RGB.value] = self.texture
 
     if self.geom_names_expr is not None:
-      from mjlab.utils.string import filter_exp
-
       all_geom_names = tuple(g.name for g in spec.geoms)
       matched = filter_exp(self.geom_names_expr, all_geom_names)
       for geom_name in matched:
@@ -179,8 +179,6 @@ class MeshCfg(SpecCfg):
   matched meshes, or a dict mapping regex patterns to per-mesh values."""
 
   def edit_spec(self, spec: mujoco.MjSpec) -> None:
-    from mjlab.utils.string import filter_exp, resolve_field
-
     self.validate()
 
     all_mesh_names = tuple(m.name for m in spec.meshes)
@@ -204,6 +202,53 @@ class MeshCfg(SpecCfg):
         raise ValueError(
           f"maxhullvert must be -1 (unlimited) or greater than 3, got {value}{where}"
         )
+
+
+@dataclass
+class GeomCfg(SpecCfg):
+  """Configuration to edit attributes of existing geoms in the MuJoCo spec.
+
+  Geoms are matched by regex against their names; unnamed geoms match the empty
+  string. Collision attributes also live on geoms but are tuned via CollisionCfg.
+
+  Only attributes set to a non-None value are applied; everything else is left at
+  whatever the source XML compiled to.
+  """
+
+  geom_names_expr: tuple[str, ...]
+  """Regex patterns to match geom names."""
+  group: int | dict[str, int] | None = None
+  """Visualization group for each matched geom. Viewers and sensors draw groups
+  0-2 by default, so moving a geom to group 3-5 keeps it colliding while hiding
+  it from rendering. Must be in [0, mjNGROUP): MuJoCo does not range-check the
+  group, and out-of-range values are clamped into range by raycasting but
+  dropped by the warp renderer. May be a single value applied to all matched
+  geoms, or a dict mapping regex patterns to per-geom values."""
+
+  def edit_spec(self, spec: mujoco.MjSpec) -> None:
+    self.validate()
+
+    all_geoms: list[mujoco.MjsGeom] = spec.geoms
+    all_geom_names = tuple(g.name for g in all_geoms)
+    matched_names = set(filter_exp(self.geom_names_expr, all_geom_names))
+    geom_subset = [g for g in all_geoms if g.name in matched_names]
+
+    group = resolve_field(self.group, tuple(g.name for g in geom_subset))
+    for geom, value in zip(geom_subset, group, strict=True):
+      if value is not None:
+        geom.group = value
+
+  def validate(self) -> None:
+    if isinstance(self.group, dict):
+      items = list(self.group.items())
+    else:
+      items = [(None, self.group)]
+    for pattern, value in items:
+      if value is None:
+        continue
+      if not 0 <= value < mujoco.mjNGROUP:
+        where = f" for pattern '{pattern}'" if pattern is not None else ""
+        raise ValueError(f"group must be in [0, {mujoco.mjNGROUP}), got {value}{where}")
 
 
 @dataclass
@@ -314,7 +359,6 @@ class CollisionCfg(SpecCfg):
 
   def edit_spec(self, spec: mujoco.MjSpec) -> None:
     from mjlab.utils.spec import disable_collision
-    from mjlab.utils.string import filter_exp, resolve_field
 
     self.validate()
 

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -12,6 +12,7 @@ from mjlab.actuator import BuiltinPositionActuatorCfg, XmlActuatorCfg
 from mjlab.entity import Entity, EntityArticulationInfoCfg, EntityCfg
 from mjlab.scene import Scene, SceneCfg
 from mjlab.sim.sim import Simulation, SimulationCfg
+from mjlab.utils.spec_config import GeomCfg
 
 FIXED_BASE_XML = """
 <mujoco>
@@ -262,6 +263,19 @@ def test_multiple_freejoints_raises():
   cfg = EntityCfg(spec_fn=lambda: mujoco.MjSpec.from_string(xml))
   with pytest.raises(ValueError, match="2 freejoints"):
     Entity(cfg)
+
+
+def test_geom_editor_applied():
+  """Test that geom editors are applied during entity init."""
+  cfg = EntityCfg(
+    spec_fn=lambda: mujoco.MjSpec.from_string(FIXED_BASE_ARTICULATED_XML),
+    geoms=(GeomCfg(geom_names_expr=("link.*_geom",), group=3),),
+  )
+  entity = Entity(cfg)
+
+  assert entity.spec.geom("link1_geom").group == 3
+  assert entity.spec.geom("link2_geom").group == 3
+  assert entity.spec.geom("base_geom").group == 0
 
 
 def test_find_methods():

--- a/tests/test_spec_config.py
+++ b/tests/test_spec_config.py
@@ -8,6 +8,7 @@ import pytest
 from mjlab.utils.spec_config import (
   CameraCfg,
   CollisionCfg,
+  GeomCfg,
   LightCfg,
   MaterialCfg,
   MeshCfg,
@@ -417,3 +418,58 @@ def test_material_cfg_geom_assignment():
   assert spec.geom("link1_visual").material == "my_mat"
   assert spec.geom("link2_visual").material == "my_mat"
   assert spec.geom("arm_collision").material == ""
+
+
+def test_geom_group_basic(multi_geom_spec):
+  """GeomCfg should set the group of matching geoms."""
+  group_cfg = GeomCfg(
+    geom_names_expr=(r"^(left|right)_foot\d_collision$",), group=3
+  )
+  group_cfg.edit_spec(multi_geom_spec)
+
+  assert multi_geom_spec.geom("left_foot1_collision").group == 3
+  assert multi_geom_spec.geom("right_foot3_collision").group == 3
+
+  arm = multi_geom_spec.geom("arm_collision")
+  assert arm.group == 0  # Default unchanged.
+
+
+def test_geom_group_none_is_noop(multi_geom_spec):
+  """GeomCfg should leave the group alone when it is None."""
+  multi_geom_spec.geom("arm_collision").group = 2
+  GeomCfg(geom_names_expr=(".*",)).edit_spec(multi_geom_spec)
+
+  assert multi_geom_spec.geom("arm_collision").group == 2
+
+
+def test_geom_group_dict_field_resolution(multi_geom_spec):
+  """GeomCfg should support dict-based field resolution."""
+  group_cfg = GeomCfg(
+    geom_names_expr=(r".*_foot\d_collision$", "arm_collision"),
+    group={r".*_foot\d_collision$": 3, "arm_collision": 4},
+  )
+  group_cfg.edit_spec(multi_geom_spec)
+
+  assert multi_geom_spec.geom("left_foot1_collision").group == 3
+  assert multi_geom_spec.geom("arm_collision").group == 4
+
+
+def test_geom_group_unnamed_geoms():
+  """GeomCfg should update every matching geom, including unnamed ones."""
+  spec = mujoco.MjSpec()
+  body = spec.worldbody.add_body(name="test_body")
+  for _ in range(3):
+    body.add_geom(type=mujoco.mjtGeom.mjGEOM_BOX, size=[0.1, 0.1, 0.1])
+
+  group_cfg = GeomCfg(geom_names_expr=(".*",), group=3)
+  group_cfg.edit_spec(spec)
+
+  assert [g.group for g in spec.geoms] == [3, 3, 3]
+
+
+@pytest.mark.parametrize("value", [-1, mujoco.mjNGROUP, {"arm_collision": -1}])
+def test_geom_group_validation(value):
+  """GeomCfg should validate the group."""
+  with pytest.raises(ValueError, match="group must be in"):
+    cfg = GeomCfg(geom_names_expr=("test",), group=value)
+    cfg.validate()


### PR DESCRIPTION
Supersedes #1120. Original work by @bd-pmorais, credited as co-author on the commit.

Adds a way to set a geom's group without wrapping `spec_fn`. Group is worth exposing because the camera and raycast sensors only see groups 0-2 by default, so moving a geom to group 3-5 keeps it colliding while hiding it from rendering.

Compared to #1120 this renames `GeomGroupCfg` to `GeomCfg` and makes `group` optional, matching how `MeshCfg` works. That way future geom attributes are new fields rather than a new config class each time.
