### PR TITLE
Unify geom spec editing behind one write path with explicit collision policies

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -9,9 +9,10 @@ Added
 ^^^^^
 
 - Added ``GeomCfg``, exposed as the ``geoms`` field on ``EntityCfg``, a spec
-  editor that matches geoms by name and edits their attributes. Currently
-  supports ``group``, so a geom can collide without being drawn.
-  Contribution by @bd-pmorais.
+  editor that matches geoms by name and patches their attributes. Supports
+  ``group`` (so a geom can collide without being drawn) and all collision
+  attributes; unset attributes are left untouched. Contribution by
+  @bd-pmorais.
 - Added ``diffuse``, ``specular``, ``ambient``, ``active``, and
   ``attenuation`` fields to ``LightCfg`` for configuring light color and
   falloff. Contribution by @bd-pmorais.
@@ -22,6 +23,12 @@ Added
 Changed
 ^^^^^^^
 
+- **Breaking**: ``CollisionCfg`` now requires ``contype``, ``conaffinity``,
+  ``condim``, and ``priority`` to be explicit instead of silently defaulting
+  to MuJoCo's values, and dict values for these fields must cover every
+  matched geom (add a catch-all ``".*"`` entry). ``CollisionCfg`` and
+  ``GeomCfg`` now share one write path, and mjlab warns when a ``GeomCfg``
+  collision patch is overwritten by a ``CollisionCfg``.
 - Changed the default MuJoCo Warp render background to solid black
   (``0, 0, 0, 1``), matching MuJoCo's native renderer. Contribution by
   @bd-pmorais.

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -5,6 +5,14 @@ Changelog
 Upcoming version (not yet released)
 -----------------------------------
 
+.. admonition:: Breaking API changes
+   :class: attention
+
+   - ``CollisionCfg`` now requires ``contype``, ``conaffinity``, ``condim``,
+     and ``priority`` to be explicit instead of silently defaulting to
+     MuJoCo's values, and dict values for these fields must cover every
+     matched geom (add a catch-all ``".*"`` entry).
+
 Added
 ^^^^^
 
@@ -23,12 +31,8 @@ Added
 Changed
 ^^^^^^^
 
-- **Breaking**: ``CollisionCfg`` now requires ``contype``, ``conaffinity``,
-  ``condim``, and ``priority`` to be explicit instead of silently defaulting
-  to MuJoCo's values, and dict values for these fields must cover every
-  matched geom (add a catch-all ``".*"`` entry). ``CollisionCfg`` and
-  ``GeomCfg`` now share one write path, and mjlab warns when a ``GeomCfg``
-  collision patch is overwritten by a ``CollisionCfg``.
+- ``CollisionCfg`` and ``GeomCfg`` now share one write path, and mjlab warns
+  when a ``GeomCfg`` collision patch is overwritten by a ``CollisionCfg``.
 - Changed the default MuJoCo Warp render background to solid black
   (``0, 0, 0, 1``), matching MuJoCo's native renderer. Contribution by
   @bd-pmorais.

--- a/docs/source/entity/index.rst
+++ b/docs/source/entity/index.rst
@@ -182,7 +182,8 @@ modify the ``MjSpec`` before compilation:
    * - Field
      - Purpose
    * - ``collisions``
-     - Set contact parameters (contype, conaffinity, friction) per geom.
+     - Replace the entity's collision structure: which geoms collide, and
+       with what contact parameters.
    * - ``lights``
      - Add lights to specific bodies.
    * - ``cameras``
@@ -192,12 +193,24 @@ modify the ``MjSpec`` before compilation:
    * - ``materials``
      - Add materials and optionally assign them to geoms by regex.
    * - ``geoms``
-     - Edit attributes of existing geoms, such as the visualization group.
+     - Patch attributes of existing geoms (visualization group, collision
+       attributes). Unset attributes are left untouched.
 
 Each editor accepts regex patterns to target specific elements. For
 example, a ``CollisionCfg`` with ``geom_names_expr=(".*_foot.*",)``
 sets contact parameters only on foot geoms. See the asset zoo
 (``mjlab.asset_zoo.robots``) for complete examples.
+
+``geoms`` and ``collisions`` both write geom attributes but with
+different semantics. A ``GeomCfg`` is a sparse *patch*: every attribute
+defaults to ``None``, and only attributes you set are written. A
+``CollisionCfg`` is a *policy*: ``contype``, ``conaffinity``,
+``condim``, and ``priority`` are required and always written to every
+matched geom, and non-matched geoms have collision disabled by default,
+so the entity's contact behavior is fully determined by the config
+regardless of the source XML. Collision configs are applied after geom
+configs; mjlab warns if a ``GeomCfg`` sets a collision attribute that a
+``CollisionCfg`` then overwrites.
 
 Heterogeneous worlds
 ^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/randomization.rst
+++ b/docs/source/randomization.rst
@@ -1075,9 +1075,11 @@ Friction (reset)
 
     robot_collision = CollisionCfg(
         geom_names_expr=[".*_foot.*"],
+        contype=1,
+        conaffinity=1,
+        condim=3,
         priority=1,
         friction=(0.6,),
-        condim=3,
     )
 
 

--- a/src/mjlab/asset_zoo/robots/i2rt_yam/yam_constants.py
+++ b/src/mjlab/asset_zoo/robots/i2rt_yam/yam_constants.py
@@ -150,6 +150,8 @@ HOME_KEYFRAME = EntityCfg.InitialStateCfg(
 
 FULL_COLLISION = CollisionCfg(
   geom_names_expr=(".*_collision",),
+  contype=1,
+  conaffinity=1,
   condim={
     "[lr]f_down(6|7|8|9|10|11)_collision": 6,
     ".*_collision": 3,
@@ -163,6 +165,7 @@ FULL_COLLISION = CollisionCfg(
   },
   priority={
     "[lr]f_down(6|7|8|9|10|11)_collision": 1,
+    ".*": 0,
   },
 )
 
@@ -189,6 +192,7 @@ GRIPPER_ONLY_COLLISION = CollisionCfg(
   },
   priority={
     "[lr]f_down(6|7|8|9|10|11)_collision": 1,
+    ".*": 0,
   },
 )
 

--- a/src/mjlab/asset_zoo/robots/unitree_g1/g1_constants.py
+++ b/src/mjlab/asset_zoo/robots/unitree_g1/g1_constants.py
@@ -219,8 +219,10 @@ KNEES_BENT_KEYFRAME = EntityCfg.InitialStateCfg(
 # are given condim=3.
 FULL_COLLISION = CollisionCfg(
   geom_names_expr=(".*_collision",),
+  contype=1,
+  conaffinity=1,
   condim={r"^(left|right)_foot[1-7]_collision$": 3, ".*_collision": 1},
-  priority={r"^(left|right)_foot[1-7]_collision$": 1},
+  priority={r"^(left|right)_foot[1-7]_collision$": 1, ".*": 0},
   friction={r"^(left|right)_foot[1-7]_collision$": (0.6,)},
 )
 
@@ -229,7 +231,7 @@ FULL_COLLISION_WITHOUT_SELF = CollisionCfg(
   contype=0,
   conaffinity=1,
   condim={r"^(left|right)_foot[1-7]_collision$": 3, ".*_collision": 1},
-  priority={r"^(left|right)_foot[1-7]_collision$": 1},
+  priority={r"^(left|right)_foot[1-7]_collision$": 1, ".*": 0},
   friction={r"^(left|right)_foot[1-7]_collision$": (0.6,)},
 )
 

--- a/src/mjlab/asset_zoo/robots/unitree_go1/go1_constants.py
+++ b/src/mjlab/asset_zoo/robots/unitree_go1/go1_constants.py
@@ -110,11 +110,13 @@ FEET_ONLY_COLLISION = CollisionCfg(
 # Foot collisions are given custom condim, friction.
 FULL_COLLISION = CollisionCfg(
   geom_names_expr=(".*_collision",),
+  contype=1,
+  conaffinity=1,
   # Harden all collision geoms.
   solref=(0.01, 1),
   # Configure feet colliders. Other colliders are frictionless (condim=1).
   condim={_foot_regex: 6, ".*_collision": 1},
-  priority={_foot_regex: 1},
+  priority={_foot_regex: 1, ".*": 0},
   friction={_foot_regex: (1, 5e-3, 5e-4)},
 )
 

--- a/src/mjlab/entity/entity.py
+++ b/src/mjlab/entity/entity.py
@@ -188,6 +188,9 @@ class Entity:
       self._non_free_joints = tuple(self._all_joints[1:])
 
   def _apply_spec_editors(self) -> None:
+    spec_cfg.warn_overlapping_geom_edits(
+      self.cfg.geoms, self.cfg.collisions, self._spec
+    )
     for cfg_list in [
       self.cfg.lights,
       self.cfg.cameras,

--- a/src/mjlab/utils/spec.py
+++ b/src/mjlab/utils/spec.py
@@ -220,12 +220,6 @@ def get_free_joint(spec: mujoco.MjSpec) -> mujoco.MjsJoint | None:
   return joint
 
 
-def disable_collision(geom: mujoco.MjsGeom) -> None:
-  """Disables collision for a geom."""
-  geom.contype = 0
-  geom.conaffinity = 0
-
-
 def is_joint_limited(jnt: mujoco.MjsJoint) -> bool:
   """Returns True if a joint is limited."""
   match jnt.limited:

--- a/src/mjlab/utils/spec_config.py
+++ b/src/mjlab/utils/spec_config.py
@@ -79,8 +79,9 @@ def _set_geom_attr(geom: mujoco.MjsGeom, name: str, value) -> None:
 def _matched_geoms(spec: mujoco.MjSpec, exprs: tuple[str, ...]) -> list[mujoco.MjsGeom]:
   """Return geom objects whose names match any expression.
 
-  Matching is by object rather than name lookup so that unnamed geoms (which
-  all share the empty-string name) are handled correctly.
+  Filters the geom objects by name membership instead of looking names up via
+  ``spec.geom(name)``, so unnamed geoms (which all share the empty-string name)
+  are handled correctly. Geoms sharing a name are matched as a group.
   """
   all_geoms: list[mujoco.MjsGeom] = spec.geoms
   matched = set(filter_exp(exprs, tuple(g.name for g in all_geoms)))
@@ -209,9 +210,9 @@ class MaterialCfg(SpecCfg):
 class MeshCfg(SpecCfg):
   """Configuration to edit attributes of existing mesh assets in the MuJoCo spec.
 
-  Unlike collision properties such as contype, condim, and friction, which live on
-  geoms and are tuned via CollisionCfg, the attributes here belong to the mesh asset
-  itself. A mesh asset is a shared resource: one asset may be referenced by many
+  Unlike geom attributes, which are edited per geom via GeomCfg and CollisionCfg,
+  the attributes here belong to the mesh asset itself. A mesh asset is a shared
+  resource: one asset may be referenced by many
   mesh geoms across different bodies, and there is a single convex hull per asset.
   Attributes are therefore matched by mesh-asset name, not geom name.
 

--- a/src/mjlab/utils/spec_config.py
+++ b/src/mjlab/utils/spec_config.py
@@ -1,6 +1,7 @@
+import warnings
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Literal
+from typing import Any, Literal, Sequence
 
 import mujoco
 
@@ -24,18 +25,67 @@ _MARK_MAP = {
   "none": mujoco.mjtMark.mjMARK_NONE,
 }
 
-_GEOM_ATTR_DEFAULTS = {
-  "condim": 3,
-  "contype": 1,
-  "conaffinity": 1,
-  "priority": 0,
-  "friction": None,
-  "solref": None,
-  "solimp": None,
-  "margin": None,
-  "gap": None,
-  "solmix": None,
-}
+# Geom attributes that define the discrete contact structure: which pairs
+# collide and what contact type they produce. CollisionCfg always writes these.
+_GEOM_STRUCTURAL_FIELDS = ("contype", "conaffinity", "condim", "priority")
+# Continuous contact parameters; None inherits the compiled XML value.
+_GEOM_TUNING_FIELDS = ("friction", "solref", "solimp", "margin", "gap", "solmix")
+_GEOM_COLLISION_FIELDS = _GEOM_STRUCTURAL_FIELDS + _GEOM_TUNING_FIELDS
+# Fields written element-wise into a fixed-size MuJoCo array.
+_GEOM_ARRAY_FIELDS = ("friction", "solref", "solimp")
+
+_VALID_CONDIM = (1, 3, 4, 6)
+
+
+def _field_items(value) -> list[tuple[str | None, Any]]:
+  """Normalize a scalar-or-dict field to (pattern, value) pairs."""
+  if isinstance(value, dict):
+    return list(value.items())
+  return [(None, value)]
+
+
+def _validate_geom_attr(name: str, value) -> None:
+  """Validate a scalar-or-dict geom attribute. None values are skipped."""
+  for pattern, v in _field_items(value):
+    if v is None or name in _GEOM_ARRAY_FIELDS:
+      continue
+    where = f" for pattern '{pattern}'" if pattern is not None else ""
+    if name == "condim":
+      if v not in _VALID_CONDIM:
+        raise ValueError(f"condim must be one of {set(_VALID_CONDIM)}, got {v}{where}")
+    elif name == "group":
+      if not 0 <= v < mujoco.mjNGROUP:
+        raise ValueError(f"group must be in [0, {mujoco.mjNGROUP}), got {v}{where}")
+    elif name in ("contype", "conaffinity", "priority", "margin", "gap"):
+      if v < 0:
+        raise ValueError(f"{name} must be non-negative, got {v}{where}")
+    elif name == "solmix":
+      if not 0 <= v <= 1:
+        raise ValueError(f"solmix must be in [0, 1], got {v}{where}")
+
+
+def _set_geom_attr(geom: mujoco.MjsGeom, name: str, value) -> None:
+  """Write a single geom attribute; None is a no-op."""
+  if value is None:
+    return
+  if name in _GEOM_ARRAY_FIELDS:
+    field = getattr(geom, name)
+    for i, v in enumerate(value):
+      field[i] = v
+  else:
+    setattr(geom, name, value)
+
+
+def _matched_geoms(spec: mujoco.MjSpec, exprs: tuple[str, ...]) -> list[mujoco.MjsGeom]:
+  """Return geom objects whose names match any expression.
+
+  Matching is by object rather than name lookup so that unnamed geoms (which
+  all share the empty-string name) are handled correctly.
+  """
+  all_geoms: list[mujoco.MjsGeom] = spec.geoms
+  matched = set(filter_exp(exprs, tuple(g.name for g in all_geoms)))
+  return [g for g in all_geoms if g.name in matched]
+
 
 _LIGHT_TYPE_MAP = {
   "directional": mujoco.mjtLightType.mjLIGHT_DIRECTIONAL,
@@ -206,13 +256,23 @@ class MeshCfg(SpecCfg):
 
 @dataclass
 class GeomCfg(SpecCfg):
-  """Configuration to edit attributes of existing geoms in the MuJoCo spec.
+  """Sparse patch on attributes of existing geoms in the MuJoCo spec.
 
   Geoms are matched by regex against their names; unnamed geoms match the empty
-  string. Collision attributes also live on geoms but are tuned via CollisionCfg.
+  string. Every attribute defaults to None, and only attributes set to a
+  non-None value are applied; everything else is left at whatever the source
+  XML compiled to.
 
-  Only attributes set to a non-None value are applied; everything else is left at
-  whatever the source XML compiled to.
+  This is the single low-level editor for geom attributes. CollisionCfg is a
+  higher-level policy built on the same machinery that *replaces* an entity's
+  collision structure instead of patching it; prefer CollisionCfg for defining
+  which geoms collide, and GeomCfg for targeted tweaks. Within an EntityCfg,
+  CollisionCfg is applied after GeomCfg and overwrites any collision
+  attributes it also touches.
+
+  All attributes may be a single value applied to all matched geoms, or a dict
+  mapping regex patterns to per-geom values (first matching pattern wins;
+  geoms matching no pattern are left untouched).
   """
 
   geom_names_expr: tuple[str, ...]
@@ -222,56 +282,76 @@ class GeomCfg(SpecCfg):
   0-2 by default, so moving a geom to group 3-5 keeps it colliding while hiding
   it from rendering. Must be in [0, mjNGROUP): MuJoCo does not range-check the
   group, and out-of-range values are clamped into range by raycasting but
-  dropped by the warp renderer. May be a single value applied to all matched
-  geoms, or a dict mapping regex patterns to per-geom values."""
+  dropped by the warp renderer."""
+  contype: int | dict[str, int] | None = None
+  """Collision type bitmask. Must be non-negative."""
+  conaffinity: int | dict[str, int] | None = None
+  """Collision affinity bitmask. Must be non-negative."""
+  condim: int | dict[str, int] | None = None
+  """Contact dimension. Must be one of {1, 3, 4, 6}."""
+  priority: int | dict[str, int] | None = None
+  """Collision priority. Must be non-negative."""
+  friction: tuple[float, ...] | dict[str, tuple[float, ...]] | None = None
+  """Friction coefficients (sliding, torsional, rolling)."""
+  solref: tuple[float, ...] | dict[str, tuple[float, ...]] | None = None
+  """Solver reference parameters."""
+  solimp: tuple[float, ...] | dict[str, tuple[float, ...]] | None = None
+  """Solver impedance parameters."""
+  margin: float | dict[str, float] | None = None
+  """Detection margin. Contacts are generated when geom distance < margin."""
+  gap: float | dict[str, float] | None = None
+  """Gap for solver inclusion. Contact included when dist < margin - gap."""
+  solmix: float | dict[str, float] | None = None
+  """Mixing weight for blending solver parameters between geom pairs."""
+
+  _PATCH_FIELDS = ("group",) + _GEOM_COLLISION_FIELDS
 
   def edit_spec(self, spec: mujoco.MjSpec) -> None:
     self.validate()
 
-    all_geoms: list[mujoco.MjsGeom] = spec.geoms
-    all_geom_names = tuple(g.name for g in all_geoms)
-    matched_names = set(filter_exp(self.geom_names_expr, all_geom_names))
-    geom_subset = [g for g in all_geoms if g.name in matched_names]
-
-    group = resolve_field(self.group, tuple(g.name for g in geom_subset))
-    for geom, value in zip(geom_subset, group, strict=True):
-      if value is not None:
-        geom.group = value
+    geom_subset = _matched_geoms(spec, self.geom_names_expr)
+    subset_names = tuple(g.name for g in geom_subset)
+    for field_name in self._PATCH_FIELDS:
+      values = resolve_field(getattr(self, field_name), subset_names)
+      for geom, value in zip(geom_subset, values, strict=True):
+        _set_geom_attr(geom, field_name, value)
 
   def validate(self) -> None:
-    if isinstance(self.group, dict):
-      items = list(self.group.items())
-    else:
-      items = [(None, self.group)]
-    for pattern, value in items:
-      if value is None:
-        continue
-      if not 0 <= value < mujoco.mjNGROUP:
-        where = f" for pattern '{pattern}'" if pattern is not None else ""
-        raise ValueError(f"group must be in [0, {mujoco.mjNGROUP}), got {value}{where}")
+    for field_name in self._PATCH_FIELDS:
+      _validate_geom_attr(field_name, getattr(self, field_name))
 
 
 @dataclass
 class CollisionCfg(SpecCfg):
-  """Configuration to modify collision properties of geoms in the MuJoCo spec.
+  """Collision policy for the geoms in a MuJoCo spec.
 
-  Supports regex pattern matching for geom names and dict-based field resolution
-  for fine-grained control over collision properties.
+  Unlike GeomCfg, which patches only the attributes you set, this config
+  *replaces* the collision structure of every matched geom: ``contype``,
+  ``conaffinity``, ``condim``, and ``priority`` are required and always
+  written, so the contact behavior of matched geoms is fully determined by
+  this config regardless of what the source XML compiled to. When one of
+  these structural fields is a dict, its patterns must cover every matched
+  geom; add a catch-all ``".*"`` entry for the default case.
+
+  Continuous contact parameters (``friction``, ``solref``, ``solimp``,
+  ``margin``, ``gap``, ``solmix``) are optional patches: None inherits the
+  compiled XML value.
+
+  With ``disable_other_geoms=True`` (the default), every geom *not* matched
+  by ``geom_names_expr`` has its contype and conaffinity zeroed, so a single
+  CollisionCfg describes the entire collision story of the spec it edits.
   """
 
   geom_names_expr: tuple[str, ...]
   """Tuple of regex patterns to match geom names."""
-  contype: int | dict[str, int] = 1
-  """Collision type (int or dict mapping patterns to values). Must be non-negative."""
-  conaffinity: int | dict[str, int] = 1
-  """Collision affinity (int or dict mapping patterns to values). Must be
-  non-negative."""
-  condim: int | dict[str, int] = 3
-  """Contact dimension (int or dict mapping patterns to values). Must be one
-  of {1, 3, 4, 6}."""
-  priority: int | dict[str, int] = 0
-  """Collision priority (int or dict mapping patterns to values). Must be
-  non-negative."""
+  contype: int | dict[str, int]
+  """Collision type bitmask. Must be non-negative."""
+  conaffinity: int | dict[str, int]
+  """Collision affinity bitmask. Must be non-negative."""
+  condim: int | dict[str, int]
+  """Contact dimension. Must be one of {1, 3, 4, 6}."""
+  priority: int | dict[str, int]
+  """Collision priority. Must be non-negative."""
   friction: tuple[float, ...] | dict[str, tuple[float, ...]] | None = None
   """Friction coefficients as tuple or dict mapping patterns to tuples."""
   solref: tuple[float, ...] | dict[str, tuple[float, ...]] | None = None
@@ -287,114 +367,95 @@ class CollisionCfg(SpecCfg):
   disable_other_geoms: bool = True
   """Whether to disable collision for non-matching geoms."""
 
-  @staticmethod
-  def set_array_field(field, values):
-    if values is None:
-      return
-    for i, v in enumerate(values):
-      field[i] = v
-
   def validate(self) -> None:
-    """Validate collision configuration parameters."""
-    valid_condim = {1, 3, 4, 6}
-
-    # Validate condim specifically (has special valid values).
-    if isinstance(self.condim, int):
-      if self.condim not in valid_condim:
-        raise ValueError(f"condim must be one of {valid_condim}, got {self.condim}")
-    elif isinstance(self.condim, dict):
-      for pattern, value in self.condim.items():
-        if value not in valid_condim:
-          raise ValueError(
-            f"condim must be one of {valid_condim}, got {value} for pattern '{pattern}'"
-          )
-
-    # Validate other int parameters.
-    if isinstance(self.contype, int) and self.contype < 0:
-      raise ValueError("contype must be non-negative")
-    if isinstance(self.conaffinity, int) and self.conaffinity < 0:
-      raise ValueError("conaffinity must be non-negative")
-    if isinstance(self.priority, int) and self.priority < 0:
-      raise ValueError("priority must be non-negative")
-
-    # Validate dict parameters (excluding condim which is handled above).
-    for field_name in ["contype", "conaffinity", "priority"]:
-      field_value = getattr(self, field_name)
-      if isinstance(field_value, dict):
-        for pattern, value in field_value.items():
-          if value < 0:
-            raise ValueError(
-              f"{field_name} must be non-negative, got {value} for pattern '{pattern}'"
-            )
-
-    # Validate margin (non-negative).
-    if isinstance(self.margin, (int, float)) and self.margin < 0:
-      raise ValueError("margin must be non-negative")
-    if isinstance(self.margin, dict):
-      for pattern, value in self.margin.items():
-        if value < 0:
-          raise ValueError(
-            f"margin must be non-negative, got {value} for pattern '{pattern}'"
-          )
-
-    # Validate gap (non-negative).
-    if isinstance(self.gap, (int, float)) and self.gap < 0:
-      raise ValueError("gap must be non-negative")
-    if isinstance(self.gap, dict):
-      for pattern, value in self.gap.items():
-        if value < 0:
-          raise ValueError(
-            f"gap must be non-negative, got {value} for pattern '{pattern}'"
-          )
-
-    # Validate solmix (must be in [0, 1]).
-    if isinstance(self.solmix, (int, float)) and not (0 <= self.solmix <= 1):
-      raise ValueError("solmix must be in [0, 1]")
-    if isinstance(self.solmix, dict):
-      for pattern, value in self.solmix.items():
-        if not (0 <= value <= 1):
-          raise ValueError(
-            f"solmix must be in [0, 1], got {value} for pattern '{pattern}'"
-          )
+    for field_name in _GEOM_STRUCTURAL_FIELDS:
+      if getattr(self, field_name) is None:
+        raise ValueError(
+          f"{field_name} is required: CollisionCfg fully determines the "
+          "collision structure of matched geoms and cannot leave it to the "
+          "source XML. Use GeomCfg for sparse patches."
+        )
+    for field_name in _GEOM_COLLISION_FIELDS:
+      _validate_geom_attr(field_name, getattr(self, field_name))
 
   def edit_spec(self, spec: mujoco.MjSpec) -> None:
-    from mjlab.utils.spec import disable_collision
-
     self.validate()
 
     all_geoms: list[mujoco.MjsGeom] = spec.geoms
-    all_geom_names = tuple(g.name for g in all_geoms)
-    geom_subset = filter_exp(self.geom_names_expr, all_geom_names)
+    matched = set(filter_exp(self.geom_names_expr, tuple(g.name for g in all_geoms)))
+    geom_subset = [g for g in all_geoms if g.name in matched]
+    subset_names = tuple(g.name for g in geom_subset)
 
-    resolved_fields = {
-      name: resolve_field(getattr(self, name), geom_subset, default)
-      for name, default in _GEOM_ATTR_DEFAULTS.items()
-    }
-
-    for i, geom_name in enumerate(geom_subset):
-      geom = spec.geom(geom_name)
-
-      geom.condim = resolved_fields["condim"][i]
-      geom.contype = resolved_fields["contype"][i]
-      geom.conaffinity = resolved_fields["conaffinity"][i]
-      geom.priority = resolved_fields["priority"][i]
-
-      CollisionCfg.set_array_field(geom.friction, resolved_fields["friction"][i])
-      CollisionCfg.set_array_field(geom.solref, resolved_fields["solref"][i])
-      CollisionCfg.set_array_field(geom.solimp, resolved_fields["solimp"][i])
-
-      if resolved_fields["margin"][i] is not None:
-        geom.margin = resolved_fields["margin"][i]
-      if resolved_fields["gap"][i] is not None:
-        geom.gap = resolved_fields["gap"][i]
-      if resolved_fields["solmix"][i] is not None:
-        geom.solmix = resolved_fields["solmix"][i]
+    for field_name in _GEOM_COLLISION_FIELDS:
+      values = resolve_field(getattr(self, field_name), subset_names)
+      structural = field_name in _GEOM_STRUCTURAL_FIELDS
+      for geom, value in zip(geom_subset, values, strict=True):
+        if structural and value is None:
+          raise ValueError(
+            f"{field_name} dict does not match geom '{geom.name}'. Structural "
+            "collision fields must cover every matched geom; add a catch-all "
+            "'.*' entry for the default case."
+          )
+        _set_geom_attr(geom, field_name, value)
 
     if self.disable_other_geoms:
-      other_geoms = set(all_geom_names).difference(geom_subset)
-      for geom_name in other_geoms:
-        geom = spec.geom(geom_name)
-        disable_collision(geom)
+      for geom in all_geoms:
+        if geom.name not in matched:
+          geom.contype = 0
+          geom.conaffinity = 0
+
+
+def warn_overlapping_geom_edits(
+  geom_cfgs: Sequence[GeomCfg],
+  collision_cfgs: Sequence[CollisionCfg],
+  spec: mujoco.MjSpec,
+) -> None:
+  """Warn when GeomCfg collision patches would be overwritten by a CollisionCfg.
+
+  Within an EntityCfg, collision configs are applied after geom configs, so any
+  collision attribute both of them write on the same geom ends up with the
+  CollisionCfg value. This lint makes that silent last-writer-wins visible.
+  """
+  if not geom_cfgs or not collision_cfgs:
+    return
+
+  all_names = tuple(g.name for g in spec.geoms)
+
+  # (geom name, field) pairs each CollisionCfg will write.
+  policy_writes: set[tuple[str, str]] = set()
+  for ccfg in collision_cfgs:
+    matched = set(filter_exp(ccfg.geom_names_expr, all_names))
+    subset = tuple(sorted(matched))
+    for field_name in _GEOM_COLLISION_FIELDS:
+      values = resolve_field(getattr(ccfg, field_name), subset)
+      structural = field_name in _GEOM_STRUCTURAL_FIELDS
+      for name, value in zip(subset, values, strict=True):
+        if structural or value is not None:
+          policy_writes.add((name, field_name))
+    if ccfg.disable_other_geoms:
+      for name in set(all_names) - matched:
+        policy_writes.add((name, "contype"))
+        policy_writes.add((name, "conaffinity"))
+
+  clobbered: set[str] = set()
+  for gcfg in geom_cfgs:
+    matched = set(filter_exp(gcfg.geom_names_expr, all_names))
+    subset = tuple(sorted(matched))
+    for field_name in _GEOM_COLLISION_FIELDS:
+      values = resolve_field(getattr(gcfg, field_name), subset)
+      for name, value in zip(subset, values, strict=True):
+        if value is not None and (name, field_name) in policy_writes:
+          clobbered.add(f"{name}.{field_name}")
+
+  if clobbered:
+    shown = ", ".join(sorted(clobbered)[:8])
+    more = f" (and {len(clobbered) - 8} more)" if len(clobbered) > 8 else ""
+    warnings.warn(
+      f"GeomCfg sets collision attributes that a CollisionCfg (applied "
+      f"after) overwrites: {shown}{more}. Set these through CollisionCfg "
+      "instead.",
+      stacklevel=3,
+    )
 
 
 @dataclass

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -12,7 +12,7 @@ from mjlab.actuator import BuiltinPositionActuatorCfg, XmlActuatorCfg
 from mjlab.entity import Entity, EntityArticulationInfoCfg, EntityCfg
 from mjlab.scene import Scene, SceneCfg
 from mjlab.sim.sim import Simulation, SimulationCfg
-from mjlab.utils.spec_config import GeomCfg
+from mjlab.utils.spec_config import CollisionCfg, GeomCfg
 
 FIXED_BASE_XML = """
 <mujoco>
@@ -276,6 +276,21 @@ def test_geom_editor_applied():
   assert entity.spec.geom("link1_geom").group == 3
   assert entity.spec.geom("link2_geom").group == 3
   assert entity.spec.geom("base_geom").group == 0
+
+
+def test_geom_collision_overlap_warns():
+  """A GeomCfg collision patch clobbered by a CollisionCfg triggers a warning."""
+  cfg = EntityCfg(
+    spec_fn=lambda: mujoco.MjSpec.from_string(FIXED_BASE_ARTICULATED_XML),
+    geoms=(GeomCfg(geom_names_expr=("link1_geom",), condim=6),),
+    collisions=(
+      CollisionCfg(
+        geom_names_expr=("link.*_geom",), contype=1, conaffinity=1, condim=3, priority=0
+      ),
+    ),
+  )
+  with pytest.warns(UserWarning, match="link1_geom.condim"):
+    Entity(cfg)
 
 
 def test_find_methods():

--- a/tests/test_spec_config.py
+++ b/tests/test_spec_config.py
@@ -1,6 +1,7 @@
 """Tests for spec_config.py."""
 
 import math
+from typing import cast
 
 import mujoco
 import pytest
@@ -77,6 +78,8 @@ def test_collision_regex_matching(multi_geom_spec):
   """CollisionCfg should support regex pattern matching."""
   collision_cfg = CollisionCfg(
     geom_names_expr=(r"^(left|right)_foot\d_collision$",),
+    contype=1,
+    conaffinity=1,
     condim=3,
     priority=1,
     friction=(0.6,),
@@ -100,6 +103,8 @@ def test_collision_dict_field_resolution(multi_geom_spec):
   """CollisionCfg should support dict-based field resolution."""
   collision_cfg = CollisionCfg(
     geom_names_expr=(r".*_foot\d_collision$", "arm_collision"),
+    contype=1,
+    conaffinity=1,
     condim={r".*_foot\d_collision$": 3, "arm_collision": 1},
     priority={r".*_foot\d_collision$": 2, "arm_collision": 0},
   )
@@ -118,6 +123,10 @@ def test_collision_margin_gap_solmix(multi_geom_spec):
   """CollisionCfg should set margin, gap, and solmix on matched geoms."""
   collision_cfg = CollisionCfg(
     geom_names_expr=("arm_collision",),
+    contype=1,
+    conaffinity=1,
+    condim=3,
+    priority=0,
     margin=0.01,
     gap=0.005,
     solmix=0.5,
@@ -135,6 +144,10 @@ def test_collision_margin_gap_solmix_dict(multi_geom_spec):
   """CollisionCfg should support dict-based margin, gap, solmix overrides."""
   collision_cfg = CollisionCfg(
     geom_names_expr=(r".*_foot\d_collision$", "arm_collision"),
+    contype=1,
+    conaffinity=1,
+    condim=3,
+    priority=0,
     margin={r".*_foot\d_collision$": 0.02, "arm_collision": 0.01},
     gap={r".*_foot\d_collision$": 0.01, "arm_collision": 0.0},
     solmix={r".*_foot\d_collision$": 0.8, "arm_collision": 0.2},
@@ -152,10 +165,41 @@ def test_collision_margin_gap_solmix_dict(multi_geom_spec):
   assert arm.solmix == pytest.approx(0.2)
 
 
+def test_collision_structural_dict_requires_coverage(multi_geom_spec):
+  """Dict-valued structural fields must cover every matched geom."""
+  collision_cfg = CollisionCfg(
+    geom_names_expr=(".*_collision",),
+    contype=1,
+    conaffinity=1,
+    condim={r".*_foot\d_collision$": 3},  # Does not cover arm_collision.
+    priority=0,
+  )
+  with pytest.raises(ValueError, match="condim dict does not match geom"):
+    collision_cfg.edit_spec(multi_geom_spec)
+
+
+def test_collision_structural_fields_are_required():
+  """Structural fields cannot be None."""
+  cfg = CollisionCfg(
+    geom_names_expr=(".*",),
+    contype=1,
+    conaffinity=1,
+    condim=cast(int, None),
+    priority=0,
+  )
+  with pytest.raises(ValueError, match="condim is required"):
+    cfg.validate()
+
+
 def test_collision_disable_other_geoms(multi_geom_spec):
   """CollisionCfg should disable non-matching geoms when requested."""
   collision_cfg = CollisionCfg(
-    geom_names_expr=("left_foot1_collision",), contype=2, disable_other_geoms=True
+    geom_names_expr=("left_foot1_collision",),
+    contype=2,
+    conaffinity=1,
+    condim=3,
+    priority=0,
+    disable_other_geoms=True,
   )
   collision_cfg.edit_spec(multi_geom_spec)
 
@@ -473,3 +517,29 @@ def test_geom_group_validation(value):
   with pytest.raises(ValueError, match="group must be in"):
     cfg = GeomCfg(geom_names_expr=("test",), group=value)
     cfg.validate()
+
+
+def test_geom_patches_collision_attrs(multi_geom_spec):
+  """GeomCfg should patch collision attributes, leaving unset ones alone."""
+  multi_geom_spec.geom("left_foot1_collision").contype = 2
+  GeomCfg(
+    geom_names_expr=(r"^(left|right)_foot\d_collision$",),
+    condim=6,
+    friction=(1.0, 5e-3, 5e-4),
+  ).edit_spec(multi_geom_spec)
+
+  left_foot = multi_geom_spec.geom("left_foot1_collision")
+  assert left_foot.condim == 6
+  assert left_foot.friction[0] == pytest.approx(1.0)
+  assert left_foot.contype == 2  # Unset attribute untouched.
+
+  arm = multi_geom_spec.geom("arm_collision")
+  assert arm.condim == 3  # Unmatched geom untouched.
+
+
+def test_geom_collision_attr_validation():
+  """GeomCfg should validate collision attributes like CollisionCfg does."""
+  with pytest.raises(ValueError, match="condim must be one of"):
+    GeomCfg(geom_names_expr=("test",), condim=2).validate()
+  with pytest.raises(ValueError, match="solmix must be in"):
+    GeomCfg(geom_names_expr=("test",), solmix=1.5).validate()


### PR DESCRIPTION
GeomCfg and CollisionCfg were two disjoint mechanisms for editing the same geom attributes: GeomCfg patched sparsely (None leaves the compiled XML value alone) while CollisionCfg silently reset contype, conaffinity, condim, and priority to hard-coded defaults on every matched geom, which meant matching a geom could clobber values the XML author set deliberately, and the two classes disagreed on unnamed-geom handling.

This change makes GeomCfg the single low-level geom editor, extending it to all collision attributes with patch semantics, and reimplements CollisionCfg as a policy on top of the same write path. The structural fields (contype, conaffinity, condim, priority) are now required, and dict values for them must cover every matched geom, so an entity's collision structure is fully determined by the config instead of falling back to invisible defaults. Entity also warns when a GeomCfg collision patch would be overwritten by a CollisionCfg, which is applied after it.

The tradeoff is a small breaking change: existing CollisionCfg call sites must spell out the four structural fields. The asset zoo configs are migrated in this PR and now read as the complete contact story of each robot.