### PR TITLE
Make go1 collision pattern robust to numbered geom suffixes

### DIFF
--- a/src/mjlab/asset_zoo/robots/unitree_go1/go1_constants.py
+++ b/src/mjlab/asset_zoo/robots/unitree_go1/go1_constants.py
@@ -108,14 +108,19 @@ FEET_ONLY_COLLISION = CollisionCfg(
 
 # This enables all collisions.
 # Foot collisions are given custom condim, friction.
+# The go1 XML numbers its secondary collision capsules (FR_thigh_collision1,
+# RL_calf_collision2, ...), so the pattern allows a trailing index. This keeps
+# the match set identical whether patterns are matched by prefix or in full.
+_collision_regex = r".*_collision\d*"
+
 FULL_COLLISION = CollisionCfg(
-  geom_names_expr=(".*_collision",),
+  geom_names_expr=(_collision_regex,),
   contype=1,
   conaffinity=1,
   # Harden all collision geoms.
   solref=(0.01, 1),
   # Configure feet colliders. Other colliders are frictionless (condim=1).
-  condim={_foot_regex: 6, ".*_collision": 1},
+  condim={_foot_regex: 6, _collision_regex: 1},
   priority={_foot_regex: 1, ".*": 0},
   friction={_foot_regex: (1, 5e-3, 5e-4)},
 )

--- a/tests/test_go1_constants.py
+++ b/tests/test_go1_constants.py
@@ -77,6 +77,25 @@ def test_foot_collision_geoms(go1_model) -> None:
       assert geom.friction[0] == 1.0
 
 
+def test_all_collision_geoms_enabled(go1_model) -> None:
+  """Every *_collision geom, including numbered ones, must stay collidable.
+
+  The go1 XML numbers its secondary collision capsules (FR_thigh_collision1,
+  ...), which a pattern anchored at "_collision" would silently drop, letting
+  disable_other_geoms zero their contype. Guard against that regression with
+  an oracle independent of the config's own regex resolution.
+  """
+  collision_geoms = [
+    go1_model.geom(i)
+    for i in range(go1_model.ngeom)
+    if "_collision" in go1_model.geom(i).name
+  ]
+  assert len(collision_geoms) == 30
+  for geom in collision_geoms:
+    assert geom.contype == 1, f"{geom.name} lost its contype"
+    assert geom.conaffinity == 1, f"{geom.name} lost its conaffinity"
+
+
 def test_collision_geom_count(go1_model) -> None:
   """Go1 should have 4 foot collision geoms."""
   foot_pattern = r"^[FR][LR]_foot_collision$"


### PR DESCRIPTION
Update the Go1 collision regex to explicitly match numbered collision geoms, keeping behavior consistent under prefix and full-match semantics.

Add a regression test that verifies all 30 collision geoms remain enabled.