### PR TITLE
Add reduce option `sum` for metrics

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -123,6 +123,9 @@ Version 1.5.1 (July 15, 2026)
 Added
 ^^^^^
 
+- Added ``reduce="sum"`` to ``MetricsTermCfg`` for reporting the accumulated
+  episode total (e.g. episodic reward, total distance traveled) instead of a
+  per-step average.
 - Added ``MeshCfg``, a spec editor that matches mesh assets by name and edits
   their asset-level attributes. The first attribute is ``maxhullvert``, which
   caps the collision convex hull's vertex count to lower narrowphase cost.

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -27,6 +27,9 @@ Added
 - Added light domain randomization functions: ``dr.light_diffuse``,
   ``dr.light_specular``, ``dr.light_ambient``, ``dr.light_attenuation``,
   ``dr.light_cutoff``, and ``dr.light_exponent``. Contribution by @bd-pmorais.
+- Added ``reduce="sum"`` to ``MetricsTermCfg`` for reporting the accumulated
+  episode total (e.g. episodic reward, total distance traveled) instead of a
+  per-step average. Contribution by @bd-mlutter
 
 Changed
 ^^^^^^^
@@ -123,9 +126,6 @@ Version 1.5.1 (July 15, 2026)
 Added
 ^^^^^
 
-- Added ``reduce="sum"`` to ``MetricsTermCfg`` for reporting the accumulated
-  episode total (e.g. episodic reward, total distance traveled) instead of a
-  per-step average.
 - Added ``MeshCfg``, a spec editor that matches mesh assets by name and edits
   their asset-level attributes. The first attribute is ``maxhullvert``, which
   caps the collision convex hull's vertex count to lower narrowphase cost.

--- a/docs/source/metrics.rst
+++ b/docs/source/metrics.rst
@@ -64,6 +64,13 @@ The reduction is controlled by the ``reduce`` field on ``MetricsTermCfg``:
 - ``"last"``: reports the value from the final step of the episode. This is
   useful for binary success metrics (such as whether the robot is standing)
   that should not be averaged over time.
+- ``"max"``: reports the highest value seen during the episode, useful for
+  peak quantities such as maximum power draw or contact force.
+- ``"sum"``: reports the accumulated total over the episode without dividing
+  by the step count. Use it for quantities that are inherently cumulative,
+  such as episodic reward or total distance traveled. Note that the value
+  grows with episode length, so it is not comparable across episodes of
+  differing duration.
 
 These scalars flow through ``env.extras["log"]`` into the training runner,
 which writes them to the configured logger. In a typical training run they

--- a/src/mjlab/managers/metrics_manager.py
+++ b/src/mjlab/managers/metrics_manager.py
@@ -140,17 +140,10 @@ class MetricsManager(ManagerBase):
       elif reduce == "sum":
         extras["Episode_Metrics/" + key] = torch.mean(self._episode_sums[key][env_ids])
 
-      elif reduce == "mean":
+      else:
         extras["Episode_Metrics/" + key] = torch.mean(
           self._episode_sums[key][env_ids] / safe_counts
         )
-
-      else:
-        msg = (
-          f"The reduce method '{reduce}' for metric '{key}' is unknown. "
-          f"Valid options are {REDUCE_OPTIONS}."
-        )
-        raise ValueError(msg)
 
       self._episode_sums[key][env_ids] = 0.0
     self._step_count[env_ids] = 0

--- a/src/mjlab/managers/metrics_manager.py
+++ b/src/mjlab/managers/metrics_manager.py
@@ -14,26 +14,33 @@ from mjlab.managers.manager_base import ManagerBase, ManagerTermBaseCfg
 if TYPE_CHECKING:
   from mjlab.envs.manager_based_rl_env import ManagerBasedRlEnv
 
+REDUCE_OPTIONS = ("last", "max", "mean", "sum")
+
 
 @dataclass(kw_only=True)
 class MetricsTermCfg(ManagerTermBaseCfg):
   """Configuration for a metrics term.
 
   Attributes:
-    per_substep: If True, evaluate this term once per physics substep inside the
-    decimation loop and report the per-step mean. Only the integrated state
-    (qpos, qvel, act) is current mid-loop; all derived quantities (xpos, xquat,
-    site_xpos, actuator_force, contacts, ...) are stale.
+    per_substep: If True, evaluate this term once per physics substep inside
+      the decimation loop and report the per-step mean. Only the integrated
+      state (qpos, qvel, act) is current mid-loop; all derived quantities
+      (xpos, xquat, site_xpos, actuator_force, contacts, ...) are stale.
+
     reduce: How to aggregate per-step values into an episode metric.
-    ``"mean"`` (default) reports ``sum / step_count``. ``"last"`` reports
-    the value from the final step of the episode, which is useful for binary
-    success metrics that should not be averaged over timesteps. ``"max"``
-    reports the highest value seen during the episode, useful for peak
-    metrics like maximum power or contact force.
+      - ``"mean"`` (default) reports ``sum / step_count``.
+      - ``"last"`` reports the value from the final step of the episode,
+        useful for binary success metrics that should not be averaged over
+        timesteps.
+      - ``"max"`` reports the highest value seen during the episode, useful
+        for peak metrics like maximum power or contact force.
+      - ``"sum"`` reports the accumulated total over the episode, useful for
+        cumulative quantities like episodic reward or total distance
+        traveled.
   """
 
   per_substep: bool = False
-  reduce: Literal["mean", "last", "max"] = "mean"
+  reduce: Literal["last", "max", "mean", "sum"] = "mean"
 
 
 class MetricsManager(ManagerBase):
@@ -60,9 +67,17 @@ class MetricsManager(ManagerBase):
     self._episode_sums: dict[str, torch.Tensor] = {}
     self._episode_max: dict[str, torch.Tensor] = {}
     for idx, term_name in enumerate(self._term_names):
+      if self._term_cfgs[idx].reduce not in REDUCE_OPTIONS:
+        msg = (
+          f"The reduce method '{self._term_cfgs[idx].reduce}' for metric '{term_name}' "
+          f"is unknown. Valid options are {REDUCE_OPTIONS}."
+        )
+        raise ValueError(msg)
+
       self._episode_sums[term_name] = torch.zeros(
         self.num_envs, dtype=torch.float, device=self.device
       )
+
       if self._term_cfgs[idx].reduce == "max":
         self._episode_max[term_name] = torch.full(
           (self.num_envs,), float("-inf"), dtype=torch.float, device=self.device
@@ -118,18 +133,34 @@ class MetricsManager(ManagerBase):
       if reduce == "max":
         extras["Episode_Metrics/" + key] = torch.mean(self._episode_max[key][env_ids])
         self._episode_max[key][env_ids] = float("-inf")
+
       elif reduce == "last":
         extras["Episode_Metrics/" + key] = torch.mean(self._step_values[env_ids, idx])
-      else:
+
+      elif reduce == "sum":
+        extras["Episode_Metrics/" + key] = torch.mean(self._episode_sums[key][env_ids])
+
+      elif reduce == "mean":
         extras["Episode_Metrics/" + key] = torch.mean(
           self._episode_sums[key][env_ids] / safe_counts
         )
+
+      else:
+        msg = (
+          f"The reduce method '{reduce}' for metric '{key}' is unknown. "
+          f"Valid options are {REDUCE_OPTIONS}."
+        )
+        raise ValueError(msg)
+
       self._episode_sums[key][env_ids] = 0.0
     self._step_count[env_ids] = 0
+
     for buf in self._substep_accum:
       buf[env_ids] = 0.0
+
     for term_cfg in self._class_term_cfgs:
       term_cfg.func.reset(env_ids=env_ids)
+
     return extras
 
   def compute_substep(self) -> None:


### PR DESCRIPTION
## Changelog
* Add `sum` as additional reduce option for `metrics`. This is beneficial for metrics that accumulate over time, e.g., traveled distance or energy.

* Raise `ValueError` if `reduce` is not in the `REDUCE_OPTIONS`. Raising the error avoids silently using `mean` when `reduce` contains a typo or similar. 

## Testing
- [x]  `make format`
- [x] `make test`