### PR TITLE
Add fields for loading textures from files

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -24,6 +24,11 @@ Added
 - Added ``diffuse``, ``specular``, ``ambient``, ``active``, and
   ``attenuation`` fields to ``LightCfg`` for configuring light color and
   falloff. Contribution by @bd-pmorais.
+- Added ``random``, ``file``, ``cubefiles``, ``gridsize``, ``gridlayout``,
+  ``nchannel``, ``hflip``, and ``vflip`` fields to ``TextureCfg``, so textures
+  can be loaded from image files instead of only built-in patterns.
+  ``width`` and ``height`` are now optional, since file-based textures take
+  their size from the image. Contribution by @bd-pmorais.
 - Added light domain randomization functions: ``dr.light_diffuse``,
   ``dr.light_specular``, ``dr.light_ambient``, ``dr.light_attenuation``,
   ``dr.light_cutoff``, and ``dr.light_exponent``. Contribution by @bd-pmorais.

--- a/src/mjlab/utils/spec_config.py
+++ b/src/mjlab/utils/spec_config.py
@@ -123,20 +123,36 @@ class TextureCfg(SpecCfg):
   """Name of the texture."""
   type: Literal["2d", "cube", "skybox"]
   """Texture type ("2d", "cube", or "skybox")."""
-  builtin: Literal["checker", "gradient", "flat", "none"]
+  builtin: Literal["checker", "gradient", "flat", "none"] = "none"
   """Built-in texture pattern ("checker", "gradient", "flat", or "none")."""
-  rgb1: tuple[float, float, float]
+  rgb1: tuple[float, float, float] | None = None
   """First RGB color tuple."""
-  rgb2: tuple[float, float, float]
+  rgb2: tuple[float, float, float] | None = None
   """Second RGB color tuple."""
-  width: int
-  """Texture width in pixels (must be positive)."""
-  height: int
-  """Texture height in pixels (must be positive)."""
+  width: int | None = None
+  """Texture width in pixels."""
+  height: int | None = None
+  """Texture height in pixels."""
   mark: Literal["edge", "cross", "random", "none"] = "none"
   """Marking pattern ("edge", "cross", "random", or "none")."""
   markrgb: tuple[float, float, float] = (0.0, 0.0, 0.0)
   """RGB color for markings."""
+  random: float = 0.01
+  """Fraction of marked pixels when mark is "random"."""
+  file: str | None = None
+  """Path to an image file to load the texture from."""
+  cubefiles: tuple[str, ...] | None = None
+  """Paths to the six face images of a cube or skybox texture."""
+  gridsize: tuple[int, int] | None = None
+  """Rows and columns of the face grid in the file. Cube and skybox only."""
+  gridlayout: str | None = None
+  """Twelve-character face layout of the grid in the file. Cube and skybox only."""
+  nchannel: int = 3
+  """Number of channels in the texture."""
+  hflip: bool = False
+  """Whether to flip the loaded image horizontally."""
+  vflip: bool = False
+  """Whether to flip the loaded image vertically."""
 
   def edit_spec(self, spec: mujoco.MjSpec) -> None:
     self.validate()
@@ -149,13 +165,34 @@ class TextureCfg(SpecCfg):
       rgb1=self.rgb1,
       rgb2=self.rgb2,
       markrgb=self.markrgb,
+      random=self.random,
       width=self.width,
       height=self.height,
+      nchannel=self.nchannel,
+      file=self.file,
+      cubefiles=self.cubefiles,
+      gridsize=self.gridsize,
+      gridlayout=self.gridlayout,
+      hflip=self.hflip,
+      vflip=self.vflip,
     )
 
   def validate(self) -> None:
-    if self.width <= 0 or self.height <= 0:
-      raise ValueError("Texture width and height must be positive.")
+    if self.width is not None and self.width <= 0:
+      raise ValueError("Texture width must be positive.")
+    if self.height is not None and self.height <= 0:
+      raise ValueError("Texture height must be positive.")
+    # A 1x1 grid compiles to a single image, but the Warp renderer samples skyboxes
+    # as six faces stacked vertically. Any larger grid compiles to those six faces.
+    if (
+      self.type == "skybox"
+      and self.file is not None
+      and (self.gridsize is None or tuple(self.gridsize) == (1, 1))
+    ):
+      raise ValueError(
+        "A skybox loaded from a single file must declare a gridsize larger than "
+        "1x1, or be specified via cubefiles."
+      )
 
 
 @dataclass

--- a/src/mjlab/utils/spec_config.py
+++ b/src/mjlab/utils/spec_config.py
@@ -182,10 +182,14 @@ class TextureCfg(SpecCfg):
       raise ValueError("Texture width must be positive.")
     if self.height is not None and self.height <= 0:
       raise ValueError("Texture height must be positive.")
+    if self.builtin == "none" and self.file is None and self.cubefiles is None:
+      raise ValueError("Texture must specify a builtin pattern, a file, or cubefiles.")
     # A 1x1 grid compiles to a single image, but the Warp renderer samples skyboxes
     # as six faces stacked vertically. Any larger grid compiles to those six faces.
+    # A builtin pattern takes precedence over the file and always fills six faces.
     if (
       self.type == "skybox"
+      and self.builtin == "none"
       and self.file is not None
       and (self.gridsize is None or tuple(self.gridsize) == (1, 1))
     ):

--- a/tests/test_spec_config.py
+++ b/tests/test_spec_config.py
@@ -408,9 +408,16 @@ def test_texture_cfg_validation(param, value, expected_error):
     TextureCfg(
       name="test_texture",
       type="2d",
+      builtin="checker",
       width=value if param == "width" else 64,
       height=value if param == "height" else 64,
     ).validate()
+
+
+def test_texture_requires_source():
+  """A texture with no builtin, file, or cubefiles has nothing to render."""
+  with pytest.raises(ValueError, match="must specify a builtin pattern"):
+    TextureCfg(name="test_texture", type="2d").validate()
 
 
 @pytest.mark.parametrize("gridsize", [None, (1, 1)])
@@ -427,6 +434,13 @@ def test_texture_skybox_allows_grid_and_cubefiles():
   TextureCfg(name="sky", type="skybox", file="sky.png", gridsize=(6, 1)).validate()
   TextureCfg(
     name="sky", type="skybox", cubefiles=("a", "b", "c", "d", "e", "f")
+  ).validate()
+
+
+def test_texture_skybox_builtin_overrides_single_file():
+  """A builtin pattern takes precedence over the file, so the grid is irrelevant."""
+  TextureCfg(
+    name="sky", type="skybox", builtin="gradient", file="sky.png"
   ).validate()
 
 

--- a/tests/test_spec_config.py
+++ b/tests/test_spec_config.py
@@ -367,6 +367,69 @@ def test_texture_cfg():
   assert texture.name == "test_texture"
 
 
+def test_texture_cfg_image_fields():
+  """TextureCfg should set file, grid, nchannel, flip, and random fields."""
+  spec = mujoco.MjSpec()
+  texture_cfg = TextureCfg(
+    name="test_texture",
+    type="cube",
+    mark="random",
+    random=0.25,
+    file="sky.png",
+    gridsize=(3, 4),
+    gridlayout=".U..LFRB.D..",
+    nchannel=4,
+    hflip=True,
+    vflip=True,
+  )
+  texture_cfg.edit_spec(spec)
+
+  texture = spec.texture("test_texture")
+  assert texture.file == "sky.png"
+  assert tuple(texture.gridsize) == (3, 4)
+  assert texture.nchannel == 4
+  assert texture.hflip
+  assert texture.vflip
+  assert texture.random == pytest.approx(0.25)
+
+
+@pytest.mark.parametrize(
+  "param,value,expected_error",
+  [
+    ("width", 0, "width must be positive"),
+    ("width", -1, "width must be positive"),
+    ("height", 0, "height must be positive"),
+    ("height", -1, "height must be positive"),
+  ],
+)
+def test_texture_cfg_validation(param, value, expected_error):
+  """TextureCfg should validate explicitly set width and height."""
+  with pytest.raises(ValueError, match=expected_error):
+    TextureCfg(
+      name="test_texture",
+      type="2d",
+      width=value if param == "width" else 64,
+      height=value if param == "height" else 64,
+    ).validate()
+
+
+@pytest.mark.parametrize("gridsize", [None, (1, 1)])
+def test_texture_single_file_skybox_validation(gridsize):
+  """A single-image skybox cannot be sampled as six faces by the Warp renderer."""
+  with pytest.raises(ValueError, match="must declare a gridsize"):
+    TextureCfg(
+      name="sky", type="skybox", file="sky.png", gridsize=gridsize
+    ).validate()
+
+
+def test_texture_skybox_allows_grid_and_cubefiles():
+  """A larger grid or explicit cubefiles cover all six faces."""
+  TextureCfg(name="sky", type="skybox", file="sky.png", gridsize=(6, 1)).validate()
+  TextureCfg(
+    name="sky", type="skybox", cubefiles=("a", "b", "c", "d", "e", "f")
+  ).validate()
+
+
 def test_material_cfg():
   """MaterialCfg should add materials to spec."""
   spec = mujoco.MjSpec()


### PR DESCRIPTION
This PR extends `TextureCfg` to all the fields read by the mujoco_warp renderer which allows the creation of textures from a file. 