### PR TITLE
Make `auto_reset` and explicit `reset()` identical

### DIFF
--- a/docs/source/architecture_overview.rst
+++ b/docs/source/architecture_overview.rst
@@ -155,21 +155,23 @@ Each environment instance passes through four phases.
    which return the scene to an initial state with optional randomization.
    Command targets are resampled. Observation history buffers are cleared.
 
-4. **Step.** The policy action is processed by the ``ActionManager``. The
+4. **Step.** The policy action is processed by the ``ActionManager`` and the
+   ``EventManager`` updates the scheduled step and interval event. The
    physics simulation advances ``decimation`` times, with actuator commands
    applied and entity state updated each sub-step. After the decimation
    loop, the ``TerminationManager`` checks stop conditions, the
    ``RewardManager`` computes the reward signal, and any terminated
    environments are reset. A single ``forward()`` call refreshes derived
    quantities for all environments. The ``CommandManager`` advances or
-   resamples goals. Interval events fire if scheduled. Sensors update. The
-   ``ObservationManager`` assembles the observation for the next policy
-   query.
+   resamples goals. Sensors update. The ``ObservationManager`` assembles
+   the observation for the next policy query.
 
 The step sequence in order:
 
 .. code-block:: text
 
+    event_manager.apply(mode="step")
+    event_manager.apply(mode="interval")
     action_manager.process_action(action)
     for _ in range(decimation):
         action_manager.apply_action()
@@ -180,8 +182,7 @@ The step sequence in order:
     metrics_manager.compute()
     [reset terminated envs]
     sim.forward()
-    command_manager.compute()
-    event_manager.apply(mode="interval")
+    command_manager.compute()  # dt=0 for the envs just reset
     sim.sense()
     observation_manager.compute()
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -45,6 +45,20 @@ Changed
 - Changed the default MuJoCo Warp render background to solid black
   (``0, 0, 0, 1``), matching MuJoCo's native renderer. Contribution by
   @bd-pmorais.
+- ``step() -> reset()`` behaves identical to ``auto_reset = True``, which was
+  previously not the case. The changes to make this happen are:
+
+  - ``step`` and ``interval`` events are updated at the start of ``step()``, before
+    the action is processed and before the decimation loop, instead of after it.
+    This ordering is more consistent when using ``auto_reset`` enabled and disabled.
+    This implementation mimics the previous ``auto_reset`` implementation but now
+    explicitly resetting the environments works the same as using the ``auto_reset``
+    feature.
+  - ``command_manager.compute()`` receives a per-environment ``dt`` that is zero
+    for environments the auto-reset just restarted. The freshly sampled
+    resampling timers are no longer immediately decremented. This implementation
+    matches the implementation of the ``reset`` function which does not decrement
+    the timer for environments that were just restarted.
 
 Fixed
 ^^^^^

--- a/docs/source/events.rst
+++ b/docs/source/events.rst
@@ -106,6 +106,13 @@ every environment step.
     lightweight or manage their own activation logic internally to avoid
     unnecessary computation.
 
+.. note::
+
+   Both modes fire at the *start* of ``step()``, before the action is processed
+   and before the physics loop, so a disturbance is integrated by the decimation
+   loop of the same step and its effect reaches the observation only once the
+   physics has acted on it.
+
 As with all manager terms, ``func`` points to the callable and ``params``
 holds keyword arguments forwarded to it alongside ``env`` and ``env_ids``.
 Any ``SceneEntityCfg`` values inside ``params`` are resolved once at

--- a/src/mjlab/envs/manager_based_rl_env.py
+++ b/src/mjlab/envs/manager_based_rl_env.py
@@ -192,6 +192,10 @@ class ManagerBasedRlEnv:
       self.cfg.scene.num_envs, dtype=torch.bool, device=device
     )
 
+    # Scratch buffer for the per-env command dt used on auto-reset steps. See
+    # the comment in step() next to the auto-reset block.
+    self._command_dt = torch.zeros(self.cfg.scene.num_envs, device=device)
+
     # Initialize scene and simulation.
     self.scene = Scene(self.cfg.scene, device=device)
     self.sim = Simulation(
@@ -368,10 +372,10 @@ class ManagerBasedRlEnv:
     self.extras["log"] = dict()
     self._reset_idx(env_ids)
     self.scene.write_data_to_sim()
-    self.sim.forward()
-    self.command_manager.compute(dt=0.0)
-    self.sim.sense()
-    self.obs_buf = self.observation_manager.compute(update_history=True)
+
+    # dt = 0 as the internal timer should not be updated
+    self._update_commands_and_observations(dt=0.0)
+
     self.recorder_manager.record_post_reset(env_ids)
     return self.obs_buf, self.extras
 
@@ -416,6 +420,15 @@ class ManagerBasedRlEnv:
       )
 
     self.extras["log"] = dict()
+
+    if "step" in self.event_manager.available_modes:
+      # The dt is not used for step events as only the step count and not the
+      # time matters.
+      self.event_manager.apply(mode="step", dt=self.step_dt)
+
+    if "interval" in self.event_manager.available_modes:
+      self.event_manager.apply(mode="interval", dt=self.step_dt)
+
     self.action_manager.process_action(action.to(self.device))
 
     for _ in range(self.cfg.decimation):
@@ -440,33 +453,31 @@ class ManagerBasedRlEnv:
     self.reward_buf = self.reward_manager.compute(dt=self.step_dt)
     self.metrics_manager.compute()
 
+    # Set the command dt buffer to the default step dt. If the environment is
+    # reset, the command dt is zeroed to not increment the timers directly after
+    # the reset, which is identical to the reset function.
+    cmd_dt = self._command_dt
+    cmd_dt.fill_(self.step_dt)
+
     # Reset envs that terminated/timed-out and log the episode info.
     reset_env_ids = self.reset_buf.nonzero(as_tuple=False).squeeze(-1)
+
     if self.cfg.auto_reset and len(reset_env_ids) > 0:
       self.recorder_manager.record_pre_reset(reset_env_ids)
       self._reset_idx(reset_env_ids)
       self.scene.write_data_to_sim()
 
-    # Single forward() call: recompute derived quantities from current
-    # qpos/qvel for every env. For non-reset envs this resolves the
-    # one-substep staleness left by mj_step; for reset envs it picks up
-    # the freshly written reset state.
-    self.sim.forward()
+      # Zero the command dt for the reset environments
+      cmd_dt[reset_env_ids] = 0.0
 
-    self.command_manager.compute(dt=self.step_dt)
-
-    if "step" in self.event_manager.available_modes:
-      self.event_manager.apply(mode="step", dt=self.step_dt)
-    if "interval" in self.event_manager.available_modes:
-      self.event_manager.apply(mode="interval", dt=self.step_dt)
-
-    self.sim.sense()
-    self.obs_buf = self.observation_manager.compute(update_history=True)
-
-    if self.cfg.auto_reset and len(reset_env_ids) > 0:
+      self._update_commands_and_observations(dt=cmd_dt)
       self.recorder_manager.record_post_reset(reset_env_ids)
-    elif len(reset_env_ids) > 0:
-      self._manual_reset_pending[reset_env_ids] = True
+
+    else:
+      self._update_commands_and_observations(dt=cmd_dt)
+
+      if len(reset_env_ids) > 0:
+        self._manual_reset_pending[reset_env_ids] = True
 
     self.recorder_manager.record_post_step()
 
@@ -550,6 +561,21 @@ class ManagerBasedRlEnv:
     self.observation_space = batch_space(self.single_observation_space, self.num_envs)
     self.action_space = batch_space(self.single_action_space, self.num_envs)
 
+  def _update_commands_and_observations(self, dt: float | torch.Tensor) -> None:
+    """Update the command and observation manager.
+
+    Args:
+      dt: Time elapsed since the last update. dt is 0.0 for environments that were reset
+        and dt is step_dt for environments that were stepped.
+    """
+    # Single forward() call: recompute all MjData fields using the current qpos & qvel.
+    # For running environments, this resolves the one-substep staleness left by mj_step.
+    # For reset environments, this updates the fields with the new qpos and qvel.
+    self.sim.forward()
+    self.command_manager.compute(dt=dt)
+    self.sim.sense()
+    self.obs_buf = self.observation_manager.compute(update_history=True)
+
   def _reset_idx(self, env_ids: torch.Tensor | None = None) -> None:
     self.curriculum_manager.compute(env_ids=env_ids)
     self.sim.reset(env_ids)
@@ -586,6 +612,11 @@ class ManagerBasedRlEnv:
     # termination manager.
     info = self.termination_manager.reset(env_ids)
     self.extras["log"].update(info)
+
+    # Log the number of envs that were reset.
+    num_reset = self.num_envs if env_ids is None else len(env_ids)
+    self.extras["log"]["Episode/num_reset_envs"] = num_reset
+
     # reset the episode length buffer.
     self.episode_length_buf[env_ids] = 0
     self._manual_reset_pending[env_ids] = False

--- a/src/mjlab/managers/command_manager.py
+++ b/src/mjlab/managers/command_manager.py
@@ -106,7 +106,13 @@ class CommandTerm(ManagerTermBase):
     self._resample(env_ids)
     return extras
 
-  def compute(self, dt: float) -> None:
+  def compute(self, dt: float | torch.Tensor) -> None:
+    """Advance the resampling timer and update the command.
+
+    Args:
+      dt: Elapsed time in seconds. Either a scalar applied to every environment,
+        or a tensor that contains the elapsed time per environment.
+    """
     self._update_metrics()
     self.time_left -= dt
     resample_env_ids = (self.time_left <= 0.0).nonzero().flatten()
@@ -246,7 +252,8 @@ class CommandManager(ManagerBase):
         extras[f"Metrics/{name}/{metric_name}"] = metric_value
     return extras
 
-  def compute(self, dt: float):
+  def compute(self, dt: float | torch.Tensor):
+    """Update all command terms. See :meth:`CommandTerm.compute` for ``dt``."""
     for term in self._terms.values():
       term.compute(dt)
 
@@ -320,7 +327,7 @@ class NullCommandManager:
   def reset(self, env_ids: torch.Tensor | None = None) -> dict[str, torch.Tensor]:
     return {}
 
-  def compute(self, dt: float) -> None:
+  def compute(self, dt: float | torch.Tensor) -> None:
     pass
 
   def get_command(self, name: str) -> None:

--- a/src/mjlab/tasks/velocity/mdp/velocity_command.py
+++ b/src/mjlab/tasks/velocity/mdp/velocity_command.py
@@ -197,7 +197,7 @@ class UniformVelocityCommand(CommandTerm):
     self._joystick_sliders = sliders
     self._joystick_get_env_idx = get_env_idx
 
-  def compute(self, dt: float) -> None:
+  def compute(self, dt: float | torch.Tensor) -> None:
     super().compute(dt)
     if self._joystick_enabled is not None and self._joystick_enabled.value:
       assert self._joystick_get_env_idx is not None


### PR DESCRIPTION
## `auto_reset` vs. `reset()` inconsistency
There is a very subtle inconsistency between `auto_reset` and explicitly calling the `reset` function. 

```
###### with auto_reset enabled
1) step()
1.1) action
1.2) physics
1.3) reset
1.4) step commands with dt
1.5) step events with dt

######  with explicit reset
1) step()
1.1) action
1.2) physics
1.3) step commands with dt
1.4) step events with dt

2) reset()
2.1) step commands with dt = 0
2.2) reset events
```
So with `auto_reset`, the events and the commands are updated with `dt`, while with the explicit `reset` function the events are not called and the commands are updated with `dt = 0` instead of `dt = dt`.


## Changelog
To match the behavior of `auto_reset` and  the explicit `reset` functions, two changes were needed to make it happen. These changes cause slight difference in some edge-cases but mostly matches the previous implementation with `auto_reset = True`.

* `step` and `interval` events are updated at the start of `step()`, before the action is processed and before the decimation loop, instead of after it. This ordering is more consistent when using `auto_reset` enabled and disabled. This implementation mimics the previous `auto_reset` implementation but now explicitly resetting the environments works the same as using the `auto_reset` feature.

 * `command_manager.compute()` receives a per-environment `dt` that is zero for environments the auto-reset just restarted. The freshly sampled resampling timers are no longer immediately decremented. This implementation matches the implementation of the `reset` function which does not decrement the timer for environments that were just restarted.

### New `log` variable
* add the number of `done` environments to the log to make it easier to merge two different sets of episodic metrics.