### PR TITLE
Restore _randomize_categorical_field docstring dropped in #1111

### DIFF
--- a/src/mjlab/envs/mdp/dr/_core.py
+++ b/src/mjlab/envs/mdp/dr/_core.py
@@ -329,6 +329,7 @@ def _randomize_categorical_field(
   shared_random: bool = False,
   axis: int | None = None,
 ) -> None:
+  """Core engine for categorical fields: assign each entry a value from ``pool``."""
   asset = env.scene[asset_cfg.name]
 
   if env_ids is None:


### PR DESCRIPTION
Restores the one-line docstring that was accidentally removed in #1111.