### PR TITLE
Silence expected MULTICCD contact warning in test suite

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,3 +163,10 @@ markers = [
   "slow: marks tests as slow (deselect with '-m \"not slow\"')",
 ]
 addopts = "--strict-markers"
+filterwarnings = [
+  # MuJoCo Warp warns that MULTICCD (enabled by default) generates at most one
+  # contact for CCD pairs it lacks multicontact support for (e.g. cylinder-box,
+  # hfield-capsule). Test fixtures aren't validating contact fidelity for these
+  # pairs, so silence the expected noise.
+  "ignore:MULTICCD is enabled, but the scene contains CCD pairs:UserWarning",
+]


### PR DESCRIPTION
MuJoCo Warp warns during model setup that MULTICCD (enabled by default) generates at most one contact for CCD pairs it lacks multicontact support for, such as the cylinder-box geoms in fixed_base_articulated.xml and the heightfield collisions in the Go1 rough env; these fixtures don't validate contact fidelity for those pairs, so the warning is expected noise and is now filtered via a targeted pytest filterwarnings entry.