### PR TITLE
Stop partial resets from advancing stateful commands in other envs

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -12,6 +12,12 @@ Upcoming version (not yet released)
      and ``priority`` to be explicit instead of silently defaulting to
      MuJoCo's values, and dict values for these fields must cover every
      matched geom (add a catch-all ``".*"`` entry).
+   - ``CommandTerm._update_command`` now takes an ``env_ids`` argument:
+     ``None`` on the regular per-step update and the reset environment ids
+     when called from ``reset()``. Custom command terms must add the
+     parameter (construction raises a ``TypeError`` with migration
+     instructions otherwise) and scope any per-step state advance, such as
+     a motion frame index, to ``env_ids``.
 
 .. admonition:: Highlights
    :class: note
@@ -69,6 +75,13 @@ Fixed
   frame. Previously, each manual partial reset gave the other envs a duplicate
   frame, shortening their effective history and drifting their delay
   schedules.
+- ``reset(env_ids=...)`` no longer advances stateful commands in
+  environments that were not reset. Previously a partial reset gave every
+  environment an extra command update, so with ``auto_reset=False`` a
+  ``MotionCommand`` reference motion played at twice the normal speed and
+  could teleport non-reset robots via the wraparound resample. The adaptive
+  sampling EMA also no longer folds on resets, matching auto-reset
+  training dynamics. :issue:`1138`
 - ``RayCastSensorCfg.include_geom_groups`` now raises on values outside
   ``[0, mjNGROUP)`` instead of silently excluding every geom.
 - Geoms with a negative group no longer pick up group 5's visibility toggle in

--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -100,10 +100,24 @@ Writing custom command terms
 A custom command term is a class inheriting from ``CommandTerm`` paired
 with a configuration dataclass inheriting from ``CommandTermCfg``. The
 term must implement four methods: ``_resample_command(env_ids)`` to
-sample new goals, ``_update_command()`` for per-step updates,
+sample new goals, ``_update_command(env_ids)`` for per-step updates,
 ``_update_metrics()`` for logging, and a ``command`` property returning
 the current goal tensor. The base class manages the resampling timer
 and reset logic automatically.
+
+``_update_command`` is called in two situations. On every environment
+step it receives ``env_ids=None``, meaning update all environments.
+After a reset it is called again with the ids of the environments that
+were just reset, so their command state is brought up to date before
+observations are computed.
+
+The distinction matters when your update advances state, such as
+incrementing a frame index into a reference motion. Apply such advances
+only to ``env_ids`` (all environments when ``None``); otherwise
+resetting a few environments would also advance every other one. Updates
+that simply recompute values from the current simulation state, like a
+heading error, give the same result no matter how often they run and can
+safely ignore ``env_ids``.
 
 The configuration must implement a ``build(env)`` method that
 constructs the paired term instance.

--- a/src/mjlab/envs/manager_based_rl_env.py
+++ b/src/mjlab/envs/manager_based_rl_env.py
@@ -369,7 +369,9 @@ class ManagerBasedRlEnv:
     self._reset_idx(env_ids)
     self.scene.write_data_to_sim()
     self.sim.forward()
-    self.command_manager.compute(dt=0.0)
+    # Scoped to env_ids so a partial reset does not advance stateful commands in the
+    # other envs.
+    self.command_manager.compute(dt=0.0, env_ids=env_ids)
     self.sim.sense()
     # Scoped to env_ids: only the reset envs' history/delay buffers receive
     # the post-reset frame; other envs' observation timelines are untouched.

--- a/src/mjlab/managers/command_manager.py
+++ b/src/mjlab/managers/command_manager.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import abc
+import inspect
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Sequence
@@ -50,6 +51,7 @@ class CommandTerm(ManagerTermBase):
   def __init__(self, cfg: CommandTermCfg, env: ManagerBasedRlEnv):
     self.cfg = cfg
     super().__init__(env)
+    self._check_update_command_signature()
     self.metrics = dict()
     self.time_left = torch.zeros(self.num_envs, device=self.device)
     self.command_counter = torch.zeros(
@@ -106,13 +108,37 @@ class CommandTerm(ManagerTermBase):
     self._resample(env_ids)
     return extras
 
-  def compute(self, dt: float) -> None:
+  def compute(self, dt: float, env_ids: torch.Tensor | None = None) -> None:
+    """Advance the command state by dt.
+
+    With env_ids=None (the per-step path) all envs are updated; with env_ids
+    (the reset path) timers and the command update are scoped to those envs.
+    Metrics are always refreshed.
+    """
     self._update_metrics()
-    self.time_left -= dt
-    resample_env_ids = (self.time_left <= 0.0).nonzero().flatten()
+    if env_ids is None:
+      self.time_left -= dt
+      resample_env_ids = (self.time_left <= 0.0).nonzero().flatten()
+    else:
+      self.time_left[env_ids] -= dt
+      resample_env_ids = env_ids[self.time_left[env_ids] <= 0.0]
     if len(resample_env_ids) > 0:
       self._resample(resample_env_ids)
-    self._update_command()
+    self._update_command(env_ids)
+
+  def _check_update_command_signature(self) -> None:
+    """Fail fast with a migration hint for terms with the old signature."""
+    try:
+      sig = inspect.signature(self._update_command)
+    except (TypeError, ValueError):
+      return
+    if len(sig.parameters) == 0:
+      raise TypeError(
+        f"{type(self).__name__}._update_command must accept env_ids: "
+        "_update_command(self, env_ids: torch.Tensor | None). It receives "
+        "None on the per-step update and the reset env ids on reset(); "
+        "scope per-step state advances to env_ids."
+      )
 
   def _resample(self, env_ids: torch.Tensor) -> None:
     if len(env_ids) != 0:
@@ -133,8 +159,13 @@ class CommandTerm(ManagerTermBase):
     raise NotImplementedError
 
   @abc.abstractmethod
-  def _update_command(self) -> None:
-    """Update the command based on the current state."""
+  def _update_command(self, env_ids: torch.Tensor | None) -> None:
+    """Update the command based on the current state.
+
+    env_ids is None on the per-step update (all envs) and the reset env ids on reset().
+    Scope per-step state advances (e.g. a motion frame index) to env_ids; pure
+    functions of the current state may ignore it.
+    """
     raise NotImplementedError
 
 
@@ -246,9 +277,9 @@ class CommandManager(ManagerBase):
         extras[f"Metrics/{name}/{metric_name}"] = metric_value
     return extras
 
-  def compute(self, dt: float):
+  def compute(self, dt: float, env_ids: torch.Tensor | None = None):
     for term in self._terms.values():
-      term.compute(dt)
+      term.compute(dt, env_ids)
 
   def get_command(self, name: str) -> torch.Tensor:
     return self._terms[name].command
@@ -320,7 +351,7 @@ class NullCommandManager:
   def reset(self, env_ids: torch.Tensor | None = None) -> dict[str, torch.Tensor]:
     return {}
 
-  def compute(self, dt: float) -> None:
+  def compute(self, dt: float, env_ids: torch.Tensor | None = None) -> None:
     pass
 
   def get_command(self, name: str) -> None:

--- a/src/mjlab/tasks/manipulation/mdp/commands.py
+++ b/src/mjlab/tasks/manipulation/mdp/commands.py
@@ -97,7 +97,7 @@ class LiftingCommand(CommandTerm):
       self.object.write_root_link_pose_to_sim(pose, env_ids=env_ids)
       self.object.write_root_link_velocity_to_sim(velocity, env_ids=env_ids)
 
-  def _update_command(self) -> None:
+  def _update_command(self, env_ids: torch.Tensor | None = None) -> None:
     pass
 
   def _debug_vis_impl(self, visualizer: DebugVisualizer) -> None:
@@ -219,7 +219,7 @@ class MultiCubeLiftingCommand(CommandTerm):
       cube.write_root_link_pose_to_sim(pose, env_ids=env_ids)
       cube.write_root_link_velocity_to_sim(velocity, env_ids=env_ids)
 
-  def _update_command(self) -> None:
+  def _update_command(self, env_ids: torch.Tensor | None = None) -> None:
     pass
 
   def _debug_vis_impl(self, visualizer: DebugVisualizer) -> None:

--- a/src/mjlab/tasks/tracking/mdp/commands.py
+++ b/src/mjlab/tasks/tracking/mdp/commands.py
@@ -404,11 +404,14 @@ class MotionCommand(CommandTerm):
       delta_ori_w, self.body_pos_w - anchor_pos_w_repeat
     )
 
-  def _update_command(self):
-    self.time_steps += 1
-    env_ids = torch.where(self.time_steps >= self.motion.time_step_total)[0]
-    if env_ids.numel() > 0:
-      self._resample_command(env_ids)
+  def _update_command(self, env_ids: torch.Tensor | None = None):
+    if env_ids is None:
+      self.time_steps += 1
+    else:
+      self.time_steps[env_ids] += 1
+    wrap_ids = torch.where(self.time_steps >= self.motion.time_step_total)[0]
+    if wrap_ids.numel() > 0:
+      self._resample_command(wrap_ids)
       # _resample_command writes qpos/qvel but does not refresh derived
       # quantities; forward() so update_relative_body_poses reads the
       # post-teleport robot anchor instead of the stale pre-resample pose.
@@ -416,7 +419,9 @@ class MotionCommand(CommandTerm):
 
     self.update_relative_body_poses()
 
-    if self.cfg.sampling_mode == "adaptive":
+    # Fold failure counts into the EMA only on the per-step update so
+    # manual resets do not decay it faster.
+    if env_ids is None and self.cfg.sampling_mode == "adaptive":
       self.bin_failed_count = (
         self.cfg.adaptive_alpha * self._current_bin_failed
         + (1 - self.cfg.adaptive_alpha) * self.bin_failed_count

--- a/src/mjlab/tasks/velocity/mdp/velocity_command.py
+++ b/src/mjlab/tasks/velocity/mdp/velocity_command.py
@@ -113,12 +113,14 @@ class UniformVelocityCommand(CommandTerm):
       )
       self.robot.write_root_state_to_sim(root_state, init_vel_env_ids)
 
-  def _update_command(self) -> None:
+  def _update_command(self, env_ids: torch.Tensor | None = None) -> None:
+    # Pure function of the current state; refreshing all envs is safe.
+    del env_ids
     if self.cfg.heading_command:
       self.heading_error = wrap_to_pi(self.heading_target - self.robot.data.heading_w)
-      env_ids = self.is_heading_env.nonzero(as_tuple=False).flatten()
-      self.vel_command_b[env_ids, 2] = torch.clip(
-        self.cfg.heading_control_stiffness * self.heading_error[env_ids],
+      heading_ids = self.is_heading_env.nonzero(as_tuple=False).flatten()
+      self.vel_command_b[heading_ids, 2] = torch.clip(
+        self.cfg.heading_control_stiffness * self.heading_error[heading_ids],
         min=self.cfg.ranges.ang_vel_z[0],
         max=self.cfg.ranges.ang_vel_z[1],
       )
@@ -197,8 +199,8 @@ class UniformVelocityCommand(CommandTerm):
     self._joystick_sliders = sliders
     self._joystick_get_env_idx = get_env_idx
 
-  def compute(self, dt: float) -> None:
-    super().compute(dt)
+  def compute(self, dt: float, env_ids: torch.Tensor | None = None) -> None:
+    super().compute(dt, env_ids)
     if self._joystick_enabled is not None and self._joystick_enabled.value:
       assert self._joystick_get_env_idx is not None
       idx = self._joystick_get_env_idx()

--- a/tests/test_command_manager.py
+++ b/tests/test_command_manager.py
@@ -1,0 +1,148 @@
+"""Tests for command manager."""
+
+from dataclasses import dataclass
+from unittest.mock import Mock
+
+import pytest
+import torch
+from conftest import get_test_device
+
+from mjlab.envs import ManagerBasedRlEnv
+from mjlab.managers.command_manager import CommandTerm, CommandTermCfg
+from mjlab.tasks.cartpole.cartpole_env_cfg import cartpole_balance_env_cfg
+from mjlab.tasks.tracking.mdp.commands import MotionCommand
+
+
+@pytest.fixture(scope="module")
+def device():
+  return get_test_device()
+
+
+class CounterCommand(CommandTerm):
+  """Stateful command term: a per-env counter ticked by _update_command."""
+
+  def __init__(self, cfg, env):
+    super().__init__(cfg, env)
+    self.ticks = torch.zeros(self.num_envs, dtype=torch.long, device=self.device)
+
+  @property
+  def command(self) -> torch.Tensor:
+    return self.ticks.unsqueeze(-1).float()
+
+  def _update_metrics(self) -> None:
+    pass
+
+  def _resample_command(self, env_ids: torch.Tensor) -> None:
+    self.ticks[env_ids] = 0
+
+  def _update_command(self, env_ids: torch.Tensor | None = None) -> None:
+    if env_ids is None:
+      self.ticks += 1
+    else:
+      self.ticks[env_ids] += 1
+
+
+@dataclass(kw_only=True)
+class CounterCommandCfg(CommandTermCfg):
+  resampling_time_range: tuple[float, float] = (1e9, 1e9)
+
+  def build(self, env) -> CounterCommand:
+    return CounterCommand(self, env)
+
+
+@pytest.fixture
+def counter_env(device):
+  cfg = cartpole_balance_env_cfg()
+  cfg.scene.num_envs = 4
+  cfg.commands = {"counter": CounterCommandCfg()}
+  env = ManagerBasedRlEnv(cfg=cfg, device=device)
+  yield env
+  env.close()
+
+
+def test_partial_reset_does_not_advance_other_envs(counter_env):
+  env = counter_env
+  term = env.command_manager.get_term("counter")
+  assert isinstance(term, CounterCommand)
+
+  # Full reset: every env is resampled (counter zeroed) then ticked once.
+  env.reset()
+  assert term.ticks.tolist() == [1, 1, 1, 1]
+
+  action = torch.zeros((env.num_envs, 1), device=env.device)
+  env.step(action)
+  assert term.ticks.tolist() == [2, 2, 2, 2]
+
+  # Partial reset: only env 1 is resampled and ticked. Before the fix for
+  # issue #1138 the other envs advanced too (to 3).
+  env.reset(env_ids=torch.tensor([1], dtype=torch.int64, device=env.device))
+  assert term.ticks.tolist() == [2, 1, 2, 2]
+
+  # The next step advances everyone by exactly one.
+  env.step(action)
+  assert term.ticks.tolist() == [3, 2, 3, 3]
+
+
+def test_old_style_update_command_raises(counter_env):
+  """Terms with the old zero-arg _update_command fail fast at construction."""
+
+  class OldStyleCommand(CounterCommand):
+    def _update_command(self) -> None:  # type: ignore[override]
+      self.ticks += 1
+
+  @dataclass(kw_only=True)
+  class OldStyleCommandCfg(CounterCommandCfg):
+    def build(self, env) -> "OldStyleCommand":
+      return OldStyleCommand(self, env)
+
+  with pytest.raises(TypeError, match="env_ids"):
+    OldStyleCommandCfg().build(counter_env)
+
+
+def _make_motion_command_stub(time_steps, total, sampling_mode="uniform"):
+  """A stub with just enough state to drive MotionCommand._update_command."""
+  cmd = Mock()
+  cmd.time_steps = torch.tensor(time_steps, dtype=torch.long)
+  cmd.motion = Mock()
+  cmd.motion.time_step_total = total
+  cmd.cfg = Mock()
+  cmd.cfg.sampling_mode = sampling_mode
+  cmd.cfg.adaptive_alpha = 0.5
+  cmd.bin_failed_count = torch.tensor([1.0, 1.0])
+  cmd._current_bin_failed = torch.tensor([4.0, 4.0])
+  return cmd
+
+
+def test_motion_command_update_scopes_time_advance():
+  cmd = _make_motion_command_stub([2, 5, 7], total=100)
+  MotionCommand._update_command(cmd, env_ids=torch.tensor([1]))
+  assert cmd.time_steps.tolist() == [2, 6, 7]
+  cmd._resample_command.assert_not_called()
+  cmd.update_relative_body_poses.assert_called_once()
+
+  MotionCommand._update_command(cmd, env_ids=None)
+  assert cmd.time_steps.tolist() == [3, 7, 8]
+
+
+def test_motion_command_update_resamples_on_wraparound():
+  cmd = _make_motion_command_stub([2, 9], total=10)
+  MotionCommand._update_command(cmd, env_ids=torch.tensor([1]))
+  # Env 1 wrapped past the end of the motion and must be resampled; env 0
+  # is untouched.
+  (wrap_ids,), _ = cmd._resample_command.call_args
+  assert wrap_ids.tolist() == [1]
+  assert cmd.time_steps[0].item() == 2
+  cmd._env.sim.forward.assert_called_once()
+
+
+def test_motion_command_ema_folds_only_on_step_update():
+  cmd = _make_motion_command_stub([2, 5], total=100, sampling_mode="adaptive")
+  MotionCommand._update_command(cmd, env_ids=torch.tensor([0]))
+  # Reset-scoped update: EMA untouched, pending failure counts preserved.
+  assert cmd.bin_failed_count.tolist() == [1.0, 1.0]
+  assert cmd._current_bin_failed.tolist() == [4.0, 4.0]
+
+  MotionCommand._update_command(cmd, env_ids=None)
+  # Per-step update: EMA folds the counts and clears them.
+  assert cmd.bin_failed_count.tolist() == [2.5, 2.5]
+  assert cmd._current_bin_failed.tolist() == [0.0, 0.0]


### PR DESCRIPTION
`env.reset(env_ids=...)` runs `command_manager.compute(dt=0)` (added in #762 to refresh derived command state after a reset), which called `_update_command` for every environment. Stateful commands advanced on each partial reset: with `auto_reset=False`, a `MotionCommand` reference motion played at 2x speed, and non-reset robots could even be teleported by the wraparound resample.

`_update_command` now takes `env_ids`: `None` on the regular per-step update, the reset ids when called from `reset()`. The step path is unchanged; a reset only ticks the envs being reset, matching what the auto-reset path already does. The adaptive-sampling EMA folds only on the per-step update so manual resets no longer decay it faster. Command terms with the old zero-arg signature fail fast at construction with a migration hint.

Fixes #1138