### PR TITLE
Stop partial resets from advancing other envs' observation buffers

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -64,6 +64,11 @@ Changed
 Fixed
 ^^^^^
 
+- ``reset(env_ids=...)`` no longer appends a frame to every env's observation
+  history and delay buffers; only the reset envs receive their post-reset
+  frame. Previously, each manual partial reset gave the other envs a duplicate
+  frame, shortening their effective history and drifting their delay
+  schedules.
 - ``RayCastSensorCfg.include_geom_groups`` now raises on values outside
   ``[0, mjNGROUP)`` instead of silently excluding every geom.
 - Geoms with a negative group no longer pick up group 5's visibility toggle in

--- a/src/mjlab/envs/manager_based_rl_env.py
+++ b/src/mjlab/envs/manager_based_rl_env.py
@@ -371,7 +371,11 @@ class ManagerBasedRlEnv:
     self.sim.forward()
     self.command_manager.compute(dt=0.0)
     self.sim.sense()
-    self.obs_buf = self.observation_manager.compute(update_history=True)
+    # Scoped to env_ids: only the reset envs' history/delay buffers receive
+    # the post-reset frame; other envs' observation timelines are untouched.
+    self.obs_buf = self.observation_manager.compute(
+      update_history=True, env_ids=env_ids
+    )
     self.recorder_manager.record_post_reset(env_ids)
     return self.obs_buf, self.extras
 

--- a/src/mjlab/managers/observation_manager.py
+++ b/src/mjlab/managers/observation_manager.py
@@ -303,8 +303,21 @@ class ObservationManager(ManagerBase):
     return torch.nan_to_num(tensor, nan=0.0, posinf=0.0, neginf=0.0)
 
   def compute(
-    self, update_history: bool = False
+    self,
+    update_history: bool = False,
+    env_ids: torch.Tensor | None = None,
   ) -> dict[str, torch.Tensor | dict[str, torch.Tensor]]:
+    """Compute observations for all groups.
+
+    With env_ids=None (the per-step path), history and delay buffers advance
+    for all envs. With env_ids (the reset path), only the reset envs' buffers
+    receive their post-reset frame (a backfill); other envs' buffers, delay
+    schedules, and lag draws are untouched, so a partial reset does not
+    advance their observation timelines.
+    """
+    assert env_ids is None or update_history, (
+      "env_ids is only meaningful with update_history=True (the reset path)."
+    )
     # Return cached observations if not updating and cache exists.
     # This prevents double-pushing to delay buffers when compute() is called
     # multiple times per control step (e.g., in get_observations() after step()).
@@ -313,12 +326,15 @@ class ObservationManager(ManagerBase):
 
     obs_buffer: dict[str, torch.Tensor | dict[str, torch.Tensor]] = dict()
     for group_name in self._group_obs_term_names:
-      obs_buffer[group_name] = self.compute_group(group_name, update_history)
+      obs_buffer[group_name] = self.compute_group(group_name, update_history, env_ids)
     self._obs_buffer = obs_buffer
     return obs_buffer
 
   def compute_group(
-    self, group_name: str, update_history: bool = False
+    self,
+    group_name: str,
+    update_history: bool = False,
+    env_ids: torch.Tensor | None = None,
   ) -> torch.Tensor | dict[str, torch.Tensor]:
     group_cfg = self.cfg[group_name]
     group_term_names = self._group_obs_term_names[group_name]
@@ -347,12 +363,19 @@ class ObservationManager(ManagerBase):
 
       if term_cfg.delay_max_lag > 0:
         delay_buffer = self._group_obs_term_delay_buffer[group_name][term_name]
-        delay_buffer.append(obs)
-        obs = delay_buffer.compute()
+        if env_ids is None or not delay_buffer.is_initialized:
+          delay_buffer.append(obs)
+          obs = delay_buffer.compute()
+        else:
+          delay_buffer.backfill(obs, env_ids)
+          obs = delay_buffer.peek()
       if term_cfg.history_length > 0:
         circular_buffer = self._group_obs_term_history_buffer[group_name][term_name]
-        if update_history or not circular_buffer.is_initialized:
-          circular_buffer.append(obs)
+        if env_ids is None or not circular_buffer.is_initialized:
+          if update_history or not circular_buffer.is_initialized:
+            circular_buffer.append(obs)
+        else:
+          circular_buffer.backfill(obs, env_ids)
 
         if term_cfg.flatten_history_dim:
           group_obs[term_name] = circular_buffer.buffer.reshape(self._env.num_envs, -1)

--- a/src/mjlab/utils/buffers/circular_buffer.py
+++ b/src/mjlab/utils/buffers/circular_buffer.py
@@ -187,6 +187,27 @@ class CircularBuffer:
     if self._buffer is not None:
       self._buffer[:, ids] = 0.0
 
+  def backfill(self, data: torch.Tensor, batch_ids: torch.Tensor) -> None:
+    """Fill the given rows' entire history with one frame, without advancing time.
+
+    Unlike append, the global pointer does not move and other rows are
+    untouched. Used after a partial reset: the reset rows get their first
+    post-reset frame in every slot (the same backfill their next append would
+    apply) while the remaining rows keep their history intact.
+
+    Args:
+      data: Tensor of shape (batch_size, ...); only rows at batch_ids are read.
+      batch_ids: Batch indices to backfill.
+    """
+    if data.shape[0] != self._batch_size:
+      raise ValueError(f"Expected batch size {self._batch_size}, got {data.shape[0]}")
+    if self._buffer is None:
+      raise RuntimeError("Buffer not initialized. Call append() first.")
+
+    data = data.to(self._device)
+    self._buffer[:, batch_ids] = data[batch_ids].unsqueeze(0)
+    self._num_pushes[batch_ids] = 1
+
   def append(self, data: torch.Tensor) -> None:
     """Append a new frame for all batch elements.
 

--- a/src/mjlab/utils/buffers/delay_buffer.py
+++ b/src/mjlab/utils/buffers/delay_buffer.py
@@ -226,8 +226,23 @@ class DelayBuffer:
     """
     self._buffer.append(data)
 
+  def backfill(self, data: torch.Tensor, batch_ids: torch.Tensor) -> None:
+    """Backfill the given rows with one frame, without advancing time.
+
+    Used after a partial reset: the reset rows (whose lags and step counters
+    were just zeroed by reset) get their first post-reset frame while the
+    remaining rows keep their history, lags, and update schedule intact.
+
+    Args:
+      data: Tensor of shape (batch_size, ...); only rows at batch_ids are read.
+      batch_ids: Batch indices to backfill.
+    """
+    self._buffer.backfill(data, batch_ids)
+
   def compute(self) -> torch.Tensor:
     """Compute delayed observation for current step.
+
+    Advances the lag update schedule, then returns the delayed observation.
 
     Returns:
       Delayed observation with shape (batch_size, ...).
@@ -236,6 +251,19 @@ class DelayBuffer:
       raise RuntimeError("Buffer not initialized. Call append() first.")
 
     self._update_lags()
+    return self.peek()
+
+  def peek(self) -> torch.Tensor:
+    """Return the delayed observation using current lags, without advancing.
+
+    Unlike compute, this neither steps the update schedule nor resamples lags,
+    so it is safe to call outside the once-per-step cadence.
+
+    Returns:
+      Delayed observation with shape (batch_size, ...).
+    """
+    if not self.is_initialized:
+      raise RuntimeError("Buffer not initialized. Call append() first.")
 
     # Clamp lags to valid range [0, buffer_length - 1].
     # Buffer may not be full yet (e.g., only 2 frames but sampled lag=3).

--- a/tests/test_auto_reset.py
+++ b/tests/test_auto_reset.py
@@ -163,3 +163,34 @@ def test_auto_reset_false_obs_differs_from_auto_reset_true(device):
     off_val = obs_off[group]
     assert isinstance(on_val, torch.Tensor) and isinstance(off_val, torch.Tensor)
     assert not torch.equal(on_val, off_val)
+
+
+def test_partial_reset_leaves_other_envs_obs_buffers_untouched(device):
+  """reset(env_ids=...) must not advance other envs' history/delay buffers."""
+  cfg = _make_cfg(auto_reset=False)
+  cfg.observations["actor"].terms["cart_pos"].history_length = 4
+  cfg.observations["actor"].terms["cart_vel"].delay_min_lag = 2
+  cfg.observations["actor"].terms["cart_vel"].delay_max_lag = 2
+  env = ManagerBasedRlEnv(cfg=cfg, device=device)
+  env.reset()
+  action = torch.zeros((env.num_envs, 1), device=env.device)
+  for _ in range(3):
+    env.step(action)
+
+  om = env.observation_manager
+  hist = om._group_obs_term_history_buffer["actor"]["cart_pos"]
+  delay = om._group_obs_term_delay_buffer["actor"]["cart_vel"]
+  h_before = hist.buffer[0].clone()
+  d_before = delay.peek()[0].clone()
+
+  env.reset(env_ids=torch.tensor([1], dtype=torch.int64, device=env.device))
+
+  # Env 0 was not reset: history window and delayed obs are untouched.
+  assert torch.equal(hist.buffer[0], h_before)
+  assert torch.equal(delay.peek()[0], d_before)
+
+  # Env 1 was reset: history is backfilled with its single post-reset frame.
+  h1 = hist.buffer[1]
+  assert torch.all(h1 == h1[0])
+  assert hist.current_length[1].item() == 1
+  env.close()

--- a/tests/test_circular_buffer.py
+++ b/tests/test_circular_buffer.py
@@ -215,3 +215,41 @@ def test_dtype_and_device_preserved(device):
   buffer.append(x)
   assert buffer.buffer.dtype == torch.float32
   assert buffer.buffer.device.type == torch.device(device).type
+
+
+def test_backfill_only_touches_given_rows(device):
+  """backfill writes one frame into all slots of given rows, no pointer advance."""
+  buffer = CircularBuffer(max_len=3, batch_size=3, device=device)
+  buffer.append(torch.tensor([[1.0], [10.0], [100.0]], device=device))
+  buffer.append(torch.tensor([[2.0], [20.0], [200.0]], device=device))
+  buffer.append(torch.tensor([[3.0], [30.0], [300.0]], device=device))
+
+  buffer.reset(batch_ids=torch.tensor([1], device=device))
+  data = torch.tensor([[-1.0], [99.0], [-1.0]], device=device)
+  buffer.backfill(data, torch.tensor([1], device=device))
+
+  result = buffer.buffer
+  assert torch.allclose(
+    result[0].flatten(), torch.tensor([1.0, 2.0, 3.0], device=device)
+  )
+  assert torch.allclose(
+    result[1].flatten(), torch.tensor([99.0, 99.0, 99.0], device=device)
+  )
+  assert torch.allclose(
+    result[2].flatten(), torch.tensor([100.0, 200.0, 300.0], device=device)
+  )
+  assert buffer.current_length.tolist() == [3, 1, 3]
+
+  # Subsequent appends treat the backfilled row normally.
+  buffer.append(torch.tensor([[4.0], [40.0], [400.0]], device=device))
+  result = buffer.buffer
+  assert torch.allclose(
+    result[1].flatten(), torch.tensor([99.0, 99.0, 40.0], device=device)
+  )
+  assert buffer.current_length.tolist() == [3, 2, 3]
+
+
+def test_backfill_uninitialized_raises(device):
+  buffer = CircularBuffer(max_len=2, batch_size=2, device=device)
+  with pytest.raises(RuntimeError, match="not initialized"):
+    buffer.backfill(torch.zeros(2, 1, device=device), torch.tensor([0], device=device))

--- a/tests/test_delay_buffer.py
+++ b/tests/test_delay_buffer.py
@@ -298,3 +298,30 @@ def test_delay_buffer_validation(device):
 
   with pytest.raises(ValueError, match="update_period must be >= 0"):
     DelayBuffer(min_lag=0, max_lag=3, batch_size=1, update_period=-1, device=device)
+
+
+def test_backfill_and_peek_leave_others_untouched(device):
+  """backfill serves the reset row's new frame; peek advances no schedules."""
+  B = 3
+  buf = DelayBuffer(1, 2, batch_size=B, device=device, generator=make_gen(9, device))
+  for t in range(4):
+    x = torch.arange(1, B + 1, device=device).float().unsqueeze(1) * 10 + t
+    buf.append(x)
+    buf.compute()
+
+  out_before = buf.peek()
+  lags_before = buf.current_lags.clone()
+  steps_before = buf._step_count.clone()
+
+  reset_ids = torch.tensor([1], device=device)
+  buf.reset(batch_ids=reset_ids)
+  buf.backfill(torch.tensor([[-1.0], [999.0], [-1.0]], device=device), reset_ids)
+  out = buf.peek()
+
+  # Reset row serves its backfilled frame (lag zeroed, one valid frame).
+  assert torch.allclose(out[1], torch.tensor([999.0], device=device))
+  # Other rows: same delayed frame, lags and schedule untouched.
+  keep = torch.tensor([0, 2], device=device)
+  assert torch.allclose(out[keep], out_before[keep])
+  assert torch.equal(buf.current_lags[keep], lags_before[keep])
+  assert torch.equal(buf._step_count[keep], steps_before[keep])


### PR DESCRIPTION
`env.reset(env_ids=...)` recomputed observations with `update_history=True`, appending a frame to every env's history buffer and advancing every delay buffer, not just the reset envs. In `auto_reset=False` loops, surviving envs got a duplicate frame per manual reset: history windows shrank and delay schedules drifted.

The buffers now expose `backfill` (fill a reset row's history with its post-reset frame without advancing global time) and `peek` (read the delayed obs without stepping the lag schedule); `reset()` routes the reset envs through them. The per-step path is unchanged. Regression tests at the buffer and env level fail on the previous code.