### PR TITLE
Refresh kinematics after mid-episode lifting command resamples

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -73,6 +73,9 @@ Fixed
 - The Viser motion scrubber's Start Here button no longer computes relative
   body poses from stale pre-scrub kinematics, which could spuriously
   terminate the episode on the next step.
+- Mid-episode lifting command resamples now refresh kinematics and the
+  multi-cube reward cache, so observations and rewards no longer see
+  pre-teleport object positions for one step after each resample.
 - ``reset(env_ids=...)`` no longer appends a frame to every env's observation
   history and delay buffers; only the reset envs receive their post-reset
   frame. Previously, each manual partial reset gave the other envs a duplicate

--- a/src/mjlab/tasks/manipulation/mdp/commands.py
+++ b/src/mjlab/tasks/manipulation/mdp/commands.py
@@ -27,6 +27,7 @@ class LiftingCommand(CommandTerm):
     self.object: Entity = env.scene[cfg.entity_name]
     self.target_pos = torch.zeros(self.num_envs, 3, device=self.device)
     self.episode_success = torch.zeros(self.num_envs, device=self.device)
+    self._pending_forward = False
 
     self.metrics["object_height"] = torch.zeros(self.num_envs, device=self.device)
     self.metrics["position_error"] = torch.zeros(self.num_envs, device=self.device)
@@ -96,9 +97,24 @@ class LiftingCommand(CommandTerm):
 
       self.object.write_root_link_pose_to_sim(pose, env_ids=env_ids)
       self.object.write_root_link_velocity_to_sim(velocity, env_ids=env_ids)
+      self._pending_forward = True
+
+  def reset(self, env_ids: torch.Tensor | slice | None) -> dict[str, float]:
+    extras = super().reset(env_ids)
+    # Reset-path resamples are followed by the env's own forward(); only
+    # compute-path resamples (timer expiry) need our refresh.
+    self._pending_forward = False
+    return extras
 
   def _update_command(self, env_ids: torch.Tensor | None = None) -> None:
-    pass
+    # Reset-vs-step context is handled via _pending_forward, not env_ids.
+    del env_ids
+    # A timer-expiry resample teleports the object after the step's single
+    # forward(); refresh kinematics so observations and sensors see the new
+    # pose instead of the pre-teleport one.
+    if self._pending_forward:
+      self._pending_forward = False
+      self._env.sim.forward()
 
   def _debug_vis_impl(self, visualizer: DebugVisualizer) -> None:
     env_indices = visualizer.get_env_indices(self.num_envs)
@@ -149,6 +165,7 @@ class MultiCubeLiftingCommand(CommandTerm):
 
     self._env_arange = torch.arange(self.num_envs, device=self.device)
     self._cached_target_obj_pos = torch.zeros(self.num_envs, 3, device=self.device)
+    self._pending_forward = False
 
     self.metrics["position_error"] = torch.zeros(self.num_envs, device=self.device)
     self.metrics["at_goal"] = torch.zeros(self.num_envs, device=self.device)
@@ -170,9 +187,12 @@ class MultiCubeLiftingCommand(CommandTerm):
     """
     return self._cached_target_obj_pos
 
-  def _update_metrics(self) -> None:
+  def _target_object_pos_from_sim(self) -> torch.Tensor:
     all_pos = torch.stack([c.data.root_link_pos_w for c in self.cubes])
-    self._cached_target_obj_pos = all_pos[self.target_selection, self._env_arange]
+    return all_pos[self.target_selection, self._env_arange]
+
+  def _update_metrics(self) -> None:
+    self._cached_target_obj_pos = self._target_object_pos_from_sim()
     obj_pos = self._cached_target_obj_pos
     error = torch.norm(self.target_pos - obj_pos, dim=-1)
     at_goal = (error < self.cfg.success_threshold).float()
@@ -218,9 +238,25 @@ class MultiCubeLiftingCommand(CommandTerm):
       velocity = torch.zeros(n, 6, device=self.device)
       cube.write_root_link_pose_to_sim(pose, env_ids=env_ids)
       cube.write_root_link_velocity_to_sim(velocity, env_ids=env_ids)
+    self._pending_forward = True
+
+  def reset(self, env_ids: torch.Tensor | slice | None) -> dict[str, float]:
+    extras = super().reset(env_ids)
+    # Reset-path resamples are followed by the env's own forward(); only
+    # compute-path resamples (timer expiry) need our refresh.
+    self._pending_forward = False
+    return extras
 
   def _update_command(self, env_ids: torch.Tensor | None = None) -> None:
-    pass
+    # Reset-vs-step context is handled via _pending_forward, not env_ids.
+    del env_ids
+    # A timer-expiry resample teleports the cubes after the step's single
+    # forward(); refresh kinematics and the reward-path cache (updated in
+    # _update_metrics before the resample) so both see post-teleport state.
+    if self._pending_forward:
+      self._pending_forward = False
+      self._env.sim.forward()
+      self._cached_target_obj_pos = self._target_object_pos_from_sim()
 
   def _debug_vis_impl(self, visualizer: DebugVisualizer) -> None:
     env_indices = visualizer.get_env_indices(self.num_envs)

--- a/tests/test_manipulation_commands.py
+++ b/tests/test_manipulation_commands.py
@@ -59,7 +59,6 @@ def test_lifting_resample_refreshes_kinematics(device):
   term = cfg.build(env)
 
   term.reset(env_ids=torch.arange(env.num_envs, device=device))
-  assert not term._pending_forward  # Reset path relies on the env's forward.
   env.sim.forward()
 
   counter = term.command_counter.clone()
@@ -78,7 +77,6 @@ def test_multi_cube_resample_refreshes_kinematics_and_cache(device):
   term = cfg.build(env)
 
   term.reset(env_ids=torch.arange(env.num_envs, device=device))
-  assert not term._pending_forward
   env.sim.forward()
 
   counter = term.command_counter.clone()

--- a/tests/test_manipulation_commands.py
+++ b/tests/test_manipulation_commands.py
@@ -1,0 +1,95 @@
+"""Tests for lifting command resample kinematics freshness.
+
+A timer-expiry resample runs inside command compute, after the step's single
+sim.forward(). The commands must refresh kinematics themselves so observations
+and the reward-path cache see post-teleport state.
+"""
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, cast
+
+import pytest
+import torch
+from conftest import get_test_device, make_scene_and_sim
+
+from mjlab.tasks.manipulation.mdp.commands import (
+  LiftingCommandCfg,
+  MultiCubeLiftingCommandCfg,
+)
+
+if TYPE_CHECKING:
+  from mjlab.envs import ManagerBasedRlEnv
+
+CUBE_XML = """
+<mujoco>
+  <worldbody>
+    <body name="cube">
+      <freejoint/>
+      <geom name="cube_geom" type="box" size="0.02 0.02 0.02" mass="0.1"/>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+
+@pytest.fixture(scope="module")
+def device():
+  return get_test_device()
+
+
+def _make_env(device, entity_names):
+  scene, sim = make_scene_and_sim(
+    device, {name: CUBE_XML for name in entity_names}, sensors=(), num_envs=2
+  )
+  env = SimpleNamespace(scene=scene, sim=sim, num_envs=scene.num_envs, device=device)
+  return cast("ManagerBasedRlEnv", env)
+
+
+def _assert_kinematics_fresh(scene, sim, entity_name):
+  """xpos-derived root pos must match qpos after a compute-path resample."""
+  ent = scene[entity_name]
+  q_adr = ent.indexing.free_joint_q_adr
+  qpos_pos = sim.data.qpos[:, q_adr[:3]]
+  assert torch.allclose(ent.data.root_link_pos_w, qpos_pos, atol=1e-6)
+
+
+def test_lifting_resample_refreshes_kinematics(device):
+  env = _make_env(device, ("cube0",))
+  cfg = LiftingCommandCfg(entity_name="cube0", resampling_time_range=(0.001, 0.001))
+  term = cfg.build(env)
+
+  term.reset(env_ids=torch.arange(env.num_envs, device=device))
+  assert not term._pending_forward  # Reset path relies on the env's forward.
+  env.sim.forward()
+
+  counter = term.command_counter.clone()
+  term.compute(dt=1.0)  # Timer (1 ms) expires: teleports the object.
+  assert (term.command_counter > counter).all()
+
+  _assert_kinematics_fresh(env.scene, env.sim, "cube0")
+
+
+def test_multi_cube_resample_refreshes_kinematics_and_cache(device):
+  names = ("cube0", "cube1")
+  env = _make_env(device, names)
+  cfg = MultiCubeLiftingCommandCfg(
+    entity_names=names, resampling_time_range=(0.001, 0.001)
+  )
+  term = cfg.build(env)
+
+  term.reset(env_ids=torch.arange(env.num_envs, device=device))
+  assert not term._pending_forward
+  env.sim.forward()
+
+  counter = term.command_counter.clone()
+  term.compute(dt=1.0)  # Timer (1 ms) expires: teleports all cubes.
+  assert (term.command_counter > counter).all()
+
+  for name in names:
+    _assert_kinematics_fresh(env.scene, env.sim, name)
+
+  # Reward-path cache serves the post-teleport position of the target cube.
+  all_pos = torch.stack([env.scene[n].data.root_link_pos_w for n in names])
+  arange = torch.arange(env.num_envs, device=device)
+  expected = all_pos[term.target_selection, arange]
+  assert torch.allclose(term.target_object_pos(), expected, atol=1e-6)


### PR DESCRIPTION
Timer-expiry resamples teleport the lifting objects after step()'s single sim.forward(), so observations and the multi-cube reward cache saw pre-teleport positions for one step; the commands now run the forward and cache refresh themselves. Tests fail on the previous code.