### PR TITLE
Refresh kinematics before relative pose update in viewer Start Here

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -70,6 +70,9 @@ Changed
 Fixed
 ^^^^^
 
+- The Viser motion scrubber's Start Here button no longer computes relative
+  body poses from stale pre-scrub kinematics, which could spuriously
+  terminate the episode on the next step.
 - ``reset(env_ids=...)`` no longer appends a frame to every env's observation
   history and delay buffers; only the reset envs receive their post-reset
   frame. Previously, each manual partial reset gave the other envs a duplicate

--- a/src/mjlab/tasks/tracking/mdp/commands.py
+++ b/src/mjlab/tasks/tracking/mdp/commands.py
@@ -566,6 +566,9 @@ class MotionCommand(CommandTerm):
       return False
     frame = int(self._scrubber_handles[0].value)
     self.reset_to_frame(env_ids, frame)
+    # reset_to_frame writes qpos/qvel; forward so update_relative_body_poses
+    # reads the scrubbed pose instead of the stale pre-scrub kinematics.
+    self._env.sim.forward()
     self.update_relative_body_poses()
     return True
 

--- a/tests/test_command_manager.py
+++ b/tests/test_command_manager.py
@@ -146,3 +146,17 @@ def test_motion_command_ema_folds_only_on_step_update():
   # Per-step update: EMA folds the counts and clears them.
   assert cmd.bin_failed_count.tolist() == [2.5, 2.5]
   assert cmd._current_bin_failed.tolist() == [0.0, 0.0]
+
+
+def test_motion_command_gui_reset_forwards_before_pose_update():
+  """apply_gui_reset must refresh kinematics between the state write and
+  update_relative_body_poses (viewer forwards only after it returns)."""
+  calls = []
+  cmd = Mock()
+  cmd._scrubber_handles = (Mock(value=5),)
+  cmd.reset_to_frame = lambda ids, frame: calls.append("reset_to_frame")
+  cmd._env.sim.forward = lambda: calls.append("forward")
+  cmd.update_relative_body_poses = lambda: calls.append("update_poses")
+
+  assert MotionCommand.apply_gui_reset(cmd, torch.tensor([0])) is True
+  assert calls == ["reset_to_frame", "forward", "update_poses"]


### PR DESCRIPTION
apply_gui_reset wrote the scrubbed frame's state and then computed relative body poses from pre-scrub kinematics (the viewer only forwards after it returns), which could spuriously terminate on the next step; it now forwards in between.