### PR TITLE
Stop init_velocity_prob from restoring the pre-reset pose

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -79,7 +79,7 @@ Fixed
 - ``UniformVelocityCommand``'s ``init_velocity_prob`` path no longer writes
   the previous episode's terminal pose back into the sim on reset. It read
   derived kinematics before ``forward()`` ran and rewrote the root pose; it
-  now reads qpos/qvel and writes only the root velocity.
+  now reads only qpos for the orientation and writes only the root velocity.
 - ``reset(env_ids=...)`` no longer appends a frame to every env's observation
   history and delay buffers; only the reset envs receive their post-reset
   frame. Previously, each manual partial reset gave the other envs a duplicate

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -76,6 +76,10 @@ Fixed
 - Mid-episode lifting command resamples now refresh kinematics and the
   multi-cube reward cache, so observations and rewards no longer see
   pre-teleport object positions for one step after each resample.
+- ``UniformVelocityCommand``'s ``init_velocity_prob`` path no longer writes
+  the previous episode's terminal pose back into the sim on reset. It read
+  derived kinematics before ``forward()`` ran and rewrote the root pose; it
+  now reads qpos/qvel and writes only the root velocity.
 - ``reset(env_ids=...)`` no longer appends a frame to every env's observation
   history and delay buffers; only the reset envs receive their post-reset
   frame. Previously, each manual partial reset gave the other envs a duplicate

--- a/src/mjlab/entity/data.py
+++ b/src/mjlab/entity/data.py
@@ -115,6 +115,25 @@ class EntityData:
     velocity_qvel = torch.cat([velocity[:, :3], ang_vel_b], dim=-1)
     self.data.qvel[env_ids, self.indexing.free_joint_v_adr] = velocity_qvel
 
+  def write_root_velocity_b(
+    self, velocity_b: torch.Tensor, env_ids: torch.Tensor | slice | None = None
+  ) -> None:
+    """Write the root link velocity given in the root link's body frame.
+
+    The orientation is read from qpos, so this is safe to call during a reset
+    before forward() has refreshed derived kinematics.
+    """
+    if self.is_fixed_base:
+      raise ValueError("Cannot write root velocity for fixed-base entity.")
+    assert velocity_b.shape[-1] == self.ROOT_VEL_DIM
+
+    env_ids = self._resolve_env_ids(env_ids)
+    quat_w = self.data.qpos[env_ids, self.indexing.free_joint_q_adr[3:7]]
+    lin_vel_w = quat_apply(quat_w, velocity_b[:, :3])
+    # Free joint qvel holds world-frame linear and body-frame angular velocity.
+    velocity_qvel = torch.cat([lin_vel_w, velocity_b[:, 3:]], dim=-1)
+    self.data.qvel[env_ids, self.indexing.free_joint_v_adr] = velocity_qvel
+
   def write_root_com_velocity(
     self, velocity: torch.Tensor, env_ids: torch.Tensor | slice | None = None
   ) -> None:

--- a/src/mjlab/entity/entity.py
+++ b/src/mjlab/entity/entity.py
@@ -946,6 +946,24 @@ class Entity:
     """
     self._data.write_root_velocity(root_velocity, env_ids)
 
+  def write_root_link_velocity_b_to_sim(
+    self,
+    root_velocity_b: torch.Tensor,
+    env_ids: torch.Tensor | slice | None = None,
+  ):
+    """Like `write_root_link_velocity_to_sim()` but the velocity is expressed
+    in the root link's body frame. Reads the orientation from qpos, so it is
+    safe to call during a reset before forward() runs.
+
+    Args:
+      root_velocity_b: Tensor of shape (N, 6) where N is the number of
+        environments. Contains linear velocity (3) at body origin and angular
+        velocity (3), both in the root link's body frame.
+      env_ids: Optional tensor or slice specifying which environments to set. If
+        None, all environments are set.
+    """
+    self._data.write_root_velocity_b(root_velocity_b, env_ids)
+
   def write_root_com_velocity_to_sim(
     self,
     root_velocity: torch.Tensor,

--- a/src/mjlab/tasks/velocity/mdp/velocity_command.py
+++ b/src/mjlab/tasks/velocity/mdp/velocity_command.py
@@ -11,7 +11,6 @@ from mjlab.entity import Entity
 from mjlab.managers.command_manager import CommandTerm, CommandTermCfg
 from mjlab.utils.lab_api.math import (
   matrix_from_quat,
-  quat_apply,
   wrap_to_pi,
 )
 
@@ -101,17 +100,15 @@ class UniformVelocityCommand(CommandTerm):
     init_vel_mask = r.uniform_(0.0, 1.0) < self.cfg.init_velocity_prob
     init_vel_env_ids = env_ids[init_vel_mask]
     if len(init_vel_env_ids) > 0:
-      root_pos = self.robot.data.root_link_pos_w[init_vel_env_ids]
-      root_quat = self.robot.data.root_link_quat_w[init_vel_env_ids]
-      lin_vel_b = self.robot.data.root_link_lin_vel_b[init_vel_env_ids]
-      lin_vel_b[:, :2] = self.vel_command_b[init_vel_env_ids, :2]
-      root_lin_vel_w = quat_apply(root_quat, lin_vel_b)
-      root_ang_vel_b = self.robot.data.root_link_ang_vel_b[init_vel_env_ids]
-      root_ang_vel_b[:, 2] = self.vel_command_b[init_vel_env_ids, 2]
-      root_state = torch.cat(
-        [root_pos, root_quat, root_lin_vel_w, root_ang_vel_b], dim=-1
-      )
-      self.robot.write_root_state_to_sim(root_state, init_vel_env_ids)
+      # Start these envs already moving at the commanded planar velocity. The
+      # body-frame write reads its orientation from qpos, so it is safe here:
+      # during a reset the events have written the new pose but forward() has
+      # not run, and derived kinematics still hold the previous episode's
+      # terminal state. The freshly reset pose is untouched.
+      vel_b = torch.zeros(len(init_vel_env_ids), 6, device=self.device)
+      vel_b[:, :2] = self.vel_command_b[init_vel_env_ids, :2]
+      vel_b[:, 5] = self.vel_command_b[init_vel_env_ids, 2]
+      self.robot.write_root_link_velocity_b_to_sim(vel_b, env_ids=init_vel_env_ids)
 
   def _update_command(self, env_ids: torch.Tensor | None = None) -> None:
     # Pure function of the current state; refreshing all envs is safe.

--- a/tests/test_velocity_command.py
+++ b/tests/test_velocity_command.py
@@ -1,0 +1,73 @@
+"""Tests for the velocity command's initial-velocity injection.
+
+The init_velocity_prob path runs inside the reset pipeline, after reset
+events wrote the new pose to qpos but before sim.forward(), so it must not
+read (or write back) derived kinematics.
+"""
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, cast
+
+import pytest
+import torch
+from conftest import get_test_device, load_fixture_xml, make_scene_and_sim
+
+from mjlab.tasks.velocity.mdp.velocity_command import UniformVelocityCommandCfg
+
+if TYPE_CHECKING:
+  from mjlab.envs import ManagerBasedRlEnv
+
+
+@pytest.fixture(scope="module")
+def device():
+  return get_test_device()
+
+
+def test_init_velocity_preserves_fresh_reset_pose(device):
+  scene, sim = make_scene_and_sim(
+    device, load_fixture_xml("floating_base_articulated"), sensors=(), num_envs=2
+  )
+  env = cast(
+    "ManagerBasedRlEnv",
+    SimpleNamespace(scene=scene, sim=sim, num_envs=2, device=device),
+  )
+  cfg = UniformVelocityCommandCfg(
+    entity_name="robot",
+    resampling_time_range=(1e9, 1e9),
+    init_velocity_prob=1.0,
+    rel_heading_envs=0.0,
+    ranges=UniformVelocityCommandCfg.Ranges(
+      lin_vel_x=(0.5, 0.5), lin_vel_y=(0.2, 0.2), ang_vel_z=(0.0, 0.0)
+    ),
+  )
+  term = cfg.build(env)
+  robot = scene["robot"]
+  env_ids = torch.arange(2, device=device)
+
+  # Derived kinematics now hold the spawn pose (the "previous episode" state).
+  sim.forward()
+
+  # Emulate a reset event: write a fresh pose to qpos, no forward yet.
+  pose = torch.tensor(
+    [
+      [1.0, 2.0, 1.5, 1.0, 0.0, 0.0, 0.0],
+      [3.0, -1.0, 1.5, 1.0, 0.0, 0.0, 0.0],
+    ],
+    device=device,
+  )
+  robot.write_root_link_pose_to_sim(pose, env_ids=env_ids)
+
+  term.reset(env_ids=env_ids)
+  sim.forward()
+
+  # The fresh reset pose survives. Before the fix, the init-velocity path
+  # wrote the stale pre-reset pose back into the sim.
+  assert torch.allclose(robot.data.root_link_pos_w, pose[:, :3], atol=1e-6)
+
+  # Planar velocity matches the sampled command (identity orientation, so
+  # body frame equals world frame).
+  assert torch.allclose(
+    robot.data.root_link_lin_vel_b[:, :2],
+    term.vel_command_b[:, :2],
+    atol=1e-5,
+  )


### PR DESCRIPTION
The velocity command's init_velocity_prob path runs during reset, before forward(), but read the root pose from derived kinematics (still the previous episode's terminal state) and wrote it back, clobbering the freshly randomized reset pose. It now performs no state reads at all: a new Entity.write_root_link_velocity_b_to_sim takes the commanded velocity in the body frame and reads its orientation from qpos internally, like the existing velocity write path. Latent today since init_velocity_prob defaults to 0. Test fails on the previous code.