### PR TITLE
Harden latent staleness and indexing traps from the bug hunt

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -80,6 +80,17 @@ Fixed
   the previous episode's terminal pose back into the sim on reset. It read
   derived kinematics before ``forward()`` ran and rewrote the root pose; it
   now reads only qpos for the orientation and writes only the root velocity.
+- ``Entity.set_joint_position_target`` and its velocity/effort/tendon/site
+  siblings now select the outer product when both ``env_ids`` and the element
+  ids are tensors, instead of pairing them elementwise.
+- ``MotionCommand`` now refreshes kinematics after a timer-expiry resample
+  (finite ``resampling_time_range``), matching its wraparound path.
+- ``CircularBuffer`` lag retrieval now clamps to the oldest retained frame;
+  a lag beyond the buffer length used to wrap around to a newer frame.
+- Camera sensor caches are now invalidated after ``sense()``, so a
+  pre-sense read with ``clone_data=True`` can no longer pin the previous
+  step's frame into the observations (mirrors the raycast fix for
+  :issue:`998`).
 - ``reset(env_ids=...)`` no longer appends a frame to every env's observation
   history and delay buffers; only the reset envs receive their post-reset
   frame. Previously, each manual partial reset gave the other envs a duplicate

--- a/src/mjlab/entity/entity.py
+++ b/src/mjlab/entity/entity.py
@@ -68,6 +68,19 @@ class EntityIndexing:
     return self.bodies[0].id
 
 
+def _outer_index(
+  env_ids: torch.Tensor | slice, ids: torch.Tensor | slice
+) -> tuple[torch.Tensor | slice, torch.Tensor | slice]:
+  """Make [env_ids, ids] select the outer product when both are tensors.
+
+  Plain [tensor, tensor] indexing pairs the ids elementwise, which silently
+  writes a diagonal whenever the shapes happen to broadcast.
+  """
+  if isinstance(env_ids, torch.Tensor) and isinstance(ids, torch.Tensor):
+    return env_ids[:, None], ids
+  return env_ids, ids
+
+
 @dataclass
 class EntityCfg:
   @dataclass
@@ -1055,6 +1068,7 @@ class Entity:
       env_ids = slice(None)
     if joint_ids is None:
       joint_ids = slice(None)
+    env_ids, joint_ids = _outer_index(env_ids, joint_ids)
     self._data.joint_pos_target[env_ids, joint_ids] = position
 
   def set_joint_velocity_target(
@@ -1074,6 +1088,7 @@ class Entity:
       env_ids = slice(None)
     if joint_ids is None:
       joint_ids = slice(None)
+    env_ids, joint_ids = _outer_index(env_ids, joint_ids)
     self._data.joint_vel_target[env_ids, joint_ids] = velocity
 
   def set_joint_effort_target(
@@ -1093,6 +1108,7 @@ class Entity:
       env_ids = slice(None)
     if joint_ids is None:
       joint_ids = slice(None)
+    env_ids, joint_ids = _outer_index(env_ids, joint_ids)
     self._data.joint_effort_target[env_ids, joint_ids] = effort
 
   def set_tendon_len_target(
@@ -1112,6 +1128,7 @@ class Entity:
       env_ids = slice(None)
     if tendon_ids is None:
       tendon_ids = slice(None)
+    env_ids, tendon_ids = _outer_index(env_ids, tendon_ids)
     self._data.tendon_len_target[env_ids, tendon_ids] = length
 
   def set_tendon_vel_target(
@@ -1131,6 +1148,7 @@ class Entity:
       env_ids = slice(None)
     if tendon_ids is None:
       tendon_ids = slice(None)
+    env_ids, tendon_ids = _outer_index(env_ids, tendon_ids)
     self._data.tendon_vel_target[env_ids, tendon_ids] = velocity
 
   def set_tendon_effort_target(
@@ -1150,6 +1168,7 @@ class Entity:
       env_ids = slice(None)
     if tendon_ids is None:
       tendon_ids = slice(None)
+    env_ids, tendon_ids = _outer_index(env_ids, tendon_ids)
     self._data.tendon_effort_target[env_ids, tendon_ids] = effort
 
   def set_site_effort_target(
@@ -1169,6 +1188,7 @@ class Entity:
       env_ids = slice(None)
     if site_ids is None:
       site_ids = slice(None)
+    env_ids, site_ids = _outer_index(env_ids, site_ids)
     self._data.site_effort_target[env_ids, site_ids] = effort
 
   def write_external_wrench_to_sim(

--- a/src/mjlab/envs/manager_based_rl_env.py
+++ b/src/mjlab/envs/manager_based_rl_env.py
@@ -408,11 +408,16 @@ class ManagerBasedRlEnv:
 
     .. note::
 
-      Event and command authors do not need to call ``sim.forward()`` themselves.
-      This method handles it. The only constraint is: do not read derived quantities
-      (``root_link_pose_w``, ``body_link_vel_w``, etc.) in the same function that
-      writes state (``write_root_state_to_sim``, ``write_joint_state_to_sim``,
-      etc.). See :ref:`faq` for details.
+      Reset-mode events and reset-path command resamples do not need to call
+      ``sim.forward()`` themselves; the single call above runs after them. Step
+      and interval events and command updates run *after* that call, so if they
+      write sim state they must refresh derived quantities themselves (see
+      ``MotionCommand._update_command``), and a plain state write (e.g. a
+      velocity push) is visible to qpos/qvel-backed reads this step but to
+      derived quantities only next step. In all cases, do not read derived
+      quantities (``root_link_pose_w``, ``body_link_vel_w``, etc.) in the same
+      function that writes state (``write_root_state_to_sim``,
+      ``write_joint_state_to_sim``, etc.). See :ref:`faq` for details.
     """
     if not self.cfg.auto_reset and torch.any(self._manual_reset_pending):
       pending_ids = self._manual_reset_pending.nonzero(as_tuple=False).squeeze(-1)

--- a/src/mjlab/sensor/sensor_context.py
+++ b/src/mjlab/sensor/sensor_context.py
@@ -119,6 +119,11 @@ class SensorContext:
     """Post-graph: compute raycast hit positions."""
     for sensor in self.raycast_sensors:
       sensor.postprocess_rays()
+    # Fresh render results: drop camera data cached by a pre-sense read so
+    # observations serve this step's frames (mirrors the raycast
+    # invalidation in postprocess_rays).
+    for sensor in self.camera_sensors:
+      sensor._invalidate_cache()
 
   def get_rgb(self, cam_idx: int) -> torch.Tensor:
     """Get unpacked RGB data for a camera.

--- a/src/mjlab/tasks/tracking/mdp/commands.py
+++ b/src/mjlab/tasks/tracking/mdp/commands.py
@@ -121,6 +121,7 @@ class MotionCommand(CommandTerm):
 
     self._ghost_model = None
     self._ghost_color = np.array(cfg.viz.ghost_color, dtype=np.float32)
+    self._pending_forward = False
 
   @property
   def command(self) -> torch.Tensor:
@@ -373,6 +374,7 @@ class MotionCommand(CommandTerm):
       joint_pos,
       joint_vel,
     )
+    self._pending_forward = True
 
   def update_relative_body_poses(self) -> None:
     """Recompute ``body_pos_relative_w`` and ``body_quat_relative_w``.
@@ -404,6 +406,13 @@ class MotionCommand(CommandTerm):
       delta_ori_w, self.body_pos_w - anchor_pos_w_repeat
     )
 
+  def reset(self, env_ids: torch.Tensor | slice | None) -> dict[str, float]:
+    extras = super().reset(env_ids)
+    # Reset-path resamples are followed by the env's own forward(); only
+    # compute-path resamples (wraparound or timer expiry) need our refresh.
+    self._pending_forward = False
+    return extras
+
   def _update_command(self, env_ids: torch.Tensor | None = None):
     if env_ids is None:
       self.time_steps += 1
@@ -412,9 +421,14 @@ class MotionCommand(CommandTerm):
     wrap_ids = torch.where(self.time_steps >= self.motion.time_step_total)[0]
     if wrap_ids.numel() > 0:
       self._resample_command(wrap_ids)
-      # _resample_command writes qpos/qvel but does not refresh derived
-      # quantities; forward() so update_relative_body_poses reads the
-      # post-teleport robot anchor instead of the stale pre-resample pose.
+
+    # _resample_command writes qpos/qvel but does not refresh derived
+    # quantities; forward() so update_relative_body_poses reads the
+    # post-teleport robot anchor instead of the stale pre-resample pose.
+    # Covers both the wraparound above and a timer-expiry resample that ran
+    # in compute before this call.
+    if self._pending_forward:
+      self._pending_forward = False
       self._env.sim.forward()
 
     self.update_relative_body_poses()

--- a/src/mjlab/utils/buffers/circular_buffer.py
+++ b/src/mjlab/utils/buffers/circular_buffer.py
@@ -256,8 +256,12 @@ class CircularBuffer:
     if key.numel() != self._batch_size:
       raise ValueError(f"Expected {self._batch_size} lags, got {key.numel()}")
 
+    # Clamp to the oldest retained frame: without the max_len bound, a lag
+    # beyond the buffer length would wrap around to a newer frame once
+    # num_pushes exceeds max_len.
     pushes = self._num_pushes.clamp_min(1)
-    valid = torch.minimum(key, pushes - 1).clamp_min(0)
+    max_lag = torch.minimum(pushes, self._max_len_tensor) - 1
+    valid = torch.minimum(key, max_lag).clamp_min(0)
 
     idx = torch.remainder(self._pointer - valid, self._max_len)
     return self._buffer[idx, self._all_indices]

--- a/tests/test_circular_buffer.py
+++ b/tests/test_circular_buffer.py
@@ -253,3 +253,16 @@ def test_backfill_uninitialized_raises(device):
   buffer = CircularBuffer(max_len=2, batch_size=2, device=device)
   with pytest.raises(RuntimeError, match="not initialized"):
     buffer.backfill(torch.zeros(2, 1, device=device), torch.tensor([0], device=device))
+
+
+def test_getitem_lag_clamps_to_oldest_after_wrap(device):
+  buffer = CircularBuffer(max_len=2, batch_size=1, device=device)
+  for v in [1.0, 2.0, 3.0]:
+    buffer.append(torch.tensor([[v]], device=device))
+
+  # Retained frames: [2, 3] (num_pushes exceeds max_len).
+  assert buffer[torch.tensor([0], device=device)].flatten().item() == 3.0
+  assert buffer[torch.tensor([1], device=device)].flatten().item() == 2.0
+  # A lag beyond the retained history clamps to the oldest frame instead of
+  # wrapping around to a newer one.
+  assert buffer[torch.tensor([2], device=device)].flatten().item() == 2.0

--- a/tests/test_command_manager.py
+++ b/tests/test_command_manager.py
@@ -110,6 +110,10 @@ def _make_motion_command_stub(time_steps, total, sampling_mode="uniform"):
   cmd.cfg.adaptive_alpha = 0.5
   cmd.bin_failed_count = torch.tensor([1.0, 1.0])
   cmd._current_bin_failed = torch.tensor([4.0, 4.0])
+  cmd._pending_forward = False
+  cmd._resample_command = Mock(
+    side_effect=lambda ids: setattr(cmd, "_pending_forward", True)
+  )
   return cmd
 
 
@@ -160,3 +164,16 @@ def test_motion_command_gui_reset_forwards_before_pose_update():
 
   assert MotionCommand.apply_gui_reset(cmd, torch.tensor([0])) is True
   assert calls == ["reset_to_frame", "forward", "update_poses"]
+
+
+def test_motion_command_timer_resample_triggers_forward():
+  """A timer-expiry resample (flag set before _update_command) forwards."""
+  cmd = _make_motion_command_stub([2, 5], total=100)
+  cmd._pending_forward = True  # As set by a compute-path _resample_command.
+  MotionCommand._update_command(cmd, env_ids=None)
+  cmd._env.sim.forward.assert_called_once()
+  assert cmd._pending_forward is False
+
+  cmd._env.sim.forward.reset_mock()
+  MotionCommand._update_command(cmd, env_ids=None)
+  cmd._env.sim.forward.assert_not_called()

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -854,3 +854,17 @@ def test_wildcard_warns_about_unactuated_namespaces():
   )
   with pytest.warns(match="also match.*tendon"):
     Entity(cfg)
+
+
+def test_set_joint_position_target_outer_product(device):
+  """Tensor env_ids + tensor joint_ids select the outer product, not a diagonal."""
+  entity = create_fixed_articulated_entity()
+  entity, _ = initialize_entity_with_sim(entity, device, num_envs=2)
+
+  targets = torch.tensor([[1.0, 2.0], [3.0, 4.0]], device=device)
+  entity.set_joint_position_target(
+    targets,
+    joint_ids=torch.tensor([0, 1], device=device),
+    env_ids=torch.tensor([0, 1], device=device),
+  )
+  assert torch.equal(entity.data.joint_pos_target, targets)


### PR DESCRIPTION
Four small fixes for latent traps found during the partial-reset bug hunt, none currently reachable through shipped configs:

- Entity target setters (`set_joint_position_target` and siblings) indexed `[env_ids, ids]`, which pairs two tensors elementwise instead of taking the outer product; they now index the way `EntityData`'s write path already does.
- `MotionCommand` with a finite `resampling_time_range` teleported the robot on timer expiry without the `sim.forward()` its wraparound path has; both paths now share one pending-forward refresh.
- `CircularBuffer` lag retrieval wrapped around to a *newer* frame for lags beyond the buffer length; it now clamps to the oldest retained frame.
- Camera sensor caches are invalidated after `sense()` like raycast caches (#998), so a pre-sense read with `clone_data=True` can't serve last step's frame.

Also rewrites the `step()` docstring note that claimed event authors never need `sim.forward()`: that's only true for reset-mode events. Tests fail on the previous code.