### PR TITLE
Apply init_velocity_prob on episode reset only

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -80,6 +80,9 @@ Fixed
   the previous episode's terminal pose back into the sim on reset. It read
   derived kinematics before ``forward()`` ran and rewrote the root pose; it
   now reads only qpos for the orientation and writes only the root velocity.
+- ``init_velocity_prob`` now applies on episode reset only. A mid-episode
+  timer resample used to also teleport the root velocity, which ran after
+  ``step()``'s forward and left velocity observations stale for one step.
 - ``Entity.set_joint_position_target`` and its velocity/effort/tendon/site
   siblings now select the outer product when both ``env_ids`` and the element
   ids are tensors, instead of pairing them elementwise.

--- a/src/mjlab/tasks/velocity/mdp/velocity_command.py
+++ b/src/mjlab/tasks/velocity/mdp/velocity_command.py
@@ -97,18 +97,20 @@ class UniformVelocityCommand(CommandTerm):
       self.vel_command_b[fwd_ids, 1] = 0.0
       self.vel_command_b[fwd_ids, 2] = 0.0
 
-    init_vel_mask = r.uniform_(0.0, 1.0) < self.cfg.init_velocity_prob
-    init_vel_env_ids = env_ids[init_vel_mask]
-    if len(init_vel_env_ids) > 0:
-      # Start these envs already moving at the commanded planar velocity. The
-      # body-frame write reads its orientation from qpos, so it is safe here:
-      # during a reset the events have written the new pose but forward() has
-      # not run, and derived kinematics still hold the previous episode's
-      # terminal state. The freshly reset pose is untouched.
-      vel_b = torch.zeros(len(init_vel_env_ids), 6, device=self.device)
-      vel_b[:, :2] = self.vel_command_b[init_vel_env_ids, :2]
-      vel_b[:, 5] = self.vel_command_b[init_vel_env_ids, 2]
-      self.robot.write_root_link_velocity_b_to_sim(vel_b, env_ids=init_vel_env_ids)
+  def reset(self, env_ids: torch.Tensor | slice | None) -> dict[str, float]:
+    extras = super().reset(env_ids)
+    if self.cfg.init_velocity_prob > 0.0:
+      assert isinstance(env_ids, torch.Tensor)
+      r = torch.empty(len(env_ids), device=self.device)
+      init_ids = env_ids[r.uniform_(0.0, 1.0) < self.cfg.init_velocity_prob]
+      if len(init_ids) > 0:
+        # Start these envs already moving at the commanded planar velocity.
+        # Safe pre-forward: the body-frame write reads orientation from qpos.
+        vel_b = torch.zeros(len(init_ids), 6, device=self.device)
+        vel_b[:, :2] = self.vel_command_b[init_ids, :2]
+        vel_b[:, 5] = self.vel_command_b[init_ids, 2]
+        self.robot.write_root_link_velocity_b_to_sim(vel_b, env_ids=init_ids)
+    return extras
 
   def _update_command(self, env_ids: torch.Tensor | None = None) -> None:
     # Pure function of the current state; refreshing all envs is safe.
@@ -292,6 +294,8 @@ class UniformVelocityCommandCfg(CommandTermCfg):
   lin_vel_x, zero lin_vel_y and ang_vel_z). Increases training coverage for
   straight-line walking, which is important for stair climbing."""
   init_velocity_prob: float = 0.0
+  """Probability that an env starts its episode already moving at its sampled
+  planar command velocity. Applied on reset only."""
 
   @dataclass
   class Ranges:

--- a/tests/test_velocity_command.py
+++ b/tests/test_velocity_command.py
@@ -71,3 +71,50 @@ def test_init_velocity_preserves_fresh_reset_pose(device):
     term.vel_command_b[:, :2],
     atol=1e-5,
   )
+
+
+def test_mid_episode_resample_does_not_write_velocity(device):
+  """Init velocity applies on reset only; a timer-expiry resample runs after
+  step()'s forward and must not write sim state."""
+  scene, sim = make_scene_and_sim(
+    device, load_fixture_xml("floating_base_articulated"), sensors=(), num_envs=2
+  )
+  env = cast(
+    "ManagerBasedRlEnv",
+    SimpleNamespace(scene=scene, sim=sim, num_envs=2, device=device, step_dt=0.02),
+  )
+  cfg = UniformVelocityCommandCfg(
+    entity_name="robot",
+    resampling_time_range=(0.001, 0.001),  # Expires on the first compute.
+    init_velocity_prob=1.0,
+    rel_heading_envs=0.0,
+    ranges=UniformVelocityCommandCfg.Ranges(
+      lin_vel_x=(0.7, 0.7), lin_vel_y=(0.3, 0.3), ang_vel_z=(0.0, 0.0)
+    ),
+  )
+  term = cfg.build(env)
+  robot = scene["robot"]
+  env_ids = torch.arange(2, device=device)
+
+  term.reset(env_ids=env_ids)
+  sim.forward()
+
+  # Mid-episode the robot has decelerated to rest.
+  robot.write_root_link_velocity_to_sim(
+    torch.zeros(2, 6, device=device), env_ids=env_ids
+  )
+  sim.forward()
+
+  # Step's command compute: the 1 ms timer expires and resamples.
+  counter = term.command_counter.clone()
+  term.compute(dt=1.0)
+  assert (term.command_counter > counter).all()
+
+  # Only the command changed; sim velocity is untouched.
+  qvel_lin = sim.data.qvel[:, robot.indexing.free_joint_v_adr[:3]]
+  assert torch.allclose(qvel_lin, torch.zeros_like(qvel_lin), atol=1e-6)
+  assert torch.allclose(
+    robot.data.root_link_lin_vel_b,
+    torch.zeros_like(robot.data.root_link_lin_vel_b),
+    atol=1e-6,
+  )


### PR DESCRIPTION
Mid-episode timer resamples also teleported the root velocity, after step()'s single forward, leaving cvel-derived velocity observations stale for one step; the init-velocity write now runs only in reset(), where the env's own forward follows. Test fails on the previous code.