### PR TITLE
Clean up OffscreenRenderer and ViewerConfig

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -18,6 +18,8 @@ Upcoming version (not yet released)
      parameter (construction raises a ``TypeError`` with migration
      instructions otherwise) and scope any per-step state advance, such as
      a motion frame index, to ``env_ids``.
+   - ``ViewerConfig`` is now keyword-only; positional construction no
+     longer works.
 
 .. admonition:: Highlights
    :class: note
@@ -47,6 +49,10 @@ Added
 - Added ``reduce="sum"`` to ``MetricsTermCfg`` for reporting the accumulated
   episode total (e.g. episodic reward, total distance traveled) instead of a
   per-step average. Contribution by @bd-mlutter
+- Added ``ViewerConfig.geom_group`` and ``ViewerConfig.site_group`` to
+  control which geom and site visualization groups the offscreen renderer
+  draws. Defaults match MuJoCo's (groups 0 through 2), so rendering is
+  unchanged unless configured. Contribution by @bd-mlutter.
 - Added ``dr.mat_texid`` to randomize which texture fills a given
   ``mjtTextureRole`` slot (RGB by default) of each selected material,
   sampling uniformly from ``asset_cfg.texture_names``. Contribution by
@@ -66,6 +72,15 @@ Changed
 - Changed the default MuJoCo Warp render background to solid black
   (``0, 0, 0, 1``), matching MuJoCo's native renderer. Contribution by
   @bd-pmorais.
+- The offscreen renderer now works on a copy of the ``MjModel``, so its
+  render-only tweaks (extent, shadows, reflections, offscreen size) no
+  longer leak into the shared model. Contribution by @bd-mlutter.
+- ``ViewerConfig`` is now keyword-only, with fields grouped and documented.
+  Contribution by @bd-mlutter.
+- ``ViewerConfig.fovy`` now also applies to the ``ASSET_ROOT`` and
+  ``ASSET_BODY`` tracking cameras instead of being silently ignored; leave
+  it at ``None`` (the default) to keep the model value. Contribution by
+  @bd-mlutter.
 
 Fixed
 ^^^^^

--- a/src/mjlab/viewer/native/visualizer.py
+++ b/src/mjlab/viewer/native/visualizer.py
@@ -31,17 +31,22 @@ class MujocoNativeDebugVisualizer(DebugVisualizer):
       env_idx: Index of the environment being visualized
       show_all_envs: If True, visualize all environments instead of just env_idx
     """
-    self.scn = scn
-    self.mj_model = mj_model
+    # DebugVisualizer interface.
     self.env_idx = env_idx
     self.show_all_envs = show_all_envs
+
+    self._mjv_scene = scn
     self._initial_geom_count = scn.ngeom
     self._meansize: float = mj_model.stat.meansize
 
+    # State used only by the ghost visualization. The model is a shared
+    # reference and must not be modified; ghost transparency is controlled
+    # through the mjVIS_TRANSPARENT flag rather than per-geom alpha.
+    self._ref_mj_model = mj_model
+    self._mj_data = mujoco.MjData(mj_model)
     self._vopt = mujoco.MjvOption()
     self._vopt.flags[mujoco.mjtVisFlag.mjVIS_TRANSPARENT] = True
     self._pert = mujoco.MjvPerturb()
-    self._viz_data = mujoco.MjData(mj_model)
 
   @property
   @override
@@ -60,8 +65,8 @@ class MujocoNativeDebugVisualizer(DebugVisualizer):
     """Add an arrow visualization using MuJoCo's arrow geometry."""
     del label  # Unused.
 
-    self.scn.ngeom += 1
-    geom = self.scn.geoms[self.scn.ngeom - 1]
+    self._mjv_scene.ngeom += 1
+    geom = self._mjv_scene.geoms[self._mjv_scene.ngeom - 1]
     geom.category = mujoco.mjtCatBit.mjCAT_DECOR
 
     mujoco.mjv_initGeom(
@@ -96,7 +101,9 @@ class MujocoNativeDebugVisualizer(DebugVisualizer):
 
     Args:
       qpos: Joint positions for the ghost pose
-      model: MuJoCo model with pre-configured appearance (geom_rgba for colors)
+      model: MuJoCo model with pre-configured appearance (geom_rgba for colors).
+        Must be structurally identical to the model this visualizer was
+        created with, since it is evaluated against the internal MjData.
       mocap_pos: Optional mocap position(s) for fixed-base entities
       mocap_quat: Optional mocap quaternion(s) for fixed-base entities
       alpha: Transparency override (not used in MuJoCo implementation)
@@ -104,28 +111,28 @@ class MujocoNativeDebugVisualizer(DebugVisualizer):
     """
     del alpha, label  # Unused.
 
-    self._viz_data.qpos[:] = qpos
+    self._mj_data.qpos[:] = qpos
     if mocap_pos is not None and model.nmocap > 0:
       mocap_pos_arr = np.asarray(mocap_pos)
       if mocap_pos_arr.ndim == 1:
-        self._viz_data.mocap_pos[0] = mocap_pos_arr
+        self._mj_data.mocap_pos[0] = mocap_pos_arr
       else:
-        self._viz_data.mocap_pos[:] = mocap_pos_arr
+        self._mj_data.mocap_pos[:] = mocap_pos_arr
     if mocap_quat is not None and model.nmocap > 0:
       mocap_quat_arr = np.asarray(mocap_quat)
       if mocap_quat_arr.ndim == 1:
-        self._viz_data.mocap_quat[0] = mocap_quat_arr
+        self._mj_data.mocap_quat[0] = mocap_quat_arr
       else:
-        self._viz_data.mocap_quat[:] = mocap_quat_arr
-    mujoco.mj_forward(model, self._viz_data)
+        self._mj_data.mocap_quat[:] = mocap_quat_arr
+    mujoco.mj_forward(model, self._mj_data)
 
     mujoco.mjv_addGeoms(
       model,
-      self._viz_data,
+      self._mj_data,
       self._vopt,
       self._pert,
       mujoco.mjtCatBit.mjCAT_DYNAMIC.value,
-      self.scn,
+      self._mjv_scene,
     )
 
   @override
@@ -168,8 +175,8 @@ class MujocoNativeDebugVisualizer(DebugVisualizer):
     """Add a sphere visualization using MuJoCo's sphere geometry."""
     del label  # Unused.
 
-    self.scn.ngeom += 1
-    geom = self.scn.geoms[self.scn.ngeom - 1]
+    self._mjv_scene.ngeom += 1
+    geom = self._mjv_scene.geoms[self._mjv_scene.ngeom - 1]
     geom.category = mujoco.mjtCatBit.mjCAT_DECOR
 
     mujoco.mjv_initGeom(
@@ -193,8 +200,8 @@ class MujocoNativeDebugVisualizer(DebugVisualizer):
     """Add a cylinder visualization using MuJoCo's cylinder connector."""
     del label  # Unused.
 
-    self.scn.ngeom += 1
-    geom = self.scn.geoms[self.scn.ngeom - 1]
+    self._mjv_scene.ngeom += 1
+    geom = self._mjv_scene.geoms[self._mjv_scene.ngeom - 1]
     geom.category = mujoco.mjtCatBit.mjCAT_DECOR
 
     mujoco.mjv_initGeom(
@@ -225,8 +232,8 @@ class MujocoNativeDebugVisualizer(DebugVisualizer):
     """Add an ellipsoid visualization using MuJoCo's ellipsoid geometry."""
     del label  # Unused.
 
-    self.scn.ngeom += 1
-    geom = self.scn.geoms[self.scn.ngeom - 1]
+    self._mjv_scene.ngeom += 1
+    geom = self._mjv_scene.geoms[self._mjv_scene.ngeom - 1]
     geom.category = mujoco.mjtCatBit.mjCAT_DECOR
 
     mujoco.mjv_initGeom(
@@ -250,8 +257,8 @@ class MujocoNativeDebugVisualizer(DebugVisualizer):
     """Add a box visualization using MuJoCo's box geometry."""
     del label  # Unused.
 
-    self.scn.ngeom += 1
-    geom = self.scn.geoms[self.scn.ngeom - 1]
+    self._mjv_scene.ngeom += 1
+    geom = self._mjv_scene.geoms[self._mjv_scene.ngeom - 1]
     geom.category = mujoco.mjtCatBit.mjCAT_DECOR
 
     mujoco.mjv_initGeom(
@@ -266,4 +273,4 @@ class MujocoNativeDebugVisualizer(DebugVisualizer):
   @override
   def clear(self) -> None:
     """Clear debug visualizations by resetting geom count."""
-    self.scn.ngeom = self._initial_geom_count
+    self._mjv_scene.ngeom = self._initial_geom_count

--- a/src/mjlab/viewer/offscreen_renderer.py
+++ b/src/mjlab/viewer/offscreen_renderer.py
@@ -80,10 +80,7 @@ class OffscreenRenderer:
 
     self._model.vis.global_.offheight = cfg.height
     self._model.vis.global_.offwidth = cfg.width
-    if cfg.fovy is not None and cfg.origin_type in (
-      cfg.OriginType.AUTO,
-      cfg.OriginType.WORLD,
-    ):
+    if cfg.fovy is not None:
       self._model.vis.global_.fovy = cfg.fovy
 
     if not cfg.enable_shadows:

--- a/src/mjlab/viewer/offscreen_renderer.py
+++ b/src/mjlab/viewer/offscreen_renderer.py
@@ -96,6 +96,8 @@ class OffscreenRenderer:
 
     self._renderer: mujoco.Renderer | None = None
     self._opt = mujoco.MjvOption()
+    self._opt.geomgroup[:] = np.array(cfg.geom_group, dtype=np.uint8)
+    self._opt.sitegroup[:] = np.array(cfg.site_group, dtype=np.uint8)
     self._pert = mujoco.MjvPerturb()
     self._catmask = mujoco.mjtCatBit.mjCAT_DYNAMIC
 
@@ -139,7 +141,7 @@ class OffscreenRenderer:
     self._sync_data_fields(data, primary_env)
 
     cam = camera if camera is not None else self._cam
-    self._renderer.update_scene(self._data, camera=cam)
+    self._renderer.update_scene(self._data, camera=cam, scene_option=self._opt)
 
     # Note: update_scene() resets the scene each frame, so no need to manually clear.
     if debug_vis_callback is not None:

--- a/src/mjlab/viewer/offscreen_renderer.py
+++ b/src/mjlab/viewer/offscreen_renderer.py
@@ -6,6 +6,7 @@ from typing import Any, Callable
 import mujoco
 import numpy as np
 
+from mjlab.entity import Entity
 from mjlab.scene import Scene
 from mjlab.viewer.model_sync import (
   VIEWER_MODEL_FIELDS,
@@ -14,6 +15,41 @@ from mjlab.viewer.model_sync import (
 )
 from mjlab.viewer.native.visualizer import MujocoNativeDebugVisualizer
 from mjlab.viewer.viewer_config import ViewerConfig
+
+
+def _get_camera_body_id(cfg: ViewerConfig, entities: dict[str, Entity]) -> int:
+  """Resolve the body id the camera tracks, or -1 for free cameras."""
+  if cfg.origin_type in (
+    ViewerConfig.OriginType.AUTO,
+    ViewerConfig.OriginType.WORLD,
+  ):
+    return -1
+
+  entity_name = cfg.entity_name
+  if entity_name is None:
+    if len(entities) != 1:
+      raise ValueError(
+        f"Cannot auto-detect entity: scene has {len(entities)} entities "
+        f"({list(entities.keys())}). Set ViewerConfig.entity_name to choose one."
+      )
+    entity_name = next(iter(entities))
+  elif entity_name not in entities:
+    raise ValueError(
+      f"Entity '{entity_name}' not found in scene. "
+      f"Available entities: {list(entities.keys())}."
+    )
+  entity = entities[entity_name]
+
+  if cfg.origin_type == ViewerConfig.OriginType.ASSET_ROOT:
+    return entity.indexing.root_body_id
+
+  assert cfg.origin_type == ViewerConfig.OriginType.ASSET_BODY
+  if not cfg.body_name:
+    raise ValueError("body_name is required for the ASSET_BODY origin type.")
+  if cfg.body_name not in entity.body_names:
+    raise ValueError(f"Body '{cfg.body_name}' not found in entity '{entity_name}'.")
+  body_ids, _ = entity.find_bodies(cfg.body_name)
+  return entity.indexing.bodies[body_ids[0]].id
 
 
 class OffscreenRenderer:
@@ -26,19 +62,21 @@ class OffscreenRenderer:
     expanded_fields: set[str] | None = None,
   ) -> None:
     self._cfg = cfg
+    self._scene = scene
+    self._sim_model = sim_model
+    self._expanded_fields = expanded_fields
+
     # Work on a copy so render-only tweaks (extent, shadows, reflections,
     # sameframe shortcuts) never leak into the shared model.
     self._model = copy.copy(model)
-    self._sim_model = sim_model
-    self._expanded_fields = expanded_fields
     self._data = mujoco.MjData(self._model)
-    self._scene = scene
+
     if self._sim_model is not None:
       disable_model_sameframe_shortcuts(self._model)
-    self._render_extent = self._compute_render_extent()
+
     # Keep extent override local to offscreen rendering so shadow/camera scaling
     # is not dominated by the full multi-env world bounds.
-    self._model.stat.extent = self._render_extent
+    self._model.stat.extent = self._compute_render_extent(cfg.distance)
 
     self._model.vis.global_.offheight = cfg.height
     self._model.vis.global_.offwidth = cfg.width
@@ -53,13 +91,13 @@ class OffscreenRenderer:
     if not cfg.enable_reflections:
       self._model.mat_reflectance[:] = 0.0
 
-    self._cam = self._setup_camera()
+    self._cam = self._setup_camera(cfg, self._model, scene.entities)
+    self._env_ids: tuple[int, ...] | None = None
 
     self._renderer: mujoco.Renderer | None = None
     self._opt = mujoco.MjvOption()
     self._pert = mujoco.MjvPerturb()
     self._catmask = mujoco.mjtCatBit.mjCAT_DYNAMIC
-    self._extra_env_ids: list[int] | None = None
 
   @property
   def renderer(self) -> mujoco.Renderer:
@@ -87,19 +125,18 @@ class OffscreenRenderer:
     if self._renderer is None:
       raise ValueError("Renderer not initialized. Call 'initialize()' first.")
 
-    nworld = int(data.nworld)
-    if nworld <= 0:
+    if int(data.nworld) <= 0:
       return
 
-    env_idx = max(0, min(int(self._cfg.env_idx), nworld - 1))
-    self._sync_model_fields(env_idx)
-    if self._model.nq > 0:
-      self._data.qpos[:] = data.qpos[env_idx].cpu().numpy()
-      self._data.qvel[:] = data.qvel[env_idx].cpu().numpy()
-    if self._model.nmocap > 0:
-      self._data.mocap_pos[:] = data.mocap_pos[env_idx].cpu().numpy()
-      self._data.mocap_quat[:] = data.mocap_quat[env_idx].cpu().numpy()
-    mujoco.mj_forward(self._model, self._data)
+    if self._env_ids is None:
+      self._env_ids = self._get_env_ids(
+        self._cfg, self._scene.env_origins.cpu().numpy()
+      )
+
+    # The primary env frames the camera and receives the debug overlays.
+    primary_env = self._env_ids[0]
+    self._sync_model_fields(primary_env)
+    self._sync_data_fields(data, primary_env)
 
     cam = camera if camera is not None else self._cam
     self._renderer.update_scene(self._data, camera=cam)
@@ -107,20 +144,14 @@ class OffscreenRenderer:
     # Note: update_scene() resets the scene each frame, so no need to manually clear.
     if debug_vis_callback is not None:
       visualizer = MujocoNativeDebugVisualizer(
-        self._renderer.scene, self._model, env_idx=self._cfg.env_idx
+        self._renderer.scene, self._model, env_idx=primary_env
       )
       debug_vis_callback(visualizer)
 
-    # Add nearest neighboring environments as geoms for context.
-    for i in self._get_extra_env_ids(nworld, env_idx):
-      self._sync_model_fields(i)
-      if self._model.nq > 0:
-        self._data.qpos[:] = data.qpos[i].cpu().numpy()
-        self._data.qvel[:] = data.qvel[i].cpu().numpy()
-      if self._model.nmocap > 0:
-        self._data.mocap_pos[:] = data.mocap_pos[i].cpu().numpy()
-        self._data.mocap_quat[:] = data.mocap_quat[i].cpu().numpy()
-      mujoco.mj_forward(self._model, self._data)
+    # Add neighboring environments as geoms for context.
+    for env_id in self._env_ids[1:]:
+      self._sync_model_fields(env_id)
+      self._sync_data_fields(data, env_id)
       mujoco.mjv_addGeoms(
         self._model,
         self._data,
@@ -130,33 +161,26 @@ class OffscreenRenderer:
         self._renderer.scene,
       )
 
-  def _get_extra_env_ids(self, nworld: int, env_idx: int) -> list[int]:
-    """Return nearest neighboring env ids to render as context.
+  def render(self) -> np.ndarray:
+    if self._renderer is None:
+      raise ValueError("Renderer not initialized. Call 'initialize()' first.")
 
-    We render a small local neighborhood around ``env_idx`` instead of the first
-    N environments, so videos stay focused on the tracked robot and nearby peers.
+    return self._renderer.render()
 
-    The neighbor set is computed once and cached. ``env_origins`` can mutate during
-    training (e.g. the terrain curriculum reassigns origins on reset), so recomputing
-    every frame would make the context robots pop in and out, causing video flicker.
-    """
-    if self._extra_env_ids is not None:
-      return self._extra_env_ids
+  def close(self) -> None:
+    if self._renderer is not None:
+      self._renderer.close()
+      self._renderer = None
 
-    if self._cfg.max_extra_envs <= 0 or nworld <= 1:
-      self._extra_env_ids = []
-      return self._extra_env_ids
-
-    k = min(self._cfg.max_extra_envs, nworld - 1)
-    origins = self._scene.env_origins[:nworld].cpu().numpy()
-    ref = origins[env_idx]
-    dist2 = np.sum((origins - ref) ** 2, axis=1)
-    dist2[env_idx] = np.inf
-
-    nearest = np.argpartition(dist2, kth=k - 1)[:k]
-    nearest = nearest[np.argsort(dist2[nearest])]
-    self._extra_env_ids = [int(i) for i in nearest]
-    return self._extra_env_ids
+  def _sync_data_fields(self, data: Any, env_idx: int) -> None:
+    """Copy one env's state into the host MjData and refresh kinematics."""
+    if self._model.nq > 0:
+      self._data.qpos[:] = data.qpos[env_idx].cpu().numpy()
+      self._data.qvel[:] = data.qvel[env_idx].cpu().numpy()
+    if self._model.nmocap > 0:
+      self._data.mocap_pos[:] = data.mocap_pos[env_idx].cpu().numpy()
+      self._data.mocap_quat[:] = data.mocap_quat[env_idx].cpu().numpy()
+    mujoco.mj_forward(self._model, self._data)
 
   def _sync_model_fields(self, env_idx: int) -> None:
     """Sync visually relevant per-world model fields into the host MjModel."""
@@ -165,85 +189,68 @@ class OffscreenRenderer:
     fields = self._expanded_fields & VIEWER_MODEL_FIELDS
     sync_model_fields(self._model, self._sim_model, fields, env_idx)
 
-  def render(self) -> np.ndarray:
-    if self._renderer is None:
-      raise ValueError("Renderer not initialized. Call 'initialize()' first.")
+  @staticmethod
+  def _get_env_ids(cfg: ViewerConfig, env_origins: np.ndarray) -> tuple[int, ...]:
+    """Return the ids of the environments to render, primary env first.
 
-    return self._renderer.render()
+    The primary env is cfg.env_idx (clamped to the available worlds), followed
+    by up to max_extra_envs nearest neighbors by env origin, so videos stay
+    focused on the tracked robot and nearby peers.
 
-  def _setup_camera(self) -> mujoco.MjvCamera:
+    The set is resolved once, on first use, and kept stable: env_origins can
+    mutate during training (e.g. the terrain curriculum reassigns origins on
+    reset), and recomputing every frame would make the context robots pop in
+    and out, causing video flicker.
+    """
+    if cfg.max_extra_envs < 0:
+      raise ValueError(
+        f"'max_extra_envs' must be non-negative, got {cfg.max_extra_envs}."
+      )
+
+    n_world = env_origins.shape[0]
+    env_idx = max(0, min(int(cfg.env_idx), n_world - 1))
+    k = min(cfg.max_extra_envs, n_world - 1)
+    if k <= 0:
+      return (env_idx,)
+
+    dist2 = np.sum((env_origins - env_origins[env_idx]) ** 2, axis=1)
+    dist2[env_idx] = np.inf
+    nearest = np.argpartition(dist2, kth=k - 1)[:k]
+    nearest = nearest[np.argsort(dist2[nearest])]
+    return (env_idx, *(int(i) for i in nearest))
+
+  @staticmethod
+  def _setup_camera(
+    cfg: ViewerConfig,
+    model: mujoco.MjModel,
+    entities: dict[str, Entity],
+  ) -> mujoco.MjvCamera:
     """Setup camera based on config's origin_type."""
+    body_id = _get_camera_body_id(cfg, entities)
+
     camera = mujoco.MjvCamera()
-    mujoco.mjv_defaultFreeCamera(self._model, camera)
-
-    if self._cfg.origin_type in (
-      self._cfg.OriginType.AUTO,
-      self._cfg.OriginType.WORLD,
-    ):
-      # Free camera, no tracking.
+    mujoco.mjv_defaultFreeCamera(model, camera)
+    if body_id == -1:
       camera.type = mujoco.mjtCamera.mjCAMERA_FREE.value
-      camera.fixedcamid = -1
-      camera.trackbodyid = -1
-
-    elif self._cfg.origin_type == self._cfg.OriginType.ASSET_ROOT:
-      from mjlab.entity import Entity
-
-      if self._cfg.entity_name:
-        robot: Entity = self._scene[self._cfg.entity_name]
-      else:
-        # Auto-detect if only one entity.
-        if len(self._scene.entities) == 1:
-          robot = list(self._scene.entities.values())[0]
-        else:
-          raise ValueError(
-            f"Multiple entities in scene ({len(self._scene.entities)}): "
-            f"{list(self._scene.entities.keys())}. "
-            "Set ViewerConfig.entity_name to choose which one."
-          )
-
-      body_id = robot.indexing.root_body_id
+    else:
       camera.type = mujoco.mjtCamera.mjCAMERA_TRACKING.value
-      camera.trackbodyid = body_id
-      camera.fixedcamid = -1
-
-    elif self._cfg.origin_type == self._cfg.OriginType.ASSET_BODY:
-      if not self._cfg.entity_name or not self._cfg.body_name:
-        raise ValueError("entity_name/body_name required for ASSET_BODY origin type")
-
-      from mjlab.entity import Entity
-
-      robot: Entity = self._scene[self._cfg.entity_name]
-      if self._cfg.body_name not in robot.body_names:
-        raise ValueError(
-          f"Body '{self._cfg.body_name}' not found in asset '{self._cfg.entity_name}'"
-        )
-      body_id_list, _ = robot.find_bodies(self._cfg.body_name)
-      body_id = robot.indexing.bodies[body_id_list[0]].id
-
-      camera.type = mujoco.mjtCamera.mjCAMERA_TRACKING.value
-      camera.trackbodyid = body_id
-      camera.fixedcamid = -1
-
-    camera.lookat[:] = self._cfg.lookat
-    camera.elevation = self._cfg.elevation
-    camera.azimuth = self._cfg.azimuth
-    camera.distance = self._cfg.distance
+    camera.trackbodyid = body_id
+    camera.fixedcamid = -1
+    camera.lookat[:] = cfg.lookat
+    camera.elevation = cfg.elevation
+    camera.azimuth = cfg.azimuth
+    camera.distance = cfg.distance
 
     return camera
 
-  def close(self) -> None:
-    if self._renderer is not None:
-      self._renderer.close()
-      self._renderer = None
-
-  def _compute_render_extent(self) -> float:
+  @staticmethod
+  def _compute_render_extent(distance: float) -> float:
     """Compute a stable extent for offscreen rendering.
 
-    MuJoCo scales z-near/z-far and shadow clip with ``model.stat.extent``. In large
-    scenes this auto extent can become very large, which causes shadow-map precision
-    artifacts in offscreen video rendering.
-
-    We therefore use a local extent tied to the active camera distance.
+    MuJoCo scales z-near/z-far and shadow clip with ``model.stat.extent``. In
+    large scenes this auto extent can become very large, which causes
+    shadow-map precision artifacts in offscreen video rendering. We therefore
+    use a local extent tied to the camera distance, keeping enough room for
+    the tracked subject and camera motion.
     """
-    # Keep enough room for the tracked subject and camera motion.
-    return max(4.0, 1.5 * float(self._cfg.distance))
+    return max(4.0, 1.5 * float(distance))

--- a/src/mjlab/viewer/offscreen_renderer.py
+++ b/src/mjlab/viewer/offscreen_renderer.py
@@ -1,5 +1,6 @@
 """MuJoCo offscreen renderer for headless visualization."""
 
+import copy
 from typing import Any, Callable
 
 import mujoco
@@ -25,14 +26,15 @@ class OffscreenRenderer:
     expanded_fields: set[str] | None = None,
   ) -> None:
     self._cfg = cfg
-    self._model = model
+    # Work on a copy so render-only tweaks (extent, shadows, reflections,
+    # sameframe shortcuts) never leak into the shared model.
+    self._model = copy.copy(model)
     self._sim_model = sim_model
     self._expanded_fields = expanded_fields
-    self._data = mujoco.MjData(model)
+    self._data = mujoco.MjData(self._model)
     self._scene = scene
     if self._sim_model is not None:
       disable_model_sameframe_shortcuts(self._model)
-    self._orig_extent = float(self._model.stat.extent)
     self._render_extent = self._compute_render_extent()
     # Keep extent override local to offscreen rendering so shadow/camera scaling
     # is not dominated by the full multi-env world bounds.
@@ -127,8 +129,6 @@ class OffscreenRenderer:
         self._catmask.value,
         self._renderer.scene,
       )
-
-    self._sync_model_fields(env_idx)
 
   def _get_extra_env_ids(self, nworld: int, env_idx: int) -> list[int]:
     """Return nearest neighboring env ids to render as context.
@@ -235,7 +235,6 @@ class OffscreenRenderer:
     if self._renderer is not None:
       self._renderer.close()
       self._renderer = None
-    self._model.stat.extent = self._orig_extent
 
   def _compute_render_extent(self) -> float:
     """Compute a stable extent for offscreen rendering.

--- a/src/mjlab/viewer/viewer_config.py
+++ b/src/mjlab/viewer/viewer_config.py
@@ -33,6 +33,10 @@ class ViewerConfig:
   enable_shadows: bool = True
   height: int = 240
   width: int = 320
+  geom_group: tuple[int, int, int, int, int, int] = (1, 1, 1, 0, 0, 0)
+  """Which geom visualization groups the offscreen renderer draws."""
+  site_group: tuple[int, int, int, int, int, int] = (1, 1, 1, 0, 0, 0)
+  """Which site visualization groups the offscreen renderer draws."""
   reward_bar_max_terms: int = 20
   """Maximum number of reward terms shown in the Viser reward bar panel.
 

--- a/src/mjlab/viewer/viewer_config.py
+++ b/src/mjlab/viewer/viewer_config.py
@@ -2,14 +2,8 @@ import enum
 from dataclasses import dataclass
 
 
-@dataclass
+@dataclass(kw_only=True)
 class ViewerConfig:
-  lookat: tuple[float, float, float] = (0.0, 0.0, 0.0)
-  distance: float = 5.0
-  fovy: float | None = None
-  elevation: float = -45.0
-  azimuth: float = 90.0
-
   class OriginType(enum.Enum):
     """The frame in which the camera position and target are defined."""
 
@@ -23,22 +17,49 @@ class ViewerConfig:
     """Track the body defined by body_name in the asset defined by
     entity_name."""
 
+  # Options that apply to every origin type.
   origin_type: OriginType = OriginType.AUTO
-  entity_name: str | None = None
-  body_name: str | None = None
-  env_idx: int = 0
-  max_extra_envs: int = 2
-  """Number of neighboring environments to render around ``env_idx``."""
-  enable_reflections: bool = True
-  enable_shadows: bool = True
+
   height: int = 240
   width: int = 320
+
+  enable_reflections: bool = True
+  enable_shadows: bool = True
+
   geom_group: tuple[int, int, int, int, int, int] = (1, 1, 1, 0, 0, 0)
   """Which geom visualization groups the offscreen renderer draws."""
+
   site_group: tuple[int, int, int, int, int, int] = (1, 1, 1, 0, 0, 0)
   """Which site visualization groups the offscreen renderer draws."""
+
+  env_idx: int = 0
+  """Environment rendered as the primary env and tracked by the camera."""
+
+  max_extra_envs: int = 2
+  """Number of neighboring environments to render around env_idx."""
+
   reward_bar_max_terms: int = 20
   """Maximum number of reward terms shown in the Viser reward bar panel.
 
   Terms beyond this limit are dropped (with a warning). Raise it for
   environments with many reward terms."""
+
+  # Camera placement.
+  distance: float = 5.0
+  elevation: float = -45.0
+  azimuth: float = 90.0
+
+  fovy: float | None = None
+  """Vertical field of view in degrees. None keeps the model default."""
+
+  lookat: tuple[float, float, float] = (0.0, 0.0, 0.0)
+  """Look-at target in the world frame. Only used by the AUTO and WORLD free
+  cameras; the ASSET_ROOT and ASSET_BODY tracking cameras ignore it."""
+
+  # Fields specific to the ASSET_ROOT and ASSET_BODY tracking cameras.
+  entity_name: str | None = None
+  """Entity tracked by the camera. Auto-detected if the scene has exactly one
+  entity."""
+
+  body_name: str | None = None
+  """Body tracked by the camera. Required for ASSET_BODY."""

--- a/tests/test_offscreen_renderer.py
+++ b/tests/test_offscreen_renderer.py
@@ -1,0 +1,45 @@
+"""Tests for offscreen renderer environment selection."""
+
+import numpy as np
+import pytest
+
+from mjlab.viewer.offscreen_renderer import OffscreenRenderer
+from mjlab.viewer.viewer_config import ViewerConfig
+
+
+def test_env_ids_clamps_when_fewer_envs_than_requested():
+  # Default max_extra_envs=2 with a single env must not raise (csv_to_npz and
+  # single-env video recording rely on this).
+  cfg = ViewerConfig(max_extra_envs=2)
+  ids = OffscreenRenderer._get_env_ids(cfg, np.zeros((1, 3)))
+  assert ids == (0,)
+
+
+def test_env_ids_primary_is_env_idx_despite_identical_origins():
+  # With identical origins, distance ties must not evict env_idx from the set.
+  cfg = ViewerConfig(env_idx=3, max_extra_envs=2)
+  ids = OffscreenRenderer._get_env_ids(cfg, np.zeros((8, 3)))
+  assert ids[0] == 3
+  assert len(ids) == 3
+  assert len(set(ids)) == 3
+
+
+def test_env_ids_selects_nearest_neighbors():
+  cfg = ViewerConfig(env_idx=0, max_extra_envs=2)
+  origins = np.array(
+    [[0.0, 0.0, 0.0], [10.0, 0.0, 0.0], [1.0, 0.0, 0.0], [2.0, 0.0, 0.0]]
+  )
+  ids = OffscreenRenderer._get_env_ids(cfg, origins)
+  assert ids == (0, 2, 3)
+
+
+def test_env_ids_out_of_range_env_idx_is_clamped():
+  cfg = ViewerConfig(env_idx=99, max_extra_envs=0)
+  ids = OffscreenRenderer._get_env_ids(cfg, np.zeros((4, 3)))
+  assert ids == (3,)
+
+
+def test_env_ids_negative_max_extra_envs_raises():
+  cfg = ViewerConfig(max_extra_envs=-1)
+  with pytest.raises(ValueError, match="max_extra_envs"):
+    OffscreenRenderer._get_env_ids(cfg, np.zeros((4, 3)))


### PR DESCRIPTION
The offscreen renderer previously mutated the shared MjModel to configure rendering (extent, shadows, reflections, sameframe flags) and only partially restored it on close. It now renders from its own copy of the model, so none of these tweaks are observable outside the renderer. Env selection and camera setup are extracted into small pure helpers, which made them testable for the first time.

ViewerConfig is now keyword-only, with fields grouped and documented. It gains geom_group and site_group to control which visualization groups the offscreen renderer draws (defaults match MuJoCo's, so nothing changes unless configured). fovy now applies to tracking cameras too; previously it was silently ignored for anything but free cameras.

Env selection behavior is deliberately unchanged: env_idx is always the primary rendered env, neighbors are chosen by proximity to it, and the count is clamped when there are fewer envs than requested. This is now locked in by tests, including the single-env and identical-origin cases.

Supersedes #1131. Thanks @bd-mlutter for the original work; commits carry co-author credit.