### PR TITLE
Make auto_reset identical to an explicit reset()

### DIFF
--- a/docs/source/architecture_overview.rst
+++ b/docs/source/architecture_overview.rst
@@ -158,13 +158,13 @@ Each environment instance passes through four phases.
 4. **Step.** The policy action is processed by the ``ActionManager``. The
    physics simulation advances ``decimation`` times, with actuator commands
    applied and entity state updated each sub-step. After the decimation
-   loop, the ``TerminationManager`` checks stop conditions, the
-   ``RewardManager`` computes the reward signal, and any terminated
-   environments are reset. A single ``forward()`` call refreshes derived
-   quantities for all environments. The ``CommandManager`` advances or
-   resamples goals. Interval events fire if scheduled. Sensors update. The
-   ``ObservationManager`` assembles the observation for the next policy
-   query.
+   loop, the ``TerminationManager`` checks stop conditions and the
+   ``RewardManager`` computes the reward signal. Step and interval events
+   fire if scheduled, acting on the pre-reset state. Any terminated
+   environments are then reset. A single ``forward()`` call refreshes
+   derived quantities for all environments. The ``CommandManager`` advances
+   or resamples goals. Sensors update. The ``ObservationManager`` assembles
+   the observation for the next policy query.
 
 The step sequence in order:
 
@@ -178,10 +178,11 @@ The step sequence in order:
     termination_manager.compute()
     reward_manager.compute()
     metrics_manager.compute()
+    event_manager.apply(mode="step")
+    event_manager.apply(mode="interval")
     [reset terminated envs]
     sim.forward()
-    command_manager.compute()
-    event_manager.apply(mode="interval")
+    command_manager.compute()  # dt=0 for envs just reset
     sim.sense()
     observation_manager.compute()
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -81,6 +81,8 @@ Changed
   ``ASSET_BODY`` tracking cameras instead of being silently ignored; leave
   it at ``None`` (the default) to keep the model value. Contribution by
   @bd-mlutter.
+- ``auto_reset`` and an explicit ``reset()`` now leave identical command and
+  event timer state (:issue:`1133`).
 
 Fixed
 ^^^^^

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -218,12 +218,14 @@ derived quantities in ``mjData`` (``xpos``, ``xquat``, ``site_xpos``,
 ``cvel``, ``sensordata``, etc.) into a consistent state with the current
 ``qpos``/``qvel``.
 The environment's ``step()`` method calls it once per step, right before
-observation computation, so observations, commands, and interval events
-always see fresh derived quantities. Termination and reward managers run
+observation computation, so observations and commands always see fresh
+derived quantities. Termination, reward, and step/interval events run
 *before* this call and therefore see derived quantities that are stale by
 one physics substep, a deliberate tradeoff that avoids a second
 ``forward()`` call while keeping the MDP well-defined (the staleness is
-consistent across all envs and all steps).
+consistent across all envs and all steps). Because events run before the
+call, any state they write (e.g. a velocity push) is refreshed by it and
+visible to the same step's observations.
 
 The one case where this matters is if you write an event or command that
 both writes state and reads derived quantities in the same function. For

--- a/src/mjlab/envs/manager_based_rl_env.py
+++ b/src/mjlab/envs/manager_based_rl_env.py
@@ -191,6 +191,8 @@ class ManagerBasedRlEnv:
     self._manual_reset_pending = torch.zeros(
       self.cfg.scene.num_envs, dtype=torch.bool, device=device
     )
+    # Scratch buffer for per-env command dt; see step().
+    self._command_dt = torch.zeros(self.cfg.scene.num_envs, device=device)
 
     # Initialize scene and simulation.
     self.scene = Scene(self.cfg.scene, device=device)
@@ -399,24 +401,27 @@ class ManagerBasedRlEnv:
     for *all* envs: non-reset envs pick up post-decimation kinematics, reset envs
     pick up post-reset kinematics.
 
-    The tradeoff is that termination and reward managers see derived quantities that
-    are stale by one physics substep (the last ``mj_step`` ran ``mj_forward`` from
-    *pre*-integration ``qpos``). In practice, the staleness is negligible for reward
-    shaping and termination checks. Critically, the staleness is *consistent*: every
-    env, every step, always sees the same lag, so the MDP is well-defined and the
-    value function can learn the correct mapping.
+    The tradeoff is that termination, reward, and step/interval event managers see
+    derived quantities that are stale by one physics substep (the last ``mj_step``
+    ran ``mj_forward`` from *pre*-integration ``qpos``). In practice, the staleness
+    is negligible for reward shaping, termination checks, and event perturbations.
+    Critically, the staleness is *consistent*: every env, every step, always sees
+    the same lag, so the MDP is well-defined and the value function can learn the
+    correct mapping.
+
+    **Auto-reset parity.** Auto-reset reproduces the explicit ``reset()`` flow:
+    events fire on the terminal state before the reset, and freshly reset envs
+    advance commands with ``dt=0`` so their timers start full.
 
     .. note::
 
-      Reset-mode events and reset-path command resamples do not need to call
-      ``sim.forward()`` themselves; the single call above runs after them. Step
-      and interval events and command updates run *after* that call, so if they
-      write sim state they must refresh derived quantities themselves (see
-      ``MotionCommand._update_command``), and a plain state write (e.g. a
-      velocity push) is visible to qpos/qvel-backed reads this step but to
-      derived quantities only next step. In all cases, do not read derived
-      quantities (``root_link_pose_w``, ``body_link_vel_w``, etc.) in the same
-      function that writes state (``write_root_state_to_sim``,
+      Events and reset-path resamples all run *before* ``forward()``, so state
+      they write (e.g. a velocity push) is refreshed automatically and visible
+      in this step's observations. Command updates run *after*
+      the call, so a command that writes sim state must refresh derived
+      quantities itself (see ``MotionCommand._update_command``). In all cases,
+      do not read derived quantities (``root_link_pose_w``, ``body_link_vel_w``,
+      etc.) in the same function that writes state (``write_root_state_to_sim``,
       ``write_joint_state_to_sim``, etc.). See :ref:`faq` for details.
     """
     if not self.cfg.auto_reset and torch.any(self._manual_reset_pending):
@@ -451,6 +456,14 @@ class ManagerBasedRlEnv:
     self.reward_buf = self.reward_manager.compute(dt=self.step_dt)
     self.metrics_manager.compute()
 
+    # Events fire before auto-reset, on the terminal state, matching the
+    # explicit flow. Staleness and forward() rules are the same as for
+    # termination/reward (see docstring above).
+    if "step" in self.event_manager.available_modes:
+      self.event_manager.apply(mode="step", dt=self.step_dt)
+    if "interval" in self.event_manager.available_modes:
+      self.event_manager.apply(mode="interval", dt=self.step_dt)
+
     # Reset envs that terminated/timed-out and log the episode info.
     reset_env_ids = self.reset_buf.nonzero(as_tuple=False).squeeze(-1)
     if self.cfg.auto_reset and len(reset_env_ids) > 0:
@@ -464,12 +477,15 @@ class ManagerBasedRlEnv:
     # the freshly written reset state.
     self.sim.forward()
 
-    self.command_manager.compute(dt=self.step_dt)
-
-    if "step" in self.event_manager.available_modes:
-      self.event_manager.apply(mode="step", dt=self.step_dt)
-    if "interval" in self.event_manager.available_modes:
-      self.event_manager.apply(mode="interval", dt=self.step_dt)
+    # Pass dt=0 for freshly reset envs so their command timers start full,
+    # matching reset().
+    if self.cfg.auto_reset and len(reset_env_ids) > 0:
+      command_dt = self._command_dt
+      command_dt.fill_(self.step_dt)
+      command_dt[reset_env_ids] = 0.0
+      self.command_manager.compute(dt=command_dt)
+    else:
+      self.command_manager.compute(dt=self.step_dt)
 
     self.sim.sense()
     self.obs_buf = self.observation_manager.compute(update_history=True)

--- a/src/mjlab/managers/command_manager.py
+++ b/src/mjlab/managers/command_manager.py
@@ -108,18 +108,25 @@ class CommandTerm(ManagerTermBase):
     self._resample(env_ids)
     return extras
 
-  def compute(self, dt: float, env_ids: torch.Tensor | None = None) -> None:
+  def compute(
+    self, dt: float | torch.Tensor, env_ids: torch.Tensor | None = None
+  ) -> None:
     """Advance the command state by dt.
 
     With env_ids=None (the per-step path) all envs are updated; with env_ids
     (the reset path) timers and the command update are scoped to those envs.
     Metrics are always refreshed.
+
+    dt may be a scalar (all envs) or a per-env tensor (auto-reset path,
+    where freshly reset envs get zero to keep their timers full). A tensor
+    dt requires env_ids=None.
     """
     self._update_metrics()
     if env_ids is None:
       self.time_left -= dt
       resample_env_ids = (self.time_left <= 0.0).nonzero().flatten()
     else:
+      assert not isinstance(dt, torch.Tensor)
       self.time_left[env_ids] -= dt
       resample_env_ids = env_ids[self.time_left[env_ids] <= 0.0]
     if len(resample_env_ids) > 0:
@@ -277,7 +284,7 @@ class CommandManager(ManagerBase):
         extras[f"Metrics/{name}/{metric_name}"] = metric_value
     return extras
 
-  def compute(self, dt: float, env_ids: torch.Tensor | None = None):
+  def compute(self, dt: float | torch.Tensor, env_ids: torch.Tensor | None = None):
     for term in self._terms.values():
       term.compute(dt, env_ids)
 
@@ -351,7 +358,9 @@ class NullCommandManager:
   def reset(self, env_ids: torch.Tensor | None = None) -> dict[str, torch.Tensor]:
     return {}
 
-  def compute(self, dt: float, env_ids: torch.Tensor | None = None) -> None:
+  def compute(
+    self, dt: float | torch.Tensor, env_ids: torch.Tensor | None = None
+  ) -> None:
     pass
 
   def get_command(self, name: str) -> None:

--- a/src/mjlab/tasks/velocity/mdp/velocity_command.py
+++ b/src/mjlab/tasks/velocity/mdp/velocity_command.py
@@ -198,7 +198,9 @@ class UniformVelocityCommand(CommandTerm):
     self._joystick_sliders = sliders
     self._joystick_get_env_idx = get_env_idx
 
-  def compute(self, dt: float, env_ids: torch.Tensor | None = None) -> None:
+  def compute(
+    self, dt: float | torch.Tensor, env_ids: torch.Tensor | None = None
+  ) -> None:
     super().compute(dt, env_ids)
     if self._joystick_enabled is not None and self._joystick_enabled.value:
       assert self._joystick_get_env_idx is not None

--- a/tests/test_auto_reset.py
+++ b/tests/test_auto_reset.py
@@ -3,8 +3,10 @@
 import pytest
 import torch
 from conftest import get_test_device
+from test_command_manager import CounterCommand, CounterCommandCfg
 
 from mjlab.envs import ManagerBasedRlEnv
+from mjlab.managers.event_manager import EventTermCfg
 from mjlab.tasks.cartpole.cartpole_env_cfg import cartpole_balance_env_cfg
 
 
@@ -194,3 +196,133 @@ def test_partial_reset_leaves_other_envs_obs_buffers_untouched(device):
   assert torch.all(h1 == h1[0])
   assert hist.current_length[1].item() == 1
   env.close()
+
+
+# Section: parity between auto-reset and the explicit reset() flow.
+
+_COMMAND_T = 7.0
+_INTERVAL_T = 5.0
+_MARKER_VEL = 37.0
+
+
+def _noop_event(env, env_ids) -> None:
+  del env, env_ids
+
+
+def _write_marker_velocity(env, env_ids) -> None:
+  """Overwrite joint velocities with a recognizable marker value."""
+  asset = env.scene["cartpole"]
+  if env_ids is None:
+    env_ids = torch.arange(env.num_envs, device=env.device)
+  joint_pos = asset.data.joint_pos[env_ids]
+  joint_vel = torch.full_like(asset.data.joint_vel[env_ids], _MARKER_VEL)
+  asset.write_joint_state_to_sim(joint_pos, joint_vel, env_ids=env_ids)
+
+
+def _make_parity_cfg(auto_reset: bool):
+  """Cartpole cfg with fixed-interval command and event timers.
+
+  Fixed ranges make timer values deterministic, so assertions are exact and
+  independent of RNG state and physics nondeterminism.
+  """
+  cfg = _make_cfg(auto_reset)
+  cfg.commands = {
+    "counter": CounterCommandCfg(resampling_time_range=(_COMMAND_T, _COMMAND_T))
+  }
+  cfg.events["probe"] = EventTermCfg(
+    func=_noop_event, mode="interval", interval_range_s=(_INTERVAL_T, _INTERVAL_T)
+  )
+  return cfg
+
+
+def _stagger_env0(env, steps_until_reset: int) -> torch.Tensor:
+  """Advance env 0's episode clock so it times out after the given steps."""
+  env.reset()
+  env.episode_length_buf[0] = env.max_episode_length - steps_until_reset
+  return torch.zeros((env.num_envs, 1), device=env.device)
+
+
+def test_auto_reset_preserves_fresh_command_timer(device):
+  """A command timer resampled by an auto-reset is not decremented that step."""
+  env = ManagerBasedRlEnv(cfg=_make_parity_cfg(auto_reset=True), device=device)
+  action = _stagger_env0(env, steps_until_reset=2)
+  env.step(action)
+  env.step(action)  # Env 0 times out and auto-resets here.
+  assert env.episode_length_buf[0].item() == 0
+
+  term = env.command_manager.get_term("counter")
+  assert isinstance(term, CounterCommand)
+  time_left = term.time_left
+  expected_running = _COMMAND_T - 2 * env.step_dt
+  assert torch.allclose(time_left[0], torch.tensor(_COMMAND_T, device=env.device))
+  assert torch.allclose(
+    time_left[1:], torch.tensor(expected_running, device=env.device)
+  )
+  env.close()
+
+
+def test_auto_reset_preserves_fresh_interval_event_timer(device):
+  """An interval event timer resampled by an auto-reset is not decremented."""
+  env = ManagerBasedRlEnv(cfg=_make_parity_cfg(auto_reset=True), device=device)
+  action = _stagger_env0(env, steps_until_reset=2)
+  env.step(action)
+  env.step(action)  # Env 0 times out and auto-resets here.
+  assert env.episode_length_buf[0].item() == 0
+
+  timer = env.event_manager._interval_term_time_left[0]
+  expected_running = _INTERVAL_T - 2 * env.step_dt
+  assert torch.allclose(timer[0], torch.tensor(_INTERVAL_T, device=env.device))
+  assert torch.allclose(timer[1:], torch.tensor(expected_running, device=env.device))
+  env.close()
+
+
+def test_interval_event_acts_on_pre_reset_state(device):
+  """An interval event firing on a reset step hits the terminal state, so the
+  freshly reset env comes out clean, as in the explicit reset flow."""
+  cfg = _make_cfg(auto_reset=True)
+  cfg.events["kick"] = EventTermCfg(
+    func=_write_marker_velocity, mode="interval", interval_range_s=(0.0, 0.0)
+  )
+  env = ManagerBasedRlEnv(cfg=cfg, device=device)
+  action = _stagger_env0(env, steps_until_reset=1)
+  env.step(action)  # Kick fires for all envs; env 0 then auto-resets.
+  assert env.episode_length_buf[0].item() == 0
+
+  joint_vel = env.scene["cartpole"].data.joint_vel
+  # Env 0 was reset after the kick: its velocity is the reset distribution's,
+  # not the marker. Env 1 was not reset and still carries the marker.
+  assert joint_vel[0].abs().max().item() < 1.0
+  assert torch.allclose(joint_vel[1], torch.full_like(joint_vel[1], _MARKER_VEL))
+  env.close()
+
+
+def test_auto_reset_matches_manual_reset_timers(device):
+  """After a reset, both flows leave identical command/event timer state."""
+  auto_env = ManagerBasedRlEnv(cfg=_make_parity_cfg(auto_reset=True), device=device)
+  manual_env = ManagerBasedRlEnv(cfg=_make_parity_cfg(auto_reset=False), device=device)
+  auto_env.reset(seed=0)
+  manual_env.reset(seed=0)
+
+  action = torch.zeros((auto_env.num_envs, 1), device=auto_env.device)
+  done = torch.zeros(auto_env.num_envs, dtype=torch.bool, device=auto_env.device)
+  for _ in range(auto_env.max_episode_length):
+    auto_env.step(action)
+    _, _, terminated, truncated, _ = manual_env.step(action)
+    done = terminated | truncated
+  done_ids = done.nonzero(as_tuple=False).squeeze(-1)
+  assert len(done_ids) == manual_env.num_envs  # Time-out is synchronized.
+  manual_env.reset(env_ids=done_ids)
+
+  for env in (auto_env, manual_env):
+    term = env.command_manager.get_term("counter")
+    assert isinstance(term, CounterCommand)
+    interval_timer = env.event_manager._interval_term_time_left[0]
+    assert torch.all(env.episode_length_buf == 0)
+    assert torch.allclose(term.time_left, torch.full_like(term.time_left, _COMMAND_T))
+    assert torch.allclose(interval_timer, torch.full_like(interval_timer, _INTERVAL_T))
+    # Stateful command advance: resample zeroed the counter, then exactly one
+    # post-reset update ran in both flows.
+    assert torch.all(term.ticks == 1)
+
+  auto_env.close()
+  manual_env.close()


### PR DESCRIPTION
Auto-reset used to decrement freshly sampled command and event timers and fire interval events on already-reset state; explicit reset() did not (#1133). This PR moves events before the reset block and passes dt=0 for freshly reset command timers so both paths leave identical timer state.

The tradeoff is that events now see derived quantities one substep stale, the same lag termination and reward already operate under. The staleness is consistent across all envs and all steps, so the MDP stays well-defined, and it avoids adding a second forward() call. State that events write (e.g. a velocity push) is picked up by the single forward() that follows, so it lands in this step's observations. Parity tests cover both timer preservation and pre-reset event ordering.