### PR TITLE
Cap wandb below 0.29 to fix crash on startup with --logger wandb

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -12,6 +12,12 @@ Changed
   attribute of the ``rsl_rl.utils.Logger``, so code that previously checked
   ``logger.logger_type`` must instead check the type of ``logger.writer``.
 
+Fixed
+^^^^^
+
+- Capped ``wandb`` below 0.29, which removed the ``start_method`` setting still passed
+  by ``rsl-rl-lib`` and crashed training runs launched with ``--logger wandb``.
+
 Version 1.6.0 (August 8, 2026)
 ------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
   "rsl-rl-lib==5.5.0",
   "tensorboard>=2.20.0",
   "onnxscript>=0.5.4",
-  "wandb>=0.22.3",
+  "wandb>=0.22.3,<0.29",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -1745,7 +1745,7 @@ requires-dist = [
     { name = "trimesh", specifier = ">=4.8.3" },
     { name = "tyro", specifier = ">=1.0.1" },
     { name = "viser", specifier = ">=1.0.27" },
-    { name = "wandb", specifier = ">=0.22.3" },
+    { name = "wandb", specifier = ">=0.22.3,<0.29" },
     { name = "warp-lang", marker = "sys_platform != 'darwin'", specifier = ">=1.14.0", index = "https://pypi.nvidia.com/" },
     { name = "warp-lang", marker = "sys_platform == 'darwin'", specifier = ">=1.14.0" },
 ]


### PR DESCRIPTION
## Problem

wandb 0.29.0 (released 2026-08-26) removed the deprecated `start_method` setting
([changelog](https://github.com/wandb/wandb/blob/main/CHANGELOG.md), wandb/wandb#12581).
`wandb.Settings` is a strict pydantic model, so passing the removed argument now raises
instead of being ignored.

rsl-rl-lib (including the currently pinned 5.5.0) still passes it in
`rsl_rl/utils/wandb_log_writer.py`:

```python
settings=wandb.Settings(start_method="thread"),
```

Since `pyproject.toml` has `wandb>=0.22.3` with no upper bound, a fresh install now
resolves wandb 0.29.0, and any training run with `--logger wandb` crashes at startup: