### PR TITLE
Fix sample_gaussian ignoring size when mean and std are tensors.

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -17,6 +17,9 @@ Fixed
 
 - Capped ``wandb`` below 0.29, which removed the ``start_method`` setting still passed
   by ``rsl-rl-lib`` and crashed training runs launched with ``--logger wandb``.
+- ``distribution="gaussian"`` domain randomization now draws an independent value per
+  environment. ``sample_gaussian`` ignored its ``size`` argument when ``mean``/``std``
+  were tensors, so every environment received the same sample :issue:`1168`.
 
 Version 1.6.0 (August 8, 2026)
 ------------------------------

--- a/docs/source/randomization.rst
+++ b/docs/source/randomization.rst
@@ -920,16 +920,23 @@ bounds:
     truncated_normal = dr.Distribution(
         name="truncated_normal",
         sample=lambda lo, hi, shape, device: torch.clamp(
-            torch.normal(
-                mean=(lo + hi) / 2,
-                std=(hi - lo) / 4,  # 95% of samples within bounds
-            ).expand(shape),
+            (lo + hi) / 2
+            + (hi - lo) / 4  # 95% of samples within bounds
+            * torch.randn(shape, device=device),
             min=lo,
             max=hi,
         ),
     )
 
     params={"distribution": truncated_normal, "ranges": (0.3, 1.2)}
+
+.. warning::
+
+   ``sample`` receives ``lower``/``upper`` as tensors, so the sampled tensor must be
+   built from ``shape`` (for example via ``torch.randn(shape, device=device)``). Passing
+   tensor bounds straight to a sampler such as ``torch.normal`` yields a tensor shaped
+   like the bounds, not like ``shape``, which silently gives every environment the same
+   value.
 
 Operation
 ^^^^^^^^^

--- a/src/mjlab/utils/lab_api/math.py
+++ b/src/mjlab/utils/lab_api/math.py
@@ -10,6 +10,8 @@
 #     identical functionality.
 #   - 2025-12-29: Fixed NaN in apply_delta_pose() when rotation angle is zero by clamping
 #     the angle to eps before division.
+#   - 2026-08-28: Fixed sample_gaussian() ignoring the size argument when mean/std were
+#     tensors, which collapsed every sample to a single value.
 
 """Sub-module containing utilities for various math operations."""
 
@@ -1415,21 +1417,24 @@ def sample_gaussian(
 ) -> torch.Tensor:
     """Sample using gaussian distribution.
 
+    Unlike ``torch.normal``, a negative :attr:`std` is not rejected: it yields the same
+    distribution as its absolute value, and checking would cost a device sync per call.
+
     Args:
-        mean: Mean of the gaussian.
-        std: Std of the gaussian.
+        mean: Mean of the gaussian. Expandable to :attr:`size`.
+        std: Std of the gaussian. Expandable to :attr:`size`.
         size: The shape of the tensor.
         device: Device to create tensor on.
 
     Returns:
-        Sampled tensor.
+        Sampled tensor. Shape is :attr:`size`; a mean or std that cannot be expanded to
+        it raises rather than silently resizing the output.
     """
-    if isinstance(mean, float):
-        if isinstance(size, int):
-            size = (size,)
-        return torch.normal(mean=mean, std=std, size=size).to(device=device)
-    else:
-        return torch.normal(mean=mean, std=std).to(device=device)
+    if isinstance(size, int):
+        size = (size,)
+    mean = torch.as_tensor(mean, device=device).expand(size)
+    std = torch.as_tensor(std, device=device).expand(size)
+    return mean + std * torch.randn(size, device=device)
 
 
 def sample_cylinder(

--- a/tests/test_domain_randomization.py
+++ b/tests/test_domain_randomization.py
@@ -214,9 +214,10 @@ def test_log_uniform_distribution(device):
 
 
 def test_gaussian_distribution(device):
-  """Gaussian: mean/std interpretation, values cluster around mean."""
+  """Gaussian: mean/std interpretation, every env gets an independent draw."""
   torch.manual_seed(42)
-  env = create_test_env(device, num_envs=128)
+  num_envs = 128
+  env = create_test_env(device, num_envs=num_envs)
 
   mean, std = 0.5, 0.05
   dr.geom_friction(
@@ -230,7 +231,34 @@ def test_gaussian_distribution(device):
   )
 
   vals = env.sim.model.geom_friction[:, env.scene["robot"].indexing.geom_ids[0], 0]
+  # Exact float32 collisions between independent draws are possible, so require most
+  # values to differ, not all.
+  assert len(torch.unique(vals)) > num_envs // 2
   assert abs(vals.mean().item() - mean) < 0.05
+  # Rejects a differently-shaped distribution (uniform here has std ~0.014) while
+  # clearing the worst deviation over 50k seeds on CPU and CUDA (0.017).
+  assert abs(vals.std().item() - std) < 0.025
+
+
+def test_gaussian_two_dim_field_and_env_subset(device):
+  """Gaussian on a 2D field: only the selected envs change, and they differ."""
+  torch.manual_seed(42)
+  env = create_test_env(device, num_envs=32)
+  dof_adr = env.scene["robot"].indexing.joint_v_adr
+
+  before = env.sim.model.dof_damping[:, dof_adr].clone()
+  dr.joint_damping(
+    env,
+    env_ids=torch.arange(0, 32, 2, device=device),
+    ranges=(5.0, 0.5),
+    operation="abs",
+    distribution="gaussian",
+    asset_cfg=SceneEntityCfg("robot", joint_names=(".*",)),
+  )
+  after = env.sim.model.dof_damping[:, dof_adr]
+
+  assert torch.equal(after[1::2], before[1::2])
+  assert len(torch.unique(after[::2])) > after[::2].numel() // 2
 
 
 # Axes.

--- a/tests/test_domain_randomization.py
+++ b/tests/test_domain_randomization.py
@@ -261,6 +261,24 @@ def test_gaussian_two_dim_field_and_env_subset(device):
   assert len(torch.unique(after[::2])) > after[::2].numel() // 2
 
 
+def test_gaussian_quat_field(device):
+  """Gaussian on a quat field: the 0-dim angle bounds still sample per env."""
+  torch.manual_seed(42)
+  num_envs = 32
+  env = create_test_env(device, num_envs=num_envs, expand_fields=("body_quat",))
+
+  dr.body_quat(
+    env,
+    env_ids=None,
+    roll_range=(0.0, 0.2),
+    distribution="gaussian",
+    asset_cfg=SceneEntityCfg("robot", body_names=("base",)),
+  )
+
+  quats = env.sim.model.body_quat[:, env.scene["robot"].indexing.body_ids[0]]
+  assert len(torch.unique(quats, dim=0)) > num_envs // 2
+
+
 # Axes.
 
 

--- a/tests/test_lab_api_math.py
+++ b/tests/test_lab_api_math.py
@@ -4,7 +4,7 @@ import pytest
 import torch
 from conftest import get_test_device
 
-from mjlab.utils.lab_api.math import apply_delta_pose
+from mjlab.utils.lab_api.math import apply_delta_pose, sample_gaussian
 
 
 @pytest.fixture
@@ -24,3 +24,57 @@ def test_apply_delta_pose_zero_rotation_is_finite_and_identity(device):
   assert torch.isfinite(target_rot).all()
   assert torch.allclose(target_pos, source_pos)
   assert torch.allclose(target_rot, source_rot)
+
+
+# sample_gaussian.
+
+
+@pytest.mark.parametrize(
+  "size, expected_shape",
+  [
+    (8, (8,)),
+    ((4, 3), (4, 3)),
+  ],
+)
+@pytest.mark.parametrize("as_tensor", [False, True])
+def test_sample_gaussian_honors_size(device, size, expected_shape, as_tensor):
+  """Output shape is always ``size``, whether mean/std are scalars or tensors."""
+  if as_tensor:
+    mean = torch.tensor([0.5], device=device)
+    std = torch.tensor([0.05], device=device)
+  else:
+    mean, std = 0.5, 0.05
+
+  out = sample_gaussian(mean, std, size, device=device)
+
+  assert out.shape == expected_shape
+
+
+def test_sample_gaussian_applies_mean_and_std(device):
+  """Samples are exactly ``mean + std * noise`` for a shared noise draw."""
+  mean = torch.tensor([0.5], device=device)
+  std = torch.tensor([0.05], device=device)
+
+  torch.manual_seed(0)
+  out = sample_gaussian(mean, std, (128,), device=device)
+  torch.manual_seed(0)
+  expected = 0.5 + 0.05 * torch.randn(128, device=device)
+
+  torch.testing.assert_close(out, expected)
+
+
+def test_sample_gaussian_broadcasts_per_element_mean(device):
+  """A mean shaped per-row broadcasts across the trailing dimension."""
+  mean = torch.tensor([[0.0], [10.0], [20.0], [30.0]], device=device)
+
+  out = sample_gaussian(mean, 0.0, (4, 3), device=device)
+
+  torch.testing.assert_close(out, mean.expand(4, 3))
+
+
+def test_sample_gaussian_rejects_unbroadcastable_mean(device):
+  """A mean that cannot broadcast to ``size`` raises instead of resizing the output."""
+  mean = torch.zeros(4, device=device)
+
+  with pytest.raises(RuntimeError):
+    sample_gaussian(mean, 1.0, (3,), device=device)


### PR DESCRIPTION
sample_gaussian ignored its size argument when mean and std were tensors, which is exactly what the domain randomization engine always passes, so distribution="gaussian" gave every environment one shared sample rather than an independent draw. It now expands both parameters to size, and the custom distribution example in the docs no longer teaches the same mistake.