### PR TITLE
Fix BuiltinPdActuator ctrl layout when sort_actuators=True

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -15,6 +15,11 @@ Changed
 Fixed
 ^^^^^
 
+- ``BuiltinPdActuator`` now keeps its ``[pos..., vel...]`` ctrl layout when the
+  entity uses ``sort_actuators=True``. The per-target ``edit_spec`` calls
+  interleaved the position and velocity elements, so position targets were
+  written to velocity actuators and vice versa, silently corrupting the PD
+  torques (and the ``dr.pd_gains`` randomization).
 - Capped ``wandb`` below 0.29, which removed the ``start_method`` setting still passed
   by ``rsl-rl-lib`` and crashed training runs launched with ``--logger wandb``.
 - ``distribution="gaussian"`` domain randomization now draws an independent value per

--- a/src/mjlab/actuator/builtin_actuator.py
+++ b/src/mjlab/actuator/builtin_actuator.py
@@ -11,6 +11,7 @@ from enum import IntEnum
 from typing import TYPE_CHECKING
 
 import mujoco
+import mujoco_warp as mjwarp
 import numpy as np
 import torch
 
@@ -143,6 +144,12 @@ class BuiltinPdActuator(Actuator[BuiltinPdActuatorCfg]):
     target_names: list[str],
   ) -> None:
     super().__init__(cfg, entity, target_ids, target_names)
+    # Pos/vel elements tracked separately so the [pos..., vel...] ctrl block
+    # layout can be restored in initialize() even when edit_spec is called
+    # once per target (EntityCfg.sort_actuators=True), which would otherwise
+    # interleave them.
+    self._pos_mjs_actuators: list[mujoco.MjsActuator] = []
+    self._vel_mjs_actuators: list[mujoco.MjsActuator] = []
 
   @property
   def num_targets(self) -> int:
@@ -165,7 +172,7 @@ class BuiltinPdActuator(Actuator[BuiltinPdActuatorCfg]):
         viscous_damping=self.cfg.viscous_damping,
         transmission_type=self.cfg.transmission_type,
       )
-      self._mjs_actuators.append(pos_act)
+      self._pos_mjs_actuators.append(pos_act)
     for target_name in target_names:
       vel_act = create_velocity_actuator(
         spec,
@@ -174,7 +181,7 @@ class BuiltinPdActuator(Actuator[BuiltinPdActuatorCfg]):
         damping=self.cfg.damping,
         transmission_type=self.cfg.transmission_type,
       )
-      self._mjs_actuators.append(vel_act)
+      self._vel_mjs_actuators.append(vel_act)
     # Effort limit: sum-clamp on the joint/tendon, not on each element.
     if self.cfg.effort_limit is not None:
       lim = self.cfg.effort_limit
@@ -185,6 +192,21 @@ class BuiltinPdActuator(Actuator[BuiltinPdActuatorCfg]):
           target = spec.tendon(target_name)
         target.actfrclimited = mujoco.mjtLimited.mjLIMITED_TRUE
         target.actfrcrange[:] = np.array([-lim, lim])
+
+  def initialize(
+    self,
+    mj_model: mujoco.MjModel,
+    model: mjwarp.Model,
+    data: mjwarp.Data,
+    device: str,
+  ) -> None:
+    # edit_spec may have been called once per target (sort_actuators=True),
+    # interleaving pos/vel elements in the spec. The order the elements appear
+    # in the spec does not matter; what matters is the order of ctrl_ids,
+    # which is derived from _mjs_actuators in the base class. Restore the
+    # [pos..., vel...] block layout that compute() and dr.pd_gains rely on.
+    self._mjs_actuators = self._pos_mjs_actuators + self._vel_mjs_actuators
+    super().initialize(mj_model, model, data, device)
 
   def compute(self, cmd: ActuatorCmd) -> torch.Tensor:
     return torch.cat((cmd.position_target, cmd.velocity_target), dim=1)

--- a/tests/test_builtin_pd_actuator.py
+++ b/tests/test_builtin_pd_actuator.py
@@ -57,6 +57,26 @@ def _make_entity(
   return create_entity_with_actuator(ROBOT_XML, cfg)
 
 
+def _make_sorted_entity() -> Entity:
+  """Same actuator, but with EntityCfg.sort_actuators=True (per-target
+  edit_spec calls)."""
+  cfg = EntityCfg(
+    spec_fn=lambda: mujoco.MjSpec.from_string(ROBOT_XML),
+    articulation=EntityArticulationInfoCfg(
+      actuators=(
+        BuiltinPdActuatorCfg(
+          target_names_expr=("joint.*",),
+          stiffness=KP,
+          damping=KD,
+          effort_limit=None,
+        ),
+      )
+    ),
+    sort_actuators=True,
+  )
+  return Entity(cfg)
+
+
 def _at_rest_with_targets(
   entity: Entity,
   sim,
@@ -94,6 +114,28 @@ def test_two_ctrls_per_target_with_pos_then_vel_layout(device):
   names = [sim.mj_model.actuator(i).name for i in act.global_ctrl_ids.tolist()]
   assert names[:n] == [f"{name}_pd_pos" for name in act.target_names]
   assert names[n:] == [f"{name}_pd_vel" for name in act.target_names]
+
+
+def test_sort_actuators_keeps_pos_then_vel_layout(device):
+  """With sort_actuators=True, edit_spec is called once per target, which
+  interleaves pos/vel elements in the spec. The ctrl order seen by compute()
+  and dr.pd_gains must still be [pos..., vel...], and the resulting torques
+  must match the unsorted path."""
+  entity, sim = initialize_entity(_make_sorted_entity(), device)
+  act = entity.actuators[0]
+  assert isinstance(act, BuiltinPdActuator)
+
+  n = act.num_targets
+  names = [sim.mj_model.actuator(i).name for i in act.global_ctrl_ids.tolist()]
+  assert names[:n] == [f"{name}_pd_pos" for name in act.target_names]
+  assert names[n:] == [f"{name}_pd_vel" for name in act.target_names]
+
+  pos = torch.tensor([[0.1, -0.05]], device=device)
+  vel = torch.tensor([[0.2, -0.1]], device=device)
+  _at_rest_with_targets(entity, sim, device, pos, vel)
+  v_adr = entity.indexing.joint_v_adr
+  expected = KP * pos[0] + KD * vel[0]
+  assert torch.allclose(sim.data.qfrc_actuator[0, v_adr], expected, atol=1e-4)
 
 
 def test_site_transmission_rejected():


### PR DESCRIPTION
With sort_actuators=True, Entity._add_actuators calls edit_spec once per target, so the `<position>` and `<velocity>`elements of BuiltinPdActuator end up interleaved in the spec as [pos_0, vel_0, pos_1, vel_1]. compute() still emits [pos..., vel...] and dr.pd_gains slices ctrl ids under the same block assumption, so position targets were applied to velocity actuators and vice versa, silently corrupting the PD torques.

The actuator now records the position and velocity elements separately and restores the block layout in initialize() before the base class derives ctrl ids from it.

Fixes #1170.