### PR TITLE
Fix flat patch sampling collapsing to the center when patch_radius=0

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -15,15 +15,14 @@ Changed
 Fixed
 ^^^^^
 
-- ``FlatPatchSamplingCfg(patch_radius=0)`` no longer collapses every patch to
-  the sub-terrain center. The edge-exclusion mask used negative-zero slicing
-  (``arr[-0:]`` is ``arr[0:]``), which cleared the whole valid mask and left
-  the center fallback as the only sampled point.
 - Capped ``wandb`` below 0.29, which removed the ``start_method`` setting still passed
   by ``rsl-rl-lib`` and crashed training runs launched with ``--logger wandb``.
 - ``distribution="gaussian"`` domain randomization now draws an independent value per
   environment. ``sample_gaussian`` ignored its ``size`` argument when ``mean``/``std``
   were tensors, so every environment received the same sample :issue:`1168`.
+- ``FlatPatchSamplingCfg(patch_radius=0)`` no longer collapses every patch to the
+  sub-terrain center. The edge-exclusion mask sliced ``arr[-0:]``, which is
+  ``arr[0:]``, so it cleared the entire valid mask :issue:`1171`.
 
 Version 1.6.0 (August 8, 2026)
 ------------------------------

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -15,6 +15,10 @@ Changed
 Fixed
 ^^^^^
 
+- ``FlatPatchSamplingCfg(patch_radius=0)`` no longer collapses every patch to
+  the sub-terrain center. The edge-exclusion mask used negative-zero slicing
+  (``arr[-0:]`` is ``arr[0:]``), which cleared the whole valid mask and left
+  the center fallback as the only sampled point.
 - Capped ``wandb`` below 0.29, which removed the ``start_method`` setting still passed
   by ``rsl-rl-lib`` and crashed training runs launched with ``--logger wandb``.
 - ``distribution="gaussian"`` domain randomization now draws an independent value per

--- a/src/mjlab/terrains/terrain_generator.py
+++ b/src/mjlab/terrains/terrain_generator.py
@@ -20,7 +20,8 @@ class FlatPatchSamplingCfg:
   num_patches: int = 10
   """Number of flat patches to sample per sub-terrain."""
   patch_radius: float = 0.5
-  """Radius of the circular footprint used to test flatness, in meters."""
+  """Radius of the circular footprint used to test flatness, in meters. ``0``
+  tests a single pixel, which accepts every location."""
   max_height_diff: float = 0.05
   """Maximum allowed height variation within the patch footprint, in meters."""
   x_range: tuple[float, float] = (-1e6, 1e6)

--- a/src/mjlab/terrains/utils.py
+++ b/src/mjlab/terrains/utils.py
@@ -67,14 +67,12 @@ def find_flat_patches_from_heightfield(
   valid_mask = (max_h - min_h) <= cfg.max_height_diff
 
   # Exclude pixels whose footprint would extend outside the array. This
-  # ensures the full patch circle lies within the heightfield bounds.
-  # Guard against radius_pixels == 0: numpy's arr[-0:] is arr[0:], which
-  # would wipe the entire mask instead of excluding nothing.
-  if radius_pixels > 0:
-    valid_mask[:radius_pixels, :] = False
-    valid_mask[-radius_pixels:, :] = False
-    valid_mask[:, :radius_pixels] = False
-    valid_mask[:, -radius_pixels:] = False
+  # ensures the full patch circle lies within the heightfield bounds. Far edges
+  # index from num_rows/num_cols, not from -radius_pixels: arr[-0:] is arr[0:].
+  valid_mask[:radius_pixels, :] = False
+  valid_mask[num_rows - radius_pixels :, :] = False
+  valid_mask[:, :radius_pixels] = False
+  valid_mask[:, num_cols - radius_pixels :] = False
 
   # Apply spatial range constraints.
   # MuJoCo hfield convention: columns map to the x-axis, rows map to the

--- a/src/mjlab/terrains/utils.py
+++ b/src/mjlab/terrains/utils.py
@@ -68,10 +68,13 @@ def find_flat_patches_from_heightfield(
 
   # Exclude pixels whose footprint would extend outside the array. This
   # ensures the full patch circle lies within the heightfield bounds.
-  valid_mask[:radius_pixels, :] = False
-  valid_mask[-radius_pixels:, :] = False
-  valid_mask[:, :radius_pixels] = False
-  valid_mask[:, -radius_pixels:] = False
+  # Guard against radius_pixels == 0: numpy's arr[-0:] is arr[0:], which
+  # would wipe the entire mask instead of excluding nothing.
+  if radius_pixels > 0:
+    valid_mask[:radius_pixels, :] = False
+    valid_mask[-radius_pixels:, :] = False
+    valid_mask[:, :radius_pixels] = False
+    valid_mask[:, -radius_pixels:] = False
 
   # Apply spatial range constraints.
   # MuJoCo hfield convention: columns map to the x-axis, rows map to the

--- a/tests/test_flat_patch_sampling.py
+++ b/tests/test_flat_patch_sampling.py
@@ -74,6 +74,19 @@ def test_fallback_when_no_valid_patches(rng: np.random.Generator):
   np.testing.assert_allclose(patches[:, 1], center_y)
 
 
+def test_zero_patch_radius(rng: np.random.Generator):
+  """patch_radius=0 means point-wise samples: every pixel of a flat region is
+  valid, so patches must spread out instead of falling back to the center."""
+  heights = np.zeros((80, 80), dtype=np.float64)
+  cfg = FlatPatchSamplingCfg(num_patches=10, patch_radius=0.0, max_height_diff=0.1)
+  patches = find_flat_patches_from_heightfield(
+    heights=heights, horizontal_scale=0.1, z_offset=0.0, cfg=cfg, rng=rng
+  )
+  assert patches.shape == (10, 3)
+  # The whole heightfield is valid; samples must not collapse to the center.
+  assert len(np.unique(patches[:, :2], axis=0)) > 1
+
+
 def test_patches_respect_edge_margin(rng: np.random.Generator):
   """No patch center should be within patch_radius of the heightfield edge."""
   heights = np.zeros((80, 80), dtype=np.float64)

--- a/tests/test_flat_patch_sampling.py
+++ b/tests/test_flat_patch_sampling.py
@@ -75,16 +75,16 @@ def test_fallback_when_no_valid_patches(rng: np.random.Generator):
 
 
 def test_zero_patch_radius(rng: np.random.Generator):
-  """patch_radius=0 means point-wise samples: every pixel of a flat region is
-  valid, so patches must spread out instead of falling back to the center."""
-  heights = np.zeros((80, 80), dtype=np.float64)
-  cfg = FlatPatchSamplingCfg(num_patches=10, patch_radius=0.0, max_height_diff=0.1)
+  """patch_radius=0 excludes no edge pixels, so every pixel stays valid."""
+  heights = np.zeros((4, 4), dtype=np.float64)
+  cfg = FlatPatchSamplingCfg(num_patches=16, patch_radius=0.0, max_height_diff=0.1)
   patches = find_flat_patches_from_heightfield(
     heights=heights, horizontal_scale=0.1, z_offset=0.0, cfg=cfg, rng=rng
   )
-  assert patches.shape == (10, 3)
-  # The whole heightfield is valid; samples must not collapse to the center.
-  assert len(np.unique(patches[:, :2], axis=0)) > 1
+  # All 16 pixels are valid, so the draw covers the grid exactly.
+  assert len(np.unique(patches[:, :2], axis=0)) == 16
+  np.testing.assert_allclose(np.unique(patches[:, 0]), [0.0, 0.1, 0.2, 0.3])
+  np.testing.assert_allclose(np.unique(patches[:, 1]), [0.0, 0.1, 0.2, 0.3])
 
 
 def test_patches_respect_edge_margin(rng: np.random.Generator):


### PR DESCRIPTION
The edge-exclusion mask in find_flat_patches_from_heightfield used negative-zero slicing: valid_mask[-0:] is valid_mask[0:], so with radius_pixels == 0 the whole valid mask was cleared even though a zero-radius footprint is valid on every flat pixel. Every patch then fell back to the sub-terrain center.

The exclusion is now skipped when radius_pixels == 0.

Fixes #1171.