### PR TITLE
Add teacher-student distillation with DAgger and RL fine-tuning

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -78,6 +78,7 @@ Table of Contents
    :caption: Training & Debugging
 
    source/training/rsl_rl
+   source/training/distillation
    source/viewers
    source/training/distributed_training
    source/training/cloud

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -5,6 +5,24 @@ Changelog
 Upcoming version (not yet released)
 -----------------------------------
 
+Added
+^^^^^
+
+- Teacher-student distillation and RL fine-tuning support following
+  `arXiv:2505.11164 <https://arxiv.org/abs/2505.11164>`_.
+  ``MjlabDistillationRunner`` wraps rsl-rl's DAgger-style ``Distillation``
+  algorithm with mjlab checkpoint handling (``teacher_checkpoints`` loads
+  frozen teachers from PPO checkpoints), ``MultiTeacherModel`` distills
+  several experts into one student with per-env expert assignment,
+  ``init_checkpoint`` initializes a PPO actor from a distilled student with
+  a reduced action std, and ``CriticWarmupPPO`` freezes the actor while the
+  critic warms up. New example tasks
+  ``Mjlab-Velocity-Rough-Unitree-G1-Distill`` (height-scan teacher into a
+  blind recurrent student) and
+  ``Mjlab-Velocity-Rough-Unitree-G1-Distill-Finetune`` (asymmetric PPO
+  fine-tuning of the distilled student). See the new "Teacher-Student
+  Distillation" documentation page.
+
 Changed
 ^^^^^^^
 

--- a/docs/source/training/distillation.rst
+++ b/docs/source/training/distillation.rst
@@ -1,0 +1,101 @@
+============================
+Teacher-Student Distillation
+============================
+
+mjlab supports DAgger-style teacher-student distillation and subsequent RL
+fine-tuning of the distilled policy, following the recipe of `Parkour in the
+Wild <https://arxiv.org/abs/2505.11164>`_ (Rudin et al., 2025). The typical
+use case: a teacher trained with privileged observations (e.g. a terrain
+height scan) is compressed into a student that only sees deployable
+observations (e.g. proprioception only), and the student is then fine-tuned
+with PPO to recover or exceed teacher performance.
+
+The pipeline has three stages:
+
+1. **Train a teacher** with RL as usual (e.g.
+   ``Mjlab-Velocity-Rough-Unitree-G1``).
+2. **Distill** the teacher into a student with
+   ``MjlabDistillationRunner``. The student acts in the environment while
+   the frozen teacher labels every visited state, and the student
+   regresses onto those labels. Because data is collected under the
+   student's own state distribution (with zero-mean Gaussian exploration
+   noise from its action distribution), this is on-policy dataset
+   aggregation (DAgger), not behavior cloning.
+3. **RL fine-tune** the student with PPO, keeping the privileged critic
+   observations (asymmetric PPO). The actor is initialized from the
+   distillation checkpoint via ``init_checkpoint``, starts with a reduced
+   action std, and is frozen for an initial critic warmup phase so the
+   randomly initialized value function cannot destroy the distilled
+   behavior.
+
+Example: G1 velocity
+--------------------
+
+Stage 1 -- train the rough-terrain teacher:
+
+.. code-block:: sh
+
+   uv run train Mjlab-Velocity-Rough-Unitree-G1
+
+Stage 2 -- distill into a blind recurrent student. The student sees the
+teacher's proprioceptive observations (with noise) but not the height scan,
+so an LSTM is used to infer the terrain from history:
+
+.. code-block:: sh
+
+   uv run train Mjlab-Velocity-Rough-Unitree-G1-Distill \
+     --agent.teacher-checkpoints /path/to/teacher/model_30000.pt
+
+Stage 3 -- RL fine-tune the distilled student:
+
+.. code-block:: sh
+
+   uv run train Mjlab-Velocity-Rough-Unitree-G1-Distill-Finetune \
+     --agent.init-checkpoint /path/to/distill/model_5000.pt
+
+Configuration
+-------------
+
+Distillation is configured with ``RslRlDistillationRunnerCfg``:
+
+- ``student`` / ``teacher``: model configs. The teacher config must match
+  the architecture the teacher checkpoint was trained with (including its
+  distribution config) so its ``actor_state_dict`` loads strictly. Give
+  the student a Gaussian distribution: its ``init_std`` sets the fixed
+  exploration-noise scale during data collection (the std receives no
+  gradient from the distillation loss).
+- ``teacher_checkpoints``: checkpoint path(s) for the frozen teacher(s).
+- ``obs_groups``: maps the ``student`` and ``teacher`` observation sets to
+  environment observation groups. The environment must define these
+  groups; see ``mjlab.tasks.velocity.distillation_env_cfg`` for helpers
+  that derive them from an existing actor/critic layout.
+- ``inherit_env_state_from_teacher``: restores the environment's
+  ``common_step_counter`` from the teacher checkpoint so time-based
+  curricula and randomization schedules start fully ramped up.
+
+Fine-tuning uses the regular ``RslRlOnPolicyRunnerCfg`` with two additions:
+
+- ``init_checkpoint``: initializes the actor from a distillation (or PPO)
+  checkpoint. Only model weights are restored; distribution parameters are
+  dropped so the configured (reduced) ``init_std`` applies.
+- ``RslRlCriticWarmupPpoAlgorithmCfg.critic_warmup_updates``: number of
+  PPO updates during which the actor stays frozen while the critic trains.
+
+Multi-expert distillation
+-------------------------
+
+Several skill- or terrain-specific experts can be distilled into a single
+generalist student in one run. Configure the teacher as a
+``RslRlMultiTeacherModelCfg`` with one model config per expert and one
+checkpoint per expert in ``teacher_checkpoints``. Each environment is
+labeled by the expert selected through an integer observation group
+(``assignment_group``, default ``"teacher_assignment"``), e.g. the per-env
+terrain type exposed by ``mjlab.tasks.velocity.mdp.terrain_type``. Pass
+``teacher_assignment=True`` to
+``mjlab.tasks.velocity.distillation_env_cfg.to_distillation_env_cfg`` to
+add that group to a velocity task.
+
+Iterative extension (new skills without forgetting old ones) works by
+chaining stages: use ``init_checkpoint`` to seed a new distillation round
+with the previous generalist student, add the new expert to the teacher
+set, and fine-tune again on the expanded task distribution.

--- a/src/mjlab/rl/__init__.py
+++ b/src/mjlab/rl/__init__.py
@@ -1,6 +1,16 @@
 from mjlab.rl.config import RslRlBaseRunnerCfg as RslRlBaseRunnerCfg
+from mjlab.rl.config import (
+  RslRlCriticWarmupPpoAlgorithmCfg as RslRlCriticWarmupPpoAlgorithmCfg,
+)
+from mjlab.rl.config import (
+  RslRlDistillationAlgorithmCfg as RslRlDistillationAlgorithmCfg,
+)
+from mjlab.rl.config import RslRlDistillationRunnerCfg as RslRlDistillationRunnerCfg
 from mjlab.rl.config import RslRlModelCfg as RslRlModelCfg
+from mjlab.rl.config import RslRlMultiTeacherModelCfg as RslRlMultiTeacherModelCfg
 from mjlab.rl.config import RslRlOnPolicyRunnerCfg as RslRlOnPolicyRunnerCfg
 from mjlab.rl.config import RslRlPpoAlgorithmCfg as RslRlPpoAlgorithmCfg
+from mjlab.rl.multi_teacher import MultiTeacherModel as MultiTeacherModel
+from mjlab.rl.runner import MjlabDistillationRunner as MjlabDistillationRunner
 from mjlab.rl.runner import MjlabOnPolicyRunner as MjlabOnPolicyRunner
 from mjlab.rl.vecenv_wrapper import RslRlVecEnvWrapper as RslRlVecEnvWrapper

--- a/src/mjlab/rl/config.py
+++ b/src/mjlab/rl/config.py
@@ -143,3 +143,115 @@ class RslRlOnPolicyRunnerCfg(RslRlBaseRunnerCfg):
   """The critic configuration."""
   algorithm: RslRlPpoAlgorithmCfg = field(default_factory=RslRlPpoAlgorithmCfg)
   """The algorithm configuration."""
+  init_checkpoint: str | None = None
+  """Optional checkpoint to initialize the actor from before training.
+
+  Unlike ``resume``, only model weights are restored (no optimizer state or
+  iteration count). Supports PPO checkpoints (``actor_state_dict``) and
+  distillation checkpoints (``student_state_dict``), enabling RL fine-tuning
+  of a distilled student policy. Distribution parameters (e.g. the action
+  std) are intentionally not restored so the configured ``init_std``
+  applies, following the reduced-initial-std recipe of arXiv:2505.11164.
+  """
+
+
+@dataclass
+class RslRlCriticWarmupPpoAlgorithmCfg(RslRlPpoAlgorithmCfg):
+  """PPO with an initial critic-only warmup phase.
+
+  For the first ``critic_warmup_updates`` updates the actor is frozen and
+  only the critic (and normalizers) train. Used when fine-tuning a distilled
+  policy with RL: the pre-trained policy would otherwise be destroyed by
+  gradients from a randomly initialized value function (arXiv:2505.11164).
+  """
+
+  critic_warmup_updates: int = 0
+  """Number of updates during which the actor parameters stay frozen."""
+  class_name: str = "mjlab.rl.ppo:CriticWarmupPPO"
+
+
+@dataclass
+class RslRlDistillationAlgorithmCfg:
+  """Config for DAgger-style teacher-student distillation.
+
+  The student acts in the environment (sampling from its own action
+  distribution for exploration noise) while the teacher labels every visited
+  state; the student regresses onto the teacher actions. This is on-policy
+  dataset aggregation (DAgger), not behavior cloning of teacher rollouts.
+  """
+
+  num_learning_epochs: int = 1
+  """The number of learning epochs per update."""
+  gradient_length: int = 15
+  """Number of consecutive steps per backpropagation (truncated BPTT length
+  for recurrent students). Should divide num_learning_epochs *
+  num_steps_per_env, otherwise trailing steps are never backpropagated.
+  """
+  learning_rate: float = 1e-3
+  """The learning rate for the student."""
+  max_grad_norm: float | None = 1.0
+  """The maximum gradient norm. None disables clipping."""
+  loss_type: Literal["mse", "huber"] = "mse"
+  """The regression loss between student and teacher actions."""
+  optimizer: Literal["adam", "adamw", "sgd", "rmsprop"] = "adam"
+  """The optimizer to use."""
+  class_name: str = "Distillation"
+  """Algorithm class name resolved by RSL-RL."""
+
+
+@dataclass
+class RslRlMultiTeacherModelCfg:
+  """Config for a multi-expert teacher (arXiv:2505.11164).
+
+  Wraps several frozen expert models; each environment is labeled by the
+  expert selected via an integer observation group (e.g. the terrain type),
+  so a single student distills all experts at once.
+  """
+
+  teachers: Tuple[RslRlModelCfg, ...] = ()
+  """One model config per expert. All experts share the teacher obs set."""
+  assignment_group: str = "teacher_assignment"
+  """Observation group holding the per-env expert index, shape (num_envs, 1).
+  This group must exist in the environment observations but should not be
+  listed in the runner's ``obs_groups``.
+  """
+  class_name: str = "mjlab.rl.multi_teacher:MultiTeacherModel"
+  """Model class resolved by RSL-RL."""
+
+
+@dataclass
+class RslRlDistillationRunnerCfg(RslRlBaseRunnerCfg):
+  class_name: str = "DistillationRunner"
+  """The runner class name."""
+  student: RslRlModelCfg = field(
+    default_factory=lambda: RslRlModelCfg(
+      distribution_cfg={
+        "class_name": "GaussianDistribution",
+        "init_std": 0.5,
+        "std_type": "scalar",
+      }
+    )
+  )
+  """The student configuration. Give the student a distribution so rollouts
+  carry zero-mean exploration noise (the std receives no gradient from the
+  distillation loss, so ``init_std`` sets a fixed noise scale)."""
+  teacher: RslRlModelCfg | RslRlMultiTeacherModelCfg = field(
+    default_factory=RslRlModelCfg
+  )
+  """The teacher configuration. Must match the architecture the teacher
+  checkpoint was trained with (including its distribution config)."""
+  algorithm: RslRlDistillationAlgorithmCfg = field(
+    default_factory=RslRlDistillationAlgorithmCfg
+  )
+  """The algorithm configuration."""
+  obs_groups: dict[str, tuple[str, ...]] = field(
+    default_factory=lambda: {"student": ("student",), "teacher": ("teacher",)},
+  )
+  teacher_checkpoints: Tuple[str, ...] = ()
+  """Checkpoints to load the teacher(s) from. One path for a single teacher,
+  one per expert for a multi-teacher setup. PPO (``actor_state_dict``) and
+  distillation (``student_state_dict``) checkpoints are supported."""
+  inherit_env_state_from_teacher: bool = True
+  """Restore the env's common_step_counter from the (first) teacher
+  checkpoint so time-based curricula and randomization schedules start in
+  their end-of-training state rather than from scratch."""

--- a/src/mjlab/rl/exporter_utils.py
+++ b/src/mjlab/rl/exporter_utils.py
@@ -32,13 +32,15 @@ def list_to_csv_str(
 
 
 def get_base_metadata(
-  env: ManagerBasedRlEnv, run_path: str
+  env: ManagerBasedRlEnv, run_path: str, obs_group: str = "actor"
 ) -> dict[str, list | str | float]:
   """Get base metadata common to all RL policy exports.
 
   Args:
     env: The RL environment.
     run_path: W&B run path or other identifier.
+    obs_group: Observation group consumed by the exported policy (e.g.
+      "student" for distilled policies).
 
   Returns:
     Dictionary of metadata fields that are common across all tasks.
@@ -64,10 +66,10 @@ def get_base_metadata(
   observation_term_flatten_history_dim: list = []
   observation_term_history_length: list = []
   observation_term_clip: list = []
-  observation_names = env.observation_manager.active_terms["actor"]
+  observation_names = env.observation_manager.active_terms[obs_group]
 
   for active_term in observation_names:
-    cfg = env.observation_manager.get_term_cfg("actor", active_term)
+    cfg = env.observation_manager.get_term_cfg(obs_group, active_term)
 
     if cfg.scale is None:
       observation_term_scale.append(1.0)

--- a/src/mjlab/rl/multi_teacher.py
+++ b/src/mjlab/rl/multi_teacher.py
@@ -1,0 +1,102 @@
+"""Multi-expert teacher model for DAgger-style distillation.
+
+Implements the multi-expert distillation setup of "Parkour in the Wild"
+(arXiv:2505.11164): several frozen terrain- or skill-specific experts label
+the student's on-policy rollouts, with each environment assigned to one
+expert via an integer observation (e.g. the terrain type).
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+from rsl_rl.models import MLPModel
+from rsl_rl.modules import HiddenState
+from rsl_rl.utils import resolve_class
+from tensordict import TensorDict
+
+from mjlab.rl.utils import clean_model_cfg
+
+
+class MultiTeacherModel(nn.Module):
+  """Dispatches each environment to one of several frozen expert models.
+
+  Exposes the subset of the rsl-rl model interface that
+  ``rsl_rl.algorithms.Distillation`` uses for the teacher. Expert selection
+  reads the ``assignment_group`` entry of the observation TensorDict, which
+  must hold the per-env expert index with shape ``(num_envs, 1)``. Because
+  the index travels with the observations, dispatch works both during
+  rollouts and when replaying stored (possibly trajectory-padded) batches.
+  """
+
+  def __init__(
+    self,
+    obs: TensorDict,
+    obs_groups: dict[str, list[str]],
+    obs_set: str,
+    output_dim: int,
+    teachers: list[dict] | tuple[dict, ...] = (),
+    assignment_group: str = "teacher_assignment",
+  ) -> None:
+    super().__init__()
+    if not teachers:
+      raise ValueError("MultiTeacherModel requires at least one teacher config.")
+    if assignment_group not in obs.keys():
+      raise ValueError(
+        f"Observation group '{assignment_group}' not found in environment "
+        f"observations {list(obs.keys())}. Add an observation group holding "
+        "the per-env expert index."
+      )
+    models: list[MLPModel] = []
+    for teacher_cfg in teachers:
+      model_class, model_kwargs = resolve_class(clean_model_cfg(dict(teacher_cfg)))
+      models.append(model_class(obs, obs_groups, obs_set, output_dim, **model_kwargs))
+    self.teachers = nn.ModuleList(models)
+    # Typed handle onto the same modules (ModuleList iteration is untyped).
+    self._models = models
+    self.assignment_group = assignment_group
+    self.is_recurrent = any(m.is_recurrent for m in models)
+
+  def forward(
+    self,
+    obs: TensorDict,
+    masks: torch.Tensor | None = None,
+    hidden_state: list[HiddenState] | None = None,
+    stochastic_output: bool = False,
+  ) -> torch.Tensor:
+    del stochastic_output  # Teacher labels are always deterministic.
+    hidden_states = (
+      hidden_state if hidden_state is not None else [None] * len(self.teachers)
+    )
+    outputs = [
+      m(obs, masks=masks, hidden_state=h)
+      for m, h in zip(self._models, hidden_states, strict=True)
+    ]
+    # Index shape (..., 1) broadcasts against action outputs (..., A).
+    index = obs[self.assignment_group].round().long()
+    result = outputs[0]
+    for i in range(1, len(outputs)):
+      result = torch.where(index == i, outputs[i], result)
+    return result
+
+  def reset(
+    self,
+    dones: torch.Tensor | None = None,
+    hidden_state: list[HiddenState] | None = None,
+  ) -> None:
+    hidden_states = (
+      hidden_state if hidden_state is not None else [None] * len(self._models)
+    )
+    for m, h in zip(self._models, hidden_states, strict=True):
+      m.reset(dones, hidden_state=h)
+
+  def get_hidden_state(self) -> list[HiddenState] | None:
+    states = [m.get_hidden_state() for m in self._models]
+    return None if all(s is None for s in states) else states
+
+  def detach_hidden_state(self, dones: torch.Tensor | None = None) -> None:
+    for m in self._models:
+      m.detach_hidden_state(dones)
+
+  def update_normalization(self, obs: TensorDict) -> None:
+    del obs  # Experts are frozen; their normalizer stats must not drift.

--- a/src/mjlab/rl/ppo.py
+++ b/src/mjlab/rl/ppo.py
@@ -1,0 +1,46 @@
+"""PPO variants for mjlab."""
+
+from __future__ import annotations
+
+from rsl_rl.algorithms import PPO
+
+
+class CriticWarmupPPO(PPO):
+  """PPO that freezes the actor for the first ``critic_warmup_updates`` updates.
+
+  When RL fine-tuning a distilled policy, the critic starts from scratch and
+  its early value estimates produce destructive policy gradients. Following
+  arXiv:2505.11164, the policy is kept frozen until the critic has trained to
+  a sufficient level. During warmup the actor's parameters (including the
+  action std) receive no gradients; observation-normalizer statistics keep
+  updating. The adaptive KL learning-rate schedule is inert during warmup
+  (KL stays exactly zero), but a ``fixed`` schedule is recommended for
+  conservative fine-tuning anyway.
+  """
+
+  def __init__(self, *args, critic_warmup_updates: int = 0, **kwargs) -> None:
+    super().__init__(*args, **kwargs)
+    self.critic_warmup_updates = critic_warmup_updates
+    self._num_updates = 0
+
+  def update(self) -> dict[str, float]:
+    warmup = self._num_updates < self.critic_warmup_updates
+    if warmup:
+      self._raw_actor.requires_grad_(False)
+    try:
+      loss_dict = super().update()
+    finally:
+      if warmup:
+        self._raw_actor.requires_grad_(True)
+    self._num_updates += 1
+    loss_dict["critic_warmup"] = float(warmup)
+    return loss_dict
+
+  def save(self) -> dict:
+    saved_dict = super().save()
+    saved_dict["ppo_num_updates"] = self._num_updates
+    return saved_dict
+
+  def load(self, loaded_dict: dict, load_cfg: dict | None, strict: bool) -> bool:
+    self._num_updates = loaded_dict.get("ppo_num_updates", self._num_updates)
+    return super().load(loaded_dict, load_cfg, strict)

--- a/src/mjlab/rl/runner.py
+++ b/src/mjlab/rl/runner.py
@@ -2,10 +2,55 @@ import os
 from pathlib import Path
 
 import torch
+from rsl_rl.algorithms import Distillation
 from rsl_rl.env import VecEnv
-from rsl_rl.runners import OnPolicyRunner
+from rsl_rl.runners import DistillationRunner, OnPolicyRunner
 
+from mjlab.rl.multi_teacher import MultiTeacherModel
+from mjlab.rl.utils import clean_model_cfg
 from mjlab.rl.vecenv_wrapper import RslRlVecEnvWrapper
+
+
+def _migrate_checkpoint(loaded_dict: dict, path: str) -> None:
+  """Migrate legacy checkpoints in place to the current rsl-rl 5.x format.
+
+  Handles pre-4.0 checkpoints (``model_state_dict`` with ``actor.*`` /
+  ``actor_obs_normalizer.*`` keys) and 4.x actor std keys.
+  """
+  if "model_state_dict" in loaded_dict:
+    print(f"Detected legacy checkpoint at {path}. Migrating to new format...")
+    model_state_dict = loaded_dict.pop("model_state_dict")
+    actor_state_dict = {}
+    critic_state_dict = {}
+
+    for key, value in model_state_dict.items():
+      # Migrate actor keys.
+      if key.startswith("actor."):
+        new_key = key.replace("actor.", "mlp.")
+        actor_state_dict[new_key] = value
+      elif key.startswith("actor_obs_normalizer."):
+        new_key = key.replace("actor_obs_normalizer.", "obs_normalizer.")
+        actor_state_dict[new_key] = value
+      elif key in ["std", "log_std"]:
+        actor_state_dict[key] = value
+
+      # Migrate critic keys.
+      if key.startswith("critic."):
+        new_key = key.replace("critic.", "mlp.")
+        critic_state_dict[new_key] = value
+      elif key.startswith("critic_obs_normalizer."):
+        new_key = key.replace("critic_obs_normalizer.", "obs_normalizer.")
+        critic_state_dict[new_key] = value
+
+    loaded_dict["actor_state_dict"] = actor_state_dict
+    loaded_dict["critic_state_dict"] = critic_state_dict
+
+  # Migrate rsl-rl 4.x actor keys to 5.x distribution keys.
+  actor_sd = loaded_dict.get("actor_state_dict", {})
+  if "std" in actor_sd:
+    actor_sd["distribution.std_param"] = actor_sd.pop("std")
+  if "log_std" in actor_sd:
+    actor_sd["distribution.log_std_param"] = actor_sd.pop("log_std")
 
 
 class MjlabOnPolicyRunner(OnPolicyRunner):
@@ -20,16 +65,44 @@ class MjlabOnPolicyRunner(OnPolicyRunner):
     log_dir: str | None = None,
     device: str = "cpu",
   ) -> None:
-    # Strip None-valued optional configs so MLPModel doesn't receive them.
-    for key in ("actor", "critic"):
+    # Strip None-valued optional configs so models don't receive them.
+    for key in ("actor", "critic", "student", "teacher"):
       if key in train_cfg:
-        for opt in ("cnn_cfg", "distribution_cfg"):
-          if train_cfg[key].get(opt) is None:
-            train_cfg[key].pop(opt, None)
-        if train_cfg[key].get("rnn_type") is None:
-          for opt in ("rnn_type", "rnn_hidden_dim", "rnn_num_layers"):
-            train_cfg[key].pop(opt, None)
+        train_cfg[key] = clean_model_cfg(train_cfg[key])
     super().__init__(env, train_cfg, log_dir, device)
+    init_checkpoint = self.cfg.get("init_checkpoint")
+    if init_checkpoint:
+      self.load_init_checkpoint(init_checkpoint)
+
+  def load_init_checkpoint(self, path: str) -> None:
+    """Initialize the policy weights from a checkpoint, nothing else.
+
+    Unlike ``load``, no optimizer state, iteration count, or env state is
+    restored. Accepts PPO checkpoints (``actor_state_dict``) as well as
+    distillation checkpoints (``student_state_dict``), so a distilled
+    student can be RL fine-tuned, and a previously distilled generalist can
+    seed a new round of distillation. Distribution parameters (the action
+    std) are dropped so the configured ``init_std`` takes effect.
+    """
+    print(f"[INFO] Initializing policy weights from checkpoint: {path}")
+    loaded_dict = torch.load(path, map_location=self.device, weights_only=False)
+    _migrate_checkpoint(loaded_dict, path)
+    state_dict = loaded_dict.get("actor_state_dict") or loaded_dict.get(
+      "student_state_dict"
+    )
+    if state_dict is None:
+      raise KeyError(f"No actor or student weights found in checkpoint: {path}")
+    state_dict = {
+      k: v for k, v in state_dict.items() if not k.startswith("distribution.")
+    }
+    policy = self.alg.get_policy()
+    missing, unexpected = policy.load_state_dict(state_dict, strict=False)
+    bad_missing = [k for k in missing if not k.startswith("distribution.")]
+    if bad_missing or unexpected:
+      raise RuntimeError(
+        f"Checkpoint {path} does not match the policy architecture. "
+        f"Missing keys: {bad_missing}. Unexpected keys: {list(unexpected)}."
+      )
 
   def export_policy_to_onnx(
     self, path: str, filename: str = "policy.onnx", verbose: bool = False
@@ -95,42 +168,7 @@ class MjlabOnPolicyRunner(OnPolicyRunner):
       -> obs_normalizer.*) to the current format (rsl-rl>=4.0).
     """
     loaded_dict = torch.load(path, map_location=map_location, weights_only=False)
-
-    if "model_state_dict" in loaded_dict:
-      print(f"Detected legacy checkpoint at {path}. Migrating to new format...")
-      model_state_dict = loaded_dict.pop("model_state_dict")
-      actor_state_dict = {}
-      critic_state_dict = {}
-
-      for key, value in model_state_dict.items():
-        # Migrate actor keys.
-        if key.startswith("actor."):
-          new_key = key.replace("actor.", "mlp.")
-          actor_state_dict[new_key] = value
-        elif key.startswith("actor_obs_normalizer."):
-          new_key = key.replace("actor_obs_normalizer.", "obs_normalizer.")
-          actor_state_dict[new_key] = value
-        elif key in ["std", "log_std"]:
-          actor_state_dict[key] = value
-
-        # Migrate critic keys.
-        if key.startswith("critic."):
-          new_key = key.replace("critic.", "mlp.")
-          critic_state_dict[new_key] = value
-        elif key.startswith("critic_obs_normalizer."):
-          new_key = key.replace("critic_obs_normalizer.", "obs_normalizer.")
-          critic_state_dict[new_key] = value
-
-      loaded_dict["actor_state_dict"] = actor_state_dict
-      loaded_dict["critic_state_dict"] = critic_state_dict
-
-    # Migrate rsl-rl 4.x actor keys to 5.x distribution keys.
-    actor_sd = loaded_dict.get("actor_state_dict", {})
-    if "std" in actor_sd:
-      actor_sd["distribution.std_param"] = actor_sd.pop("std")
-    if "log_std" in actor_sd:
-      actor_sd["distribution.log_std_param"] = actor_sd.pop("log_std")
-
+    _migrate_checkpoint(loaded_dict, path)
     load_iteration = self.alg.load(loaded_dict, load_cfg, strict)
     if load_iteration:
       self.current_learning_iteration = loaded_dict["iter"]
@@ -139,3 +177,73 @@ class MjlabOnPolicyRunner(OnPolicyRunner):
     if infos and "env_state" in infos:
       self.env.unwrapped.common_step_counter = infos["env_state"]["common_step_counter"]
     return infos
+
+
+class MjlabDistillationRunner(MjlabOnPolicyRunner, DistillationRunner):
+  """Runner for DAgger-style teacher-student distillation.
+
+  The student policy acts in the environment (sampling from its own action
+  distribution, which adds zero-mean exploration noise) while the frozen
+  teacher labels every visited state. This is on-policy dataset aggregation
+  (DAgger) rather than behavior cloning of teacher rollouts, following
+  arXiv:2505.11164. Teacher weights are loaded from the checkpoints listed
+  in the ``teacher_checkpoints`` config entry; a multi-teacher config
+  distills several experts into a single student.
+  """
+
+  alg: Distillation  # pyright: ignore[reportIncompatibleVariableOverride]
+
+  def __init__(
+    self,
+    env: VecEnv,
+    train_cfg: dict,
+    log_dir: str | None = None,
+    device: str = "cpu",
+  ) -> None:
+    super().__init__(env, train_cfg, log_dir, device)
+    teacher_checkpoints = tuple(self.cfg.get("teacher_checkpoints") or ())
+    if teacher_checkpoints:
+      self.load_teacher_checkpoints(teacher_checkpoints)
+
+  def load_teacher_checkpoints(self, paths: tuple[str, ...]) -> None:
+    """Load frozen teacher weights from PPO or distillation checkpoints.
+
+    A single-teacher setup takes exactly one path; a multi-teacher setup
+    takes one path per expert, in the order the experts are listed in the
+    teacher config. When ``inherit_env_state_from_teacher`` is set, the
+    env's ``common_step_counter`` is restored from the first checkpoint so
+    time-based curricula start in their end-of-training state.
+    """
+    teacher = self.alg._raw_teacher  # noqa: SLF001
+    if isinstance(teacher, MultiTeacherModel):
+      models = list(teacher.teachers)
+    else:
+      models = [teacher]
+    if len(paths) != len(models):
+      raise ValueError(
+        f"Got {len(paths)} teacher checkpoint(s) for {len(models)} teacher "
+        "model(s); provide exactly one checkpoint per teacher."
+      )
+
+    first_infos: dict | None = None
+    for model, path in zip(models, paths, strict=True):
+      print(f"[INFO] Loading teacher checkpoint: {path}")
+      loaded_dict = torch.load(path, map_location=self.device, weights_only=False)
+      _migrate_checkpoint(loaded_dict, path)
+      state_dict = (
+        loaded_dict.get("actor_state_dict")
+        or loaded_dict.get("student_state_dict")
+        or loaded_dict.get("teacher_state_dict")
+      )
+      if state_dict is None:
+        raise KeyError(f"No actor, student, or teacher weights found in: {path}")
+      model.load_state_dict(state_dict)
+      if first_infos is None:
+        first_infos = loaded_dict.get("infos") or {}
+    self.alg.teacher_loaded = True
+
+    if self.cfg.get("inherit_env_state_from_teacher") and first_infos:
+      if "env_state" in first_infos:
+        counter = first_infos["env_state"]["common_step_counter"]
+        self.env.unwrapped.common_step_counter = counter
+        print(f"[INFO] Inherited env common_step_counter from teacher: {counter}")

--- a/src/mjlab/rl/utils.py
+++ b/src/mjlab/rl/utils.py
@@ -1,0 +1,19 @@
+"""Helpers for translating mjlab RL configs into rsl-rl constructor kwargs."""
+
+from typing import Any
+
+
+def clean_model_cfg(cfg: dict[str, Any]) -> dict[str, Any]:
+  """Return a copy of a model config dict with unset optional keys removed.
+
+  rsl-rl model constructors do not accept ``None`` for these options, so they
+  must be dropped entirely when unset.
+  """
+  cfg = dict(cfg)
+  for opt in ("cnn_cfg", "distribution_cfg"):
+    if cfg.get(opt, "unset") is None:
+      cfg.pop(opt)
+  if cfg.get("rnn_type", "unset") is None:
+    for opt in ("rnn_type", "rnn_hidden_dim", "rnn_num_layers"):
+      cfg.pop(opt, None)
+  return cfg

--- a/src/mjlab/tasks/velocity/config/g1/__init__.py
+++ b/src/mjlab/tasks/velocity/config/g1/__init__.py
@@ -1,6 +1,12 @@
 from mjlab.tasks.registry import register_mjlab_task
-from mjlab.tasks.velocity.rl import VelocityOnPolicyRunner
+from mjlab.tasks.velocity.rl import VelocityDistillationRunner, VelocityOnPolicyRunner
 
+from .distillation_cfg import (
+  unitree_g1_distillation_env_cfg,
+  unitree_g1_distillation_runner_cfg,
+  unitree_g1_finetune_env_cfg,
+  unitree_g1_finetune_runner_cfg,
+)
 from .env_cfgs import (
   unitree_g1_flat_env_cfg,
   unitree_g1_rough_env_cfg,
@@ -20,5 +26,25 @@ register_mjlab_task(
   env_cfg=unitree_g1_flat_env_cfg(),
   play_env_cfg=unitree_g1_flat_env_cfg(play=True),
   rl_cfg=unitree_g1_ppo_runner_cfg(),
+  runner_cls=VelocityOnPolicyRunner,
+)
+
+# Stage 1: distill the rough teacher (with height scan) into a blind
+# recurrent student via DAgger. Requires --agent.teacher-checkpoints.
+register_mjlab_task(
+  task_id="Mjlab-Velocity-Rough-Unitree-G1-Distill",
+  env_cfg=unitree_g1_distillation_env_cfg(),
+  play_env_cfg=unitree_g1_distillation_env_cfg(play=True),
+  rl_cfg=unitree_g1_distillation_runner_cfg(),
+  runner_cls=VelocityDistillationRunner,
+)
+
+# Stage 2: RL fine-tune the distilled student with asymmetric PPO.
+# Requires --agent.init-checkpoint pointing at a distillation checkpoint.
+register_mjlab_task(
+  task_id="Mjlab-Velocity-Rough-Unitree-G1-Distill-Finetune",
+  env_cfg=unitree_g1_finetune_env_cfg(),
+  play_env_cfg=unitree_g1_finetune_env_cfg(play=True),
+  rl_cfg=unitree_g1_finetune_runner_cfg(),
   runner_cls=VelocityOnPolicyRunner,
 )

--- a/src/mjlab/tasks/velocity/config/g1/distillation_cfg.py
+++ b/src/mjlab/tasks/velocity/config/g1/distillation_cfg.py
@@ -1,0 +1,121 @@
+"""Distillation and RL fine-tuning configs for Unitree G1 velocity task.
+
+Stage 1 (``Mjlab-Velocity-Rough-Unitree-G1-Distill``): distill the rough
+teacher (trained with a terrain height scan) into a blind recurrent student
+via DAgger-style teacher-student distillation.
+
+Stage 2 (``Mjlab-Velocity-Rough-Unitree-G1-Distill-Finetune``): RL
+fine-tune the distilled student with asymmetric PPO (privileged critic),
+using a critic warmup phase and a reduced initial action std, following
+arXiv:2505.11164.
+"""
+
+from mjlab.envs import ManagerBasedRlEnvCfg
+from mjlab.rl import (
+  RslRlCriticWarmupPpoAlgorithmCfg,
+  RslRlDistillationAlgorithmCfg,
+  RslRlDistillationRunnerCfg,
+  RslRlModelCfg,
+  RslRlOnPolicyRunnerCfg,
+)
+from mjlab.tasks.velocity.distillation_env_cfg import (
+  to_distillation_env_cfg,
+  to_finetune_env_cfg,
+)
+
+from .env_cfgs import unitree_g1_rough_env_cfg
+from .rl_cfg import unitree_g1_ppo_runner_cfg
+
+
+def unitree_g1_distillation_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
+  return to_distillation_env_cfg(unitree_g1_rough_env_cfg(play=play))
+
+
+def unitree_g1_finetune_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
+  return to_finetune_env_cfg(unitree_g1_rough_env_cfg(play=play))
+
+
+def _student_model_cfg(init_std: float) -> RslRlModelCfg:
+  """Recurrent student: memory is needed to infer terrain without the scan."""
+  return RslRlModelCfg(
+    class_name="RNNModel",
+    rnn_type="lstm",
+    rnn_hidden_dim=256,
+    rnn_num_layers=1,
+    hidden_dims=(256, 128),
+    activation="elu",
+    obs_normalization=True,
+    distribution_cfg={
+      "class_name": "GaussianDistribution",
+      "init_std": init_std,
+      "std_type": "scalar",
+    },
+  )
+
+
+def unitree_g1_distillation_runner_cfg() -> RslRlDistillationRunnerCfg:
+  """Distillation runner config for the G1 velocity task.
+
+  The teacher config must mirror the actor of
+  :func:`unitree_g1_ppo_runner_cfg` so rough-task checkpoints load strictly.
+  Pass the teacher checkpoint via ``--agent.teacher-checkpoints <path>``.
+  """
+  teacher = unitree_g1_ppo_runner_cfg().actor
+  return RslRlDistillationRunnerCfg(
+    # init_std sets the fixed zero-mean exploration noise added to student
+    # actions during data collection (it receives no gradient).
+    student=_student_model_cfg(init_std=0.5),
+    teacher=teacher,
+    algorithm=RslRlDistillationAlgorithmCfg(
+      num_learning_epochs=1,
+      # One BPTT window per rollout: 24 steps at dt=0.02*decimation.
+      gradient_length=24,
+      learning_rate=1e-3,
+      max_grad_norm=1.0,
+      loss_type="mse",
+    ),
+    experiment_name="g1_velocity_distill",
+    save_interval=100,
+    num_steps_per_env=24,
+    max_iterations=5_000,
+  )
+
+
+def unitree_g1_finetune_runner_cfg() -> RslRlOnPolicyRunnerCfg:
+  """PPO fine-tuning config for the distilled G1 student.
+
+  Point ``--agent.init-checkpoint`` at a distillation checkpoint. The actor
+  must match the student architecture; the critic trains from scratch on
+  the privileged observations, so the actor is frozen for the first
+  ``critic_warmup_updates`` updates and starts with a reduced action std.
+  """
+  return RslRlOnPolicyRunnerCfg(
+    actor=_student_model_cfg(init_std=0.2),
+    critic=RslRlModelCfg(
+      hidden_dims=(512, 256, 128),
+      activation="elu",
+      obs_normalization=True,
+    ),
+    algorithm=RslRlCriticWarmupPpoAlgorithmCfg(
+      critic_warmup_updates=50,
+      value_loss_coef=1.0,
+      use_clipped_value_loss=True,
+      clip_param=0.2,
+      entropy_coef=0.005,
+      num_learning_epochs=5,
+      num_mini_batches=4,
+      # Conservative fine-tuning: fixed, small learning rate so the
+      # distilled behavior is not destroyed early on.
+      learning_rate=1.0e-4,
+      schedule="fixed",
+      gamma=0.99,
+      lam=0.95,
+      desired_kl=0.01,
+      max_grad_norm=1.0,
+    ),
+    obs_groups={"actor": ("student",), "critic": ("critic",)},
+    experiment_name="g1_velocity_distill_finetune",
+    save_interval=100,
+    num_steps_per_env=24,
+    max_iterations=10_000,
+  )

--- a/src/mjlab/tasks/velocity/distillation_env_cfg.py
+++ b/src/mjlab/tasks/velocity/distillation_env_cfg.py
@@ -1,0 +1,77 @@
+"""Teacher-student distillation variants of the velocity task.
+
+Transforms a fully-configured velocity env config (with "actor"/"critic"
+observation groups) into the observation layout used for the two stages of
+the distill-then-finetune pipeline of arXiv:2505.11164:
+
+- Distillation: a "teacher" group (the teacher's training observations,
+  without corruption so labels are deterministic) and a "student" group
+  (noisy, and by default blind, i.e. without the height scan, so the
+  recurrent student must infer the terrain from proprioceptive history).
+- RL fine-tuning: the same "student" group as the policy observation plus
+  the privileged "critic" group for asymmetric PPO.
+"""
+
+from dataclasses import replace
+
+from mjlab.envs import ManagerBasedRlEnvCfg
+from mjlab.managers.observation_manager import ObservationGroupCfg, ObservationTermCfg
+from mjlab.tasks.velocity import mdp
+
+STUDENT_EXCLUDED_TERMS = ("height_scan",)
+"""Actor terms hidden from the student (privileged exteroception)."""
+
+
+def _make_student_group(actor_group: ObservationGroupCfg) -> ObservationGroupCfg:
+  student_terms = {
+    name: term
+    for name, term in actor_group.terms.items()
+    if name not in STUDENT_EXCLUDED_TERMS
+  }
+  # Corruption follows the actor group: enabled for training configs,
+  # disabled for play configs.
+  return replace(actor_group, terms=student_terms)
+
+
+def to_distillation_env_cfg(
+  cfg: ManagerBasedRlEnvCfg,
+  teacher_assignment: bool = False,
+) -> ManagerBasedRlEnvCfg:
+  """Rewrite observation groups for the distillation stage.
+
+  Args:
+    cfg: A fully-configured velocity env config with "actor" and "critic"
+      observation groups. Modified in place and returned.
+    teacher_assignment: Add a "teacher_assignment" group exposing the
+      per-env terrain type, for multi-teacher distillation.
+  """
+  actor_group = cfg.observations["actor"]
+  observations = {
+    "student": _make_student_group(actor_group),
+    # The teacher sees exactly what it was trained on, but without noise so
+    # its action labels are deterministic.
+    "teacher": replace(actor_group, enable_corruption=False),
+  }
+  if teacher_assignment:
+    observations["teacher_assignment"] = ObservationGroupCfg(
+      terms={"terrain_type": ObservationTermCfg(func=mdp.terrain_type)},
+      concatenate_terms=True,
+      enable_corruption=False,
+    )
+  cfg.observations = observations
+  return cfg
+
+
+def to_finetune_env_cfg(cfg: ManagerBasedRlEnvCfg) -> ManagerBasedRlEnvCfg:
+  """Rewrite observation groups for RL fine-tuning of a distilled student.
+
+  The policy keeps the student's observation layout (so distilled weights
+  and normalizer stats transfer), while the critic keeps the privileged
+  observations for asymmetric PPO.
+  """
+  actor_group = cfg.observations["actor"]
+  cfg.observations = {
+    "student": _make_student_group(actor_group),
+    "critic": cfg.observations["critic"],
+  }
+  return cfg

--- a/src/mjlab/tasks/velocity/mdp/observations.py
+++ b/src/mjlab/tasks/velocity/mdp/observations.py
@@ -45,3 +45,14 @@ def foot_contact_forces(env: ManagerBasedRlEnv, sensor_name: str) -> torch.Tenso
   assert sensor_data.force is not None
   forces_flat = sensor_data.force.flatten(start_dim=1)  # [B, N*3]
   return torch.sign(forces_flat) * torch.log1p(torch.abs(forces_flat))
+
+
+def terrain_type(env: ManagerBasedRlEnv) -> torch.Tensor:
+  """Per-env terrain column index, shape [B, 1].
+
+  Intended as the expert-assignment observation for multi-teacher
+  distillation: each terrain type maps to the expert trained on it.
+  """
+  terrain = env.scene.terrain
+  assert terrain is not None
+  return terrain.terrain_types.float().unsqueeze(-1)

--- a/src/mjlab/tasks/velocity/rl/__init__.py
+++ b/src/mjlab/tasks/velocity/rl/__init__.py
@@ -1,3 +1,6 @@
 from mjlab.tasks.velocity.rl.runner import (
+  VelocityDistillationRunner as VelocityDistillationRunner,
+)
+from mjlab.tasks.velocity.rl.runner import (
   VelocityOnPolicyRunner as VelocityOnPolicyRunner,
 )

--- a/src/mjlab/tasks/velocity/rl/runner.py
+++ b/src/mjlab/tasks/velocity/rl/runner.py
@@ -6,22 +6,36 @@ from mjlab.rl.exporter_utils import (
   attach_metadata_to_onnx,
   get_base_metadata,
 )
-from mjlab.rl.runner import MjlabOnPolicyRunner
+from mjlab.rl.runner import MjlabDistillationRunner, MjlabOnPolicyRunner
 
 
-class VelocityOnPolicyRunner(MjlabOnPolicyRunner):
+class _OnnxExportOnSaveMixin:
+  """Exports the current policy to ONNX alongside every checkpoint save."""
+
   env: RslRlVecEnvWrapper
 
   def save(self, path: str, infos=None):
-    super().save(path, infos)
-    policy_dir, filename, onnx_path = self._get_export_paths(path)
+    super().save(path, infos)  # type: ignore[misc]
+    policy_dir, filename, onnx_path = self._get_export_paths(path)  # type: ignore[attr-defined]
     try:
-      self.export_policy_to_onnx(str(policy_dir), filename)
-      is_wandb = isinstance(self.logger.writer, WandbLogWriter)
+      self.export_policy_to_onnx(str(policy_dir), filename)  # type: ignore[attr-defined]
+      is_wandb = isinstance(self.logger.writer, WandbLogWriter)  # type: ignore[attr-defined]
       run_name: str = wandb.run.name if is_wandb and wandb.run else "local"  # type: ignore[assignment]
-      metadata = get_base_metadata(self.env.unwrapped, run_name)
+      # The exported policy consumes the "student" obs set when distilling
+      # or fine-tuning a distilled policy, and "actor" otherwise.
+      obs_sets: dict = self.cfg.get("obs_groups") or {}  # type: ignore[attr-defined]
+      policy_groups = obs_sets.get("student") or obs_sets.get("actor") or ("actor",)
+      metadata = get_base_metadata(self.env.unwrapped, run_name, policy_groups[0])
       attach_metadata_to_onnx(str(onnx_path), metadata)
-      if is_wandb and self.cfg["upload_model"]:
+      if is_wandb and self.cfg["upload_model"]:  # type: ignore[attr-defined]
         wandb.save(str(onnx_path), base_path=str(policy_dir))
     except Exception as e:
       print(f"[WARN] ONNX export failed (training continues): {e}")
+
+
+class VelocityOnPolicyRunner(_OnnxExportOnSaveMixin, MjlabOnPolicyRunner):
+  pass
+
+
+class VelocityDistillationRunner(_OnnxExportOnSaveMixin, MjlabDistillationRunner):
+  """Distillation runner that exports the student to ONNX on every save."""

--- a/tests/test_distillation.py
+++ b/tests/test_distillation.py
@@ -1,0 +1,391 @@
+"""Tests for teacher-student distillation and RL fine-tuning."""
+
+import tempfile
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+import mujoco
+import pytest
+import torch
+from conftest import get_test_device
+from tensordict import TensorDict
+
+from mjlab.actuator import XmlActuatorCfg
+from mjlab.entity import EntityArticulationInfoCfg, EntityCfg
+from mjlab.envs import ManagerBasedRlEnv, ManagerBasedRlEnvCfg, mdp
+from mjlab.managers.observation_manager import ObservationGroupCfg, ObservationTermCfg
+from mjlab.rl import (
+  MjlabDistillationRunner,
+  MjlabOnPolicyRunner,
+  MultiTeacherModel,
+  RslRlCriticWarmupPpoAlgorithmCfg,
+  RslRlDistillationAlgorithmCfg,
+  RslRlDistillationRunnerCfg,
+  RslRlModelCfg,
+  RslRlMultiTeacherModelCfg,
+  RslRlOnPolicyRunnerCfg,
+  RslRlVecEnvWrapper,
+)
+from mjlab.rl.utils import clean_model_cfg
+from mjlab.scene import SceneCfg
+from mjlab.sim import MujocoCfg, SimulationCfg
+from mjlab.terrains import TerrainEntityCfg
+
+_ROBOT_XML = """
+<mujoco>
+  <worldbody>
+    <body name="base" pos="0 0 1">
+      <freejoint name="free_joint"/>
+      <geom name="base_geom" type="box" size="0.2 0.2 0.1" mass="1.0"/>
+      <body name="link1" pos="0 0 0">
+        <joint name="joint1" type="hinge" axis="0 0 1" range="-1.57 1.57"/>
+        <geom name="link1_geom" type="box" size="0.1 0.1 0.1" mass="0.1"/>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    <motor name="actuator1" joint="joint1" gear="1.0"/>
+  </actuator>
+</mujoco>
+"""
+
+
+@pytest.fixture(scope="module")
+def device():
+  return get_test_device()
+
+
+def _make_env(device, observations: dict[str, ObservationGroupCfg]):
+  robot_cfg = EntityCfg(
+    spec_fn=lambda: mujoco.MjSpec.from_string(_ROBOT_XML),
+    articulation=EntityArticulationInfoCfg(
+      actuators=(XmlActuatorCfg(target_names_expr=(".*",)),)
+    ),
+  )
+  env_cfg = ManagerBasedRlEnvCfg(
+    scene=SceneCfg(
+      terrain=TerrainEntityCfg(terrain_type="plane"),
+      num_envs=2,
+      extent=1.0,
+      entities={"robot": robot_cfg},
+    ),
+    observations=observations,
+    actions={
+      "joint_pos": mdp.JointPositionActionCfg(
+        entity_name="robot", actuator_names=(".*",), scale=1.0
+      )
+    },
+    sim=SimulationCfg(mujoco=MujocoCfg(timestep=0.01, iterations=1)),
+    decimation=1,
+    episode_length_s=1.0,
+  )
+  return ManagerBasedRlEnv(cfg=env_cfg, device=device)
+
+
+def _joint_pos_term():
+  return ObservationTermCfg(func=lambda env: env.scene["robot"].data.joint_pos)
+
+
+def _joint_vel_term():
+  return ObservationTermCfg(func=lambda env: env.scene["robot"].data.joint_vel)
+
+
+@pytest.fixture(scope="module")
+def distill_env(device):
+  """Env with student/teacher groups plus an expert-assignment group."""
+  env = _make_env(
+    device,
+    observations={
+      "student": ObservationGroupCfg(terms={"joint_pos": _joint_pos_term()}),
+      "teacher": ObservationGroupCfg(
+        terms={"joint_pos": _joint_pos_term(), "joint_vel": _joint_vel_term()}
+      ),
+      "teacher_assignment": ObservationGroupCfg(
+        terms={
+          "expert_id": ObservationTermCfg(
+            func=lambda env: (
+              torch.arange(env.num_envs, device=env.device) % 2
+            ).unsqueeze(-1)
+          )
+        },
+      ),
+    },
+  )
+  yield env
+  env.close()
+
+
+def _distillation_runner_cfg(**overrides) -> RslRlDistillationRunnerCfg:
+  defaults: dict[str, Any] = dict(
+    student=RslRlModelCfg(
+      hidden_dims=(16, 16),
+      distribution_cfg={
+        "class_name": "GaussianDistribution",
+        "init_std": 0.5,
+        "std_type": "scalar",
+      },
+    ),
+    teacher=RslRlModelCfg(hidden_dims=(16, 16)),
+    algorithm=RslRlDistillationAlgorithmCfg(gradient_length=4),
+    num_steps_per_env=4,
+    max_iterations=2,
+    save_interval=100,
+    logger="tensorboard",
+  )
+  defaults.update(overrides)
+  return RslRlDistillationRunnerCfg(**defaults)
+
+
+def test_clean_model_cfg_strips_unset_options():
+  cfg = {
+    "class_name": "MLPModel",
+    "hidden_dims": (16,),
+    "cnn_cfg": None,
+    "distribution_cfg": None,
+    "rnn_type": None,
+    "rnn_hidden_dim": 256,
+    "rnn_num_layers": 1,
+  }
+  cleaned = clean_model_cfg(cfg)
+  assert cleaned == {"class_name": "MLPModel", "hidden_dims": (16,)}
+  # Set options are preserved.
+  cfg["rnn_type"] = "lstm"
+  assert clean_model_cfg(cfg)["rnn_hidden_dim"] == 256
+
+
+def test_distillation_runner_learns_from_teacher(distill_env, device):
+  """Full DAgger loop: teacher loads from a PPO-style checkpoint and the
+  student regresses onto its labels."""
+  wrapped_env = RslRlVecEnvWrapper(distill_env)
+
+  with tempfile.TemporaryDirectory() as tmpdir:
+    # Create a synthetic "PPO" teacher checkpoint with matching architecture.
+    bootstrap = MjlabDistillationRunner(
+      wrapped_env, asdict(_distillation_runner_cfg()), log_dir=None, device=device
+    )
+    assert not bootstrap.alg.teacher_loaded
+    teacher_path = str(Path(tmpdir) / "teacher.pt")
+    torch.save(
+      {
+        "actor_state_dict": bootstrap.alg._raw_teacher.state_dict(),
+        "iter": 7,
+        "infos": {"env_state": {"common_step_counter": 42}},
+      },
+      teacher_path,
+    )
+
+    cfg = _distillation_runner_cfg(teacher_checkpoints=(teacher_path,))
+    runner = MjlabDistillationRunner(
+      wrapped_env, asdict(cfg), log_dir=tmpdir, device=device
+    )
+    assert runner.alg.teacher_loaded
+    assert wrapped_env.unwrapped.common_step_counter == 42
+
+    student = runner.alg.get_policy()
+    params_before = [p.clone() for p in student.mlp.parameters()]
+    runner.learn(num_learning_iterations=2)
+    params_after = list(student.mlp.parameters())
+    assert any(
+      not torch.allclose(b, a) for b, a in zip(params_before, params_after, strict=True)
+    ), "Student parameters did not change during distillation."
+
+    # The distillation checkpoint round-trips.
+    ckpt_path = str(Path(tmpdir) / "distilled.pt")
+    runner.save(ckpt_path)
+    loaded = torch.load(ckpt_path, weights_only=False)
+    assert "student_state_dict" in loaded
+    assert "teacher_state_dict" in loaded
+
+
+def test_multi_teacher_dispatch(distill_env, device):
+  """Each env's labels come from the expert selected by the assignment obs."""
+  wrapped_env = RslRlVecEnvWrapper(distill_env)
+  teacher_cfg = RslRlModelCfg(hidden_dims=(16, 16))
+  cfg = _distillation_runner_cfg(
+    teacher=RslRlMultiTeacherModelCfg(
+      teachers=(teacher_cfg, teacher_cfg),
+      assignment_group="teacher_assignment",
+    ),
+  )
+  runner = MjlabDistillationRunner(
+    wrapped_env, asdict(cfg), log_dir=None, device=device
+  )
+  teacher = runner.alg._raw_teacher
+  assert isinstance(teacher, MultiTeacherModel)
+
+  obs = wrapped_env.get_observations().to(device)
+  with torch.no_grad():
+    combined = teacher(obs)
+    expected_0 = teacher.teachers[0](obs)
+    expected_1 = teacher.teachers[1](obs)
+  # Env 0 is assigned expert 0, env 1 expert 1 (see distill_env fixture).
+  torch.testing.assert_close(combined[0], expected_0[0])
+  torch.testing.assert_close(combined[1], expected_1[1])
+
+  # Loading requires one checkpoint per expert.
+  with tempfile.TemporaryDirectory() as tmpdir:
+    paths = []
+    for i in range(2):
+      path = str(Path(tmpdir) / f"expert_{i}.pt")
+      torch.save(
+        {"actor_state_dict": teacher.teachers[i].state_dict(), "infos": None}, path
+      )
+      paths.append(path)
+    with pytest.raises(ValueError, match="one checkpoint per teacher"):
+      runner.load_teacher_checkpoints((paths[0],))
+    runner.load_teacher_checkpoints(tuple(paths))
+    assert runner.alg.teacher_loaded
+    runner.learn(num_learning_iterations=1)
+
+
+@pytest.fixture(scope="module")
+def finetune_env(device):
+  """Env with the student group as policy obs and a privileged critic group."""
+  env = _make_env(
+    device,
+    observations={
+      "student": ObservationGroupCfg(terms={"joint_pos": _joint_pos_term()}),
+      "critic": ObservationGroupCfg(
+        terms={"joint_pos": _joint_pos_term(), "joint_vel": _joint_vel_term()}
+      ),
+    },
+  )
+  yield env
+  env.close()
+
+
+def test_finetune_from_distilled_student(finetune_env, device):
+  """init_checkpoint maps student weights into the PPO actor, the configured
+  init_std overrides the student's, and the critic warmup freezes the actor."""
+  wrapped_env = RslRlVecEnvWrapper(finetune_env)
+
+  with tempfile.TemporaryDirectory() as tmpdir:
+    # Fabricate a distillation checkpoint for a student with matching arch.
+    student = TensorDict({"student": torch.zeros(2, 1, device=device)}, batch_size=[2])
+    from rsl_rl.models import MLPModel
+
+    donor = MLPModel(
+      obs=student,
+      obs_groups={"student": ["student"]},
+      obs_set="student",
+      output_dim=wrapped_env.num_actions,
+      hidden_dims=[16, 16],
+      activation="elu",
+      obs_normalization=False,
+      distribution_cfg={
+        "class_name": "GaussianDistribution",
+        "init_std": 0.5,
+        "std_type": "scalar",
+      },
+    ).to(device)
+    distill_ckpt = str(Path(tmpdir) / "distilled.pt")
+    torch.save({"student_state_dict": donor.state_dict(), "infos": None}, distill_ckpt)
+
+    cfg = RslRlOnPolicyRunnerCfg(
+      actor=RslRlModelCfg(
+        hidden_dims=(16, 16),
+        distribution_cfg={
+          "class_name": "GaussianDistribution",
+          "init_std": 0.2,
+          "std_type": "scalar",
+        },
+      ),
+      critic=RslRlModelCfg(hidden_dims=(16, 16)),
+      algorithm=RslRlCriticWarmupPpoAlgorithmCfg(critic_warmup_updates=1),
+      obs_groups={"actor": ("student",), "critic": ("critic",)},
+      init_checkpoint=distill_ckpt,
+      num_steps_per_env=4,
+      max_iterations=2,
+      save_interval=100,
+      logger="tensorboard",
+    )
+    runner = MjlabOnPolicyRunner(wrapped_env, asdict(cfg), log_dir=None, device=device)
+
+    actor = runner.alg.get_policy()
+    for (name, p), p_donor in zip(
+      actor.mlp.named_parameters(), donor.mlp.parameters(), strict=True
+    ):
+      torch.testing.assert_close(p, p_donor, msg=f"actor mlp param {name}")
+    # The distilled std (0.5) must not override the configured init_std.
+    assert actor.distribution is not None
+    std_param = actor.distribution.state_dict()["std_param"]
+    torch.testing.assert_close(std_param, torch.full_like(std_param, 0.2))
+
+    # First update: actor frozen (critic warmup), critic trains.
+    actor_before = [p.clone() for p in actor.mlp.parameters()]
+    critic = runner.alg._raw_critic
+    critic_before = [p.clone() for p in critic.mlp.parameters()]
+    runner.learn(num_learning_iterations=1)
+    assert all(
+      torch.equal(b, a)
+      for b, a in zip(actor_before, actor.mlp.parameters(), strict=True)
+    ), "Actor changed during critic warmup."
+    assert any(
+      not torch.allclose(b, a)
+      for b, a in zip(critic_before, critic.mlp.parameters(), strict=True)
+    ), "Critic did not train during warmup."
+
+    # Second update: warmup over, actor trains.
+    runner.learn(num_learning_iterations=1)
+    assert any(
+      not torch.allclose(b, a)
+      for b, a in zip(actor_before, actor.mlp.parameters(), strict=True)
+    ), "Actor did not train after critic warmup."
+
+
+def test_init_checkpoint_rejects_mismatched_architecture(finetune_env, device):
+  wrapped_env = RslRlVecEnvWrapper(finetune_env)
+  with tempfile.TemporaryDirectory() as tmpdir:
+    bad_ckpt = str(Path(tmpdir) / "bad.pt")
+    torch.save(
+      {"student_state_dict": {"mlp.layers.0.weight": torch.zeros(3, 3)}}, bad_ckpt
+    )
+    cfg = RslRlOnPolicyRunnerCfg(
+      actor=RslRlModelCfg(hidden_dims=(16, 16)),
+      critic=RslRlModelCfg(hidden_dims=(16, 16)),
+      obs_groups={"actor": ("student",), "critic": ("critic",)},
+      init_checkpoint=bad_ckpt,
+      num_steps_per_env=4,
+      logger="tensorboard",
+    )
+    with pytest.raises((RuntimeError, KeyError)):
+      MjlabOnPolicyRunner(wrapped_env, asdict(cfg), log_dir=None, device=device)
+
+
+def test_g1_distillation_task_configs():
+  """The registered G1 distillation tasks have consistent obs layouts."""
+  import mjlab.tasks  # noqa: F401  (populates the registry)
+  from mjlab.tasks.registry import load_env_cfg, load_rl_cfg
+
+  cfg = load_env_cfg("Mjlab-Velocity-Rough-Unitree-G1-Distill")
+  assert set(cfg.observations) == {"student", "teacher"}
+  assert "height_scan" not in cfg.observations["student"].terms
+  assert "height_scan" in cfg.observations["teacher"].terms
+  assert not cfg.observations["teacher"].enable_corruption
+  assert cfg.observations["student"].enable_corruption
+
+  ft_cfg = load_env_cfg("Mjlab-Velocity-Rough-Unitree-G1-Distill-Finetune")
+  assert set(ft_cfg.observations) == {"student", "critic"}
+  assert (
+    ft_cfg.observations["student"].terms.keys()
+    == cfg.observations["student"].terms.keys()
+  )
+
+  rl_cfg = load_rl_cfg("Mjlab-Velocity-Rough-Unitree-G1-Distill")
+  assert isinstance(rl_cfg, RslRlDistillationRunnerCfg)
+  # Teacher must mirror the rough task's actor so its checkpoints load.
+  from mjlab.tasks.velocity.config.g1.rl_cfg import unitree_g1_ppo_runner_cfg
+
+  assert rl_cfg.teacher == unitree_g1_ppo_runner_cfg().actor
+
+  ft_rl_cfg = load_rl_cfg("Mjlab-Velocity-Rough-Unitree-G1-Distill-Finetune")
+  assert isinstance(ft_rl_cfg, RslRlOnPolicyRunnerCfg)
+  assert ft_rl_cfg.obs_groups == {"actor": ("student",), "critic": ("critic",)}
+  # Fine-tuning starts from a reduced action std (arXiv:2505.11164).
+  assert isinstance(rl_cfg.student.distribution_cfg, dict)
+  assert isinstance(ft_rl_cfg.actor.distribution_cfg, dict)
+  assert (
+    ft_rl_cfg.actor.distribution_cfg["init_std"]
+    < rl_cfg.student.distribution_cfg["init_std"]
+  )

--- a/tests/test_task_configs.py
+++ b/tests/test_task_configs.py
@@ -51,11 +51,14 @@ def test_play_mode_observation_corruption_disabled(all_task_ids: list[str]) -> N
   for task_id in all_task_ids:
     cfg = load_env_cfg(task_id, play=True)
 
-    assert "actor" in cfg.observations, (
+    # The policy observation group is "actor", or "student" for
+    # distillation tasks.
+    policy_group = "actor" if "actor" in cfg.observations else "student"
+    assert policy_group in cfg.observations, (
       f"Play mode task {task_id} missing 'policy' observation group"
     )
 
-    policy_obs = cfg.observations["actor"]
+    policy_obs = cfg.observations[policy_group]
     assert isinstance(policy_obs, ObservationGroupCfg), (
       f"Play mode task {task_id} policy observation is not ObservationGroupCfg"
     )
@@ -70,11 +73,14 @@ def test_training_mode_observation_corruption_enabled(all_task_ids: list[str]) -
   for task_id in all_task_ids:
     cfg = load_env_cfg(task_id)
 
-    assert "actor" in cfg.observations, (
+    # The policy observation group is "actor", or "student" for
+    # distillation tasks.
+    policy_group = "actor" if "actor" in cfg.observations else "student"
+    assert policy_group in cfg.observations, (
       f"Training task {task_id} missing 'policy' observation group"
     )
 
-    policy_obs = cfg.observations["actor"]
+    policy_obs = cfg.observations[policy_group]
     assert isinstance(policy_obs, ObservationGroupCfg), (
       f"Training task {task_id} policy observation is not ObservationGroupCfg"
     )


### PR DESCRIPTION
This adds a teacher-student distillation pipeline following the distill-then-finetune recipe of "Parkour in the Wild" (arXiv:2505.11164), built on the DAgger-style Distillation algorithm that ships with rsl-rl 5.5. MjlabDistillationRunner lets the student act in the environment (with zero-mean exploration noise from its action distribution) while frozen teachers label every visited state, and loads teacher weights directly from ordinary PPO checkpoints via a teacher_checkpoints config entry. A MultiTeacherModel distills several skill- or terrain-specific experts into one generalist student, dispatching each environment to its expert through an integer observation group such as the new terrain_type term, so the assignment travels with the observations and works both in rollouts and replayed batches. For the RL fine-tuning stage, init_checkpoint initializes a PPO actor from a distilled student while dropping the distribution parameters so a reduced initial action std applies, and CriticWarmupPPO freezes the actor for the first N updates so the freshly initialized value function cannot destroy the distilled behavior.

Two example tasks demonstrate the pipeline on G1 velocity: Mjlab-Velocity-Rough-Unitree-G1-Distill compresses the height-scan teacher into a blind recurrent (LSTM) student, and Mjlab-Velocity-Rough-Unitree-G1-Distill-Finetune fine-tunes it with asymmetric PPO on the privileged critic observations. ONNX export metadata now takes the policy observation group as a parameter, since distilled policies consume the "student" group rather than "actor"; the generic task-config tests were relaxed accordingly. One tradeoff worth noting: the fine-tune actor intentionally reloads only model and normalizer weights, never the optimizer or std, which makes resuming a distillation run and seeding a new one from an old student use the same code path. Includes tests covering the DAgger loop, multi-teacher dispatch and loading, the init-checkpoint mapping, and the critic warmup, plus a documentation page describing the three-stage workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)