### PR TITLE
Extend contact history, add substep latch, fix stale cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ benchmark_results/
 # Documentation outputs.
 **/_build/*
 **/generated/*
+scripts/demos/*.png

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -5,6 +5,22 @@ Changelog
 Upcoming version (not yet released)
 -----------------------------------
 
+Added
+^^^^^
+
+- ``ContactSensor`` history buffers now cover every requested per-contact
+  field (``found``, ``pos``, ``normal``, ``tangent`` in addition to the
+  ``force``/``torque``/``dist`` buffering introduced for decimation-safe
+  detection in PR #699), so brief collisions that appear and resolve
+  within a decimation substep can be detected without relying on contact
+  forces.
+- Added ``ContactSensorCfg.catch_substep_contacts``, extending the PR #699
+  approach with an opt-in per-control-step latch that accumulates contacts
+  across physics substeps and exposes ``found_any``, ``force_peak``,
+  ``dist_at_peak``, and ``pos_at_peak`` on ``ContactData``. The env clears
+  the latch at each control-step boundary via the new
+  ``Scene.begin_control_step()`` hook.
+
 Changed
 ^^^^^^^
 
@@ -15,6 +31,9 @@ Changed
 Fixed
 ^^^^^
 
+- Sensor data cached during the reward/termination stage of ``ManagerBasedRlEnv.step()``
+  is now invalidated after the post-decimation ``forward()``, so observations
+  read post-forward values instead of a stale snapshot.
 - Capped ``wandb`` below 0.29, which removed the ``start_method`` setting still passed
   by ``rsl-rl-lib`` and crashed training runs launched with ``--logger wandb``.
 - ``distribution="gaussian"`` domain randomization now draws an independent value per

--- a/scripts/demos/fast_ball_contact.py
+++ b/scripts/demos/fast_ball_contact.py
@@ -1,0 +1,290 @@
+"""Demo: latching contact sensors catch fast ball hits missed by decimation.
+
+A ball is launched at 10 m/s between two static paddles and bounces back and
+forth like a rally. Each hit enters and leaves the paddle's contact zone
+within a few physics substeps of one control step (decimation = 20), so by
+the final substep the ball is already gone and the instantaneous ``found``
+read reports no contact.
+
+Three detection modes are compared over the same rollout:
+
+- ``instant``: ``found`` read at the end of the control step (what you get
+  without any substep-aware mechanism).
+- ``history``: ``found_history`` (or ``force_history``) reduced over the
+  decimation window (PR #699 style).
+- ``latch``: ``found_any`` accumulated by ``catch_substep_contacts=True``
+  and cleared at every control-step boundary.
+
+Run with:
+  uv run python scripts/demos/fast_ball_contact.py
+  uv run python scripts/demos/fast_ball_contact.py --viewer
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+
+import matplotlib.pyplot as plt
+import mujoco
+import numpy as np
+import torch
+
+from mjlab.entity import EntityCfg
+from mjlab.scene import Scene, SceneCfg
+from mjlab.sensor.contact_sensor import ContactMatch, ContactSensorCfg
+from mjlab.sim.sim import MujocoCfg, Simulation, SimulationCfg
+
+# One entity holds both paddles and the ball so the sensor can scope geoms.
+RALLY_XML = """
+<mujoco>
+  <worldbody>
+    <body name="paddle_left" pos="-0.3 0 0.15">
+      <geom name="paddle_left_geom" type="box" size="0.01 0.15 0.15" mass="100"/>
+    </body>
+    <body name="paddle_right" pos="0.3 0 0.15">
+      <geom name="paddle_right_geom" type="box" size="0.01 0.15 0.15" mass="100"/>
+    </body>
+    <body name="ball" pos="0 0 0.15">
+      <freejoint/>
+      <!-- Stiff near-elastic contact so a 10 m/s ball genuinely rebounds
+           off the paddles instead of tunneling through them. -->
+      <geom name="ball_geom" type="sphere" size="0.033" mass="0.058"
+            solref="-100000 0"/>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+DECIMATION = 20
+NUM_ENVS = 1
+NUM_POLICY_STEPS = 60
+PHYSICS_DT = 0.002
+BALL_SPEED = 10.0
+DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
+
+
+def build() -> tuple[Scene, Simulation]:
+  entity_cfg = EntityCfg(spec_fn=lambda: mujoco.MjSpec.from_string(RALLY_XML))
+  sensor_cfg = ContactSensorCfg(
+    name="ball_contact",
+    primary=ContactMatch(mode="geom", pattern="ball_geom", entity="ball"),
+    fields=("found", "force"),
+    history_length=DECIMATION,
+    catch_substep_contacts=True,
+  )
+  scene_cfg = SceneCfg(
+    num_envs=NUM_ENVS,
+    env_spacing=3.0,
+    entities={"ball": entity_cfg},
+    sensors=(sensor_cfg,),
+  )
+  scene = Scene(scene_cfg, DEVICE)
+  model = scene.compile()
+  sim = Simulation(
+    num_envs=NUM_ENVS,
+    cfg=SimulationCfg(njmax=50, mujoco=MujocoCfg(gravity=(0.0, 0.0, 0.0))),
+    model=model,
+    device=DEVICE,
+  )
+  scene.initialize(sim.mj_model, sim.model, sim.data)
+  return scene, sim
+
+
+def launch_ball(scene: Scene):
+  """Serve the ball from the center toward the right paddle."""
+  root_state = torch.zeros((NUM_ENVS, 13), device=DEVICE)
+  root_state[:, 2] = 0.15
+  root_state[:, 3] = 1.0
+  root_state[:, 7] = BALL_SPEED
+  scene["ball"].write_root_state_to_sim(root_state)
+
+
+def run_analysis():
+  scene, sim = build()
+  sensor = scene["ball_contact"]
+  launch_ball(scene)
+
+  print("=" * 70)
+  print("Fast Ball Contact Demo")
+  print(f"  Ball speed {BALL_SPEED} m/s between paddles at x = +/-0.3")
+  print(f"  Physics dt = {PHYSICS_DT}s, decimation = {DECIMATION}")
+  print(f"  Policy dt = {DECIMATION * PHYSICS_DT}s, steps = {NUM_POLICY_STEPS}")
+  print("=" * 70)
+
+  instant_hits = []
+  history_hits = []
+  latched_hits = []
+  ball_x_substep = []
+
+  for _ in range(NUM_POLICY_STEPS):
+    sensor.begin_control_step()
+    for _ in range(DECIMATION):
+      sim.step()
+      scene.update(dt=PHYSICS_DT)
+      ball_x_substep.append(sim.data.qpos[0, 0].item())
+
+    data = sensor.data
+    instant_hits.append(bool(data.found[0, 0].item() > 0))
+    force_mag = data.force_history[0, 0].norm(dim=-1)  # [H]
+    history_hits.append(bool((force_mag > 1.0e-6).any().item()))
+    latched_hits.append(bool(data.found_any[0, 0].item()))
+
+  missed = [
+    i for i in range(NUM_POLICY_STEPS) if latched_hits[i] and not instant_hits[i]
+  ]
+  print()
+  print(f"Policy steps with contact (instant read):  {sum(instant_hits)}")
+  print(f"Policy steps with contact (history):       {sum(history_hits)}")
+  print(f"Policy steps with contact (latch):         {sum(latched_hits)}")
+  print()
+  if missed:
+    print(f"Hit(s) MISSED by the instantaneous read but caught: {len(missed)}")
+    print(f"  Policy steps: {missed}")
+  else:
+    print("No missed hits (try a faster ball or a larger decimation).")
+
+  print()
+  print("Step-by-step (first 60 policy steps):")
+  print(f"{'step':>6}  {'instant':>8}  {'history':>8}  {'latch':>8}  {'missed':>8}")
+  print("-" * 50)
+  for i in range(min(60, NUM_POLICY_STEPS)):
+    flag = " <<<" if (latched_hits[i] and not instant_hits[i]) else ""
+    print(
+      f"{i:>6}  {instant_hits[i]!s:>8}  {history_hits[i]!s:>8}  "
+      f"{latched_hits[i]!s:>8}  {flag}"
+    )
+
+  _plot(ball_x_substep, instant_hits, history_hits, latched_hits, missed)
+
+
+def _plot(
+  ball_x_substep: list[float],
+  instant_hits: list[bool],
+  history_hits: list[bool],
+  latched_hits: list[bool],
+  missed: list[int],
+):
+  """Plot the ball trajectory with per-window detection outcomes."""
+  t_substep = np.arange(len(ball_x_substep)) * PHYSICS_DT
+
+  # Sample the trajectory at the END of each policy step for markers.
+  step_end_x = [
+    ball_x_substep[(i + 1) * DECIMATION - 1] for i in range(NUM_POLICY_STEPS)
+  ]
+  t_windows = np.arange(NUM_POLICY_STEPS) * DECIMATION * PHYSICS_DT + (
+    DECIMATION * PHYSICS_DT
+  )
+
+  idx_both = [i for i in range(NUM_POLICY_STEPS) if instant_hits[i] and latched_hits[i]]
+  idx_history_only = [
+    i
+    for i in range(NUM_POLICY_STEPS)
+    if history_hits[i] and not instant_hits[i] and i not in idx_both
+  ]
+
+  fig, ax = plt.subplots(figsize=(12, 4))
+  ax.plot(t_substep, ball_x_substep, color="0.4", linewidth=0.8, label="Ball x")
+  # Shade the paddle contact zones (ball-center x range that touches a paddle).
+  for x_paddle in (-0.3, 0.3):
+    ax.axvspan(x_paddle - 0.043, x_paddle + 0.043, color="tab:blue", alpha=0.08)
+
+  if idx_both:
+    ax.scatter(
+      [t_windows[i] for i in idx_both],
+      [step_end_x[i] for i in idx_both],
+      color="tab:green",
+      s=40,
+      zorder=3,
+      label="Detected by instant + latch",
+    )
+  if missed:
+    ax.scatter(
+      [t_windows[i] for i in missed],
+      [step_end_x[i] for i in missed],
+      color="tab:red",
+      s=60,
+      marker="x",
+      linewidths=2,
+      zorder=4,
+      label="Caught by latch/history only",
+    )
+  if idx_history_only:
+    ax.scatter(
+      [t_windows[i] for i in idx_history_only],
+      [step_end_x[i] for i in idx_history_only],
+      color="tab:orange",
+      s=40,
+      zorder=3,
+      label="Caught by history only",
+    )
+
+  ax.set_xlabel("Time (s)")
+  ax.set_ylabel("Ball x (m)")
+  ax.set_title(
+    f"Fast ball rally with decimation = {DECIMATION}: "
+    f"{len(missed)} hits missed without substep-aware detection"
+  )
+  ax.legend(loc="upper right")
+  fig.tight_layout()
+  fig.savefig("scripts/demos/fast_ball_contact.png", dpi=150)
+  print("\nPlot saved to scripts/demos/fast_ball_contact.png")
+  plt.close(fig)
+
+
+def run_viewer():
+  """Launch a Viser viewer showing the rally with contact forces."""
+  import viser
+
+  from mjlab.viewer.viser import ViserMujocoScene
+
+  scene, sim = build()
+  launch_ball(scene)
+
+  server = viser.ViserServer(label="Fast Ball Rally")
+  viz = ViserMujocoScene(server, sim.mj_model, num_envs=NUM_ENVS)
+  viz.show_contact_forces = True
+  viz.show_contact_points = True
+  viz.create_scene_gui(
+    camera_distance=2.5,
+    camera_azimuth=90.0,
+    camera_elevation=15.0,
+  )
+
+  print("Open the Viser URL above to watch the rally.")
+  print("Contact forces and points are enabled by default.")
+  print("Press Ctrl+C to stop.\n")
+
+  sensor = scene["ball_contact"]
+  try:
+    while True:
+      sensor.begin_control_step()
+      for _ in range(DECIMATION):
+        sim.step()
+        scene.update(dt=PHYSICS_DT)
+      viz.update(sim.data)
+      if viz.needs_update:
+        viz.refresh_visualization()
+      time.sleep(DECIMATION * PHYSICS_DT)
+  except KeyboardInterrupt:
+    print("\nShutting down...")
+    server.stop()
+
+
+def main():
+  parser = argparse.ArgumentParser(description=__doc__)
+  parser.add_argument(
+    "--viewer",
+    action="store_true",
+    help="Launch a Viser viewer instead of running the analysis.",
+  )
+  args = parser.parse_args()
+
+  if args.viewer:
+    run_viewer()
+  else:
+    run_analysis()
+
+
+if __name__ == "__main__":
+  main()

--- a/src/mjlab/envs/manager_based_rl_env.py
+++ b/src/mjlab/envs/manager_based_rl_env.py
@@ -371,6 +371,10 @@ class ManagerBasedRlEnv:
     self._reset_idx(env_ids)
     self.scene.write_data_to_sim()
     self.sim.forward()
+    # Refresh cached sensor data for the freshly reset envs (sensor.reset()
+    # already dropped the caches, but keep the guarantee explicit after the
+    # forward() that rewrote sensordata).
+    self.scene.invalidate_sensor_caches()
     # Scoped to env_ids so a partial reset does not advance stateful commands in the
     # other envs.
     self.command_manager.compute(dt=0.0, env_ids=env_ids)
@@ -433,6 +437,9 @@ class ManagerBasedRlEnv:
 
     self.extras["log"] = dict()
     self.action_manager.process_action(action.to(self.device))
+    # Clear per-control-step sensor accumulators (e.g. the contact sensor's
+    # substep-collision latch) so they only cover this step's substeps.
+    self.scene.begin_control_step()
 
     for _ in range(self.cfg.decimation):
       self._sim_step_counter += 1
@@ -476,6 +483,10 @@ class ManagerBasedRlEnv:
     # one-substep staleness left by mj_step; for reset envs it picks up
     # the freshly written reset state.
     self.sim.forward()
+    # forward() rewrote sensordata for every env, so any sensor data cached
+    # during the reward/termination stage is stale. Drop the caches so
+    # observation-time reads observe the post-forward state.
+    self.scene.invalidate_sensor_caches()
 
     # Pass dt=0 for freshly reset envs so their command timers start full,
     # matching reset().

--- a/src/mjlab/scene/scene.py
+++ b/src/mjlab/scene/scene.py
@@ -193,6 +193,22 @@ class Scene:
     for sensor in self._sensors.values():
       sensor.reset(env_ids)
 
+  def begin_control_step(self) -> None:
+    """Notify sensors that a new control (policy) step is starting.
+
+    Called once before the env's physics substep loop so sensors that
+    accumulate state across substeps (e.g. the contact sensor's
+    ``catch_substep_contacts`` latch) can reset their per-control-step
+    accumulators.
+    """
+    for sensor in self._sensors.values():
+      sensor.begin_control_step()
+
+  def invalidate_sensor_caches(self) -> None:
+    """Drop cached sensor data so the next read recomputes from sim state."""
+    for sensor in self._sensors.values():
+      sensor.invalidate_cache()
+
   def update(self, dt: float) -> None:
     for ent in self._entities.values():
       ent.update(dt)

--- a/src/mjlab/sensor/contact_sensor.py
+++ b/src/mjlab/sensor/contact_sensor.py
@@ -58,6 +58,13 @@ _CONTACT_REDUCE_MAP = {
   "netforce": 3,
 }
 
+# Per-contact fields that support history buffering, in ContactData
+# attribute order. Scalar fields buffer to [B, N, H], vector fields to
+# [B, N, H, 3].
+_HISTORY_SCALAR_FIELDS = ("found", "dist")
+_HISTORY_VECTOR_FIELDS = ("force", "torque", "pos", "normal", "tangent")
+_HISTORY_FIELDS = _HISTORY_SCALAR_FIELDS + _HISTORY_VECTOR_FIELDS
+
 _MODE_TO_OBJTYPE = {
   "geom": mujoco.mjtObj.mjOBJ_GEOM,
   "body": mujoco.mjtObj.mjOBJ_BODY,
@@ -138,10 +145,22 @@ class ContactSensorCfg(SensorCfg):
     global_frame: Rotate ``force``/``torque`` from the contact frame to the
       global frame. Requires ``"normal"`` and ``"tangent"`` in ``fields``.
       Implicit when ``reduce="netforce"``.
+    catch_substep_contacts: If True, accumulate a per-control-step latch on
+      every physics substep (via ``update()``) and expose it as extra
+      ``ContactData`` fields: ``found_any`` (contact in *any* substep since
+      the last ``begin_control_step()``), ``force_peak``/``dist_at_peak``/
+      ``pos_at_peak`` (values at the largest-magnitude substep). Rewards can
+      read these directly instead of hand-reducing ``*_history`` buffers to
+      detect brief collisions that resolve before the final substep. Requires
+      ``"found"`` in ``fields``. The env clears the latch at each control-step
+      boundary via ``begin_control_step()``. Defaults to False (all latch
+      outputs stay ``None``).
     history_length: If >0, keep a rolling buffer of the last N substeps of
-      ``force``/``torque``/``dist`` data. Set to your decimation value so the
-      buffer covers exactly one policy step; useful for catching brief
-      collisions that resolve mid-substep. ``0`` disables the buffer.
+      every requested per-contact field (found/force/torque/dist/pos/normal/
+      tangent) as ``<field>_history`` on ``ContactData``. Set to your
+      decimation value so the buffer covers exactly one policy step; useful
+      for catching brief collisions that resolve mid-substep. ``0`` disables
+      the buffer.
     debug: Print each MuJoCo sensor as it is added to the spec. Useful for
       checking that pattern expansion produced the elements you expected.
   """
@@ -155,6 +174,7 @@ class ContactSensorCfg(SensorCfg):
   track_air_time: bool = False
   global_frame: bool = False
   history_length: int = 0
+  catch_substep_contacts: bool = False
   debug: bool = False
 
   def build(self) -> ContactSensor:
@@ -220,6 +240,28 @@ class ContactData:
   """[B, N, H, 3] contact torques over last H substeps (index 0 = most recent)"""
   dist_history: torch.Tensor | None = None
   """[B, N, H] penetration depth over last H substeps (index 0 = most recent)"""
+  found_history: torch.Tensor | None = None
+  """[B, N, H] match counts over last H substeps (index 0 = most recent)"""
+  pos_history: torch.Tensor | None = None
+  """[B, N, H, 3] contact positions over last H substeps (index 0 = most recent)"""
+  normal_history: torch.Tensor | None = None
+  """[B, N, H, 3] contact normals over last H substeps (index 0 = most recent)"""
+  tangent_history: torch.Tensor | None = None
+  """[B, N, H, 3] contact tangents over last H substeps (index 0 = most recent)"""
+
+  found_any: torch.Tensor | None = None
+  """[B, N] bool: contact in any substep since the last control-step boundary.
+
+  Only populated when ``catch_substep_contacts=True``."""
+  force_peak: torch.Tensor | None = None
+  """[B, N, 3] force at the largest-magnitude substep since the boundary.
+
+  Only populated when ``catch_substep_contacts=True`` and ``"force"`` is
+  requested."""
+  dist_at_peak: torch.Tensor | None = None
+  """[B, N] penetration depth at the peak substep (see ``force_peak``)."""
+  pos_at_peak: torch.Tensor | None = None
+  """[B, N, 3] contact position at the peak substep (see ``force_peak``)."""
 
 
 class ContactSensor(Sensor[ContactData]):
@@ -236,11 +278,18 @@ class ContactSensor(Sensor[ContactData]):
           "in fields (needed to build rotation matrix)"
         )
 
+    if cfg.catch_substep_contacts and "found" not in cfg.fields:
+      raise ValueError(
+        f"Sensor '{cfg.name}': catch_substep_contacts=True requires 'found' in "
+        "fields (the latch derives contact events from the found field)"
+      )
+
     self._slots: list[_ContactSlot] = []
     self._data: mjwarp.Data | None = None
     self._device: str | None = None
     self._air_time_state: _AirTimeState | None = None
     self._history_state: dict[str, torch.Tensor] | None = None
+    self._latch_state: dict[str, torch.Tensor] | None = None
 
   @property
   def primary_names(self) -> list[str]:
@@ -321,17 +370,37 @@ class ContactSensor(Sensor[ContactData]):
       n_contacts = n_primary * self.cfg.num_slots
       h = self.cfg.history_length
       self._history_state = {}
+      for field in _HISTORY_VECTOR_FIELDS:
+        if field in self.cfg.fields:
+          self._history_state[field] = torch.zeros(
+            (n_envs, n_contacts, h, 3), device=device
+          )
+      for field in _HISTORY_SCALAR_FIELDS:
+        if field in self.cfg.fields:
+          self._history_state[field] = torch.zeros(
+            (n_envs, n_contacts, h), device=device
+          )
+
+    if self.cfg.catch_substep_contacts:
+      n_envs = data.time.shape[0]
+      n_contacts = n_primary * self.cfg.num_slots
+      self._latch_state = {
+        "found_any": torch.zeros((n_envs, n_contacts), dtype=torch.bool, device=device),
+        # Peak-magnitude tracker for selecting the representative substep;
+        # init below zero so the first substep always seeds the latch.
+        "peak_mag": torch.full((n_envs, n_contacts), -1.0, device=device),
+      }
       if "force" in self.cfg.fields:
-        self._history_state["force"] = torch.zeros(
-          (n_envs, n_contacts, h, 3), device=device
-        )
-      if "torque" in self.cfg.fields:
-        self._history_state["torque"] = torch.zeros(
-          (n_envs, n_contacts, h, 3), device=device
+        self._latch_state["force_peak"] = torch.zeros(
+          (n_envs, n_contacts, 3), device=device
         )
       if "dist" in self.cfg.fields:
-        self._history_state["dist"] = torch.zeros(
-          (n_envs, n_contacts, h), device=device
+        self._latch_state["dist_at_peak"] = torch.zeros(
+          (n_envs, n_contacts), device=device
+        )
+      if "pos" in self.cfg.fields:
+        self._latch_state["pos_at_peak"] = torch.zeros(
+          (n_envs, n_contacts, 3), device=device
         )
 
   def _compute_data(self) -> ContactData:
@@ -342,9 +411,13 @@ class ContactSensor(Sensor[ContactData]):
       out.current_contact_time = self._air_time_state.current_contact_time
       out.last_contact_time = self._air_time_state.last_contact_time
     if self._history_state is not None:
-      out.force_history = self._history_state.get("force")
-      out.torque_history = self._history_state.get("torque")
-      out.dist_history = self._history_state.get("dist")
+      for field in _HISTORY_FIELDS:
+        setattr(out, f"{field}_history", self._history_state.get(field))
+    if self._latch_state is not None:
+      out.found_any = self._latch_state["found_any"]
+      out.force_peak = self._latch_state.get("force_peak")
+      out.dist_at_peak = self._latch_state.get("dist_at_peak")
+      out.pos_at_peak = self._latch_state.get("pos_at_peak")
     return out
 
   def reset(self, env_ids: torch.Tensor | slice | None = None) -> None:
@@ -364,12 +437,33 @@ class ContactSensor(Sensor[ContactData]):
       for buf in self._history_state.values():
         buf[env_ids] = 0.0
 
+    # Reset latch state for specified envs.
+    if self._latch_state is not None:
+      self._latch_state["found_any"][env_ids] = False
+      self._latch_state["peak_mag"][env_ids] = -1.0
+      for name in ("force_peak", "dist_at_peak", "pos_at_peak"):
+        if name in self._latch_state:
+          self._latch_state[name][env_ids] = 0.0
+
+  def begin_control_step(self) -> None:
+    """Clear the per-control-step latch (all envs)."""
+    self._invalidate_cache()
+    if self._latch_state is None:
+      return
+    self._latch_state["found_any"].zero_()
+    self._latch_state["peak_mag"].fill_(-1.0)
+    for name in ("force_peak", "dist_at_peak", "pos_at_peak"):
+      if name in self._latch_state:
+        self._latch_state[name].zero_()
+
   def update(self, dt: float) -> None:
     super().update(dt)
     if self._air_time_state is not None:
       self._update_air_time_tracking(dt)
     if self._history_state is not None:
       self._update_history()
+    if self._latch_state is not None:
+      self._update_latch()
 
   def compute_first_contact(self, dt: float, abs_tol: float = 1.0e-6) -> torch.Tensor:
     """Returns [B, P] bool: True for primaries that landed within the last dt seconds."""
@@ -484,23 +578,59 @@ class ContactSensor(Sensor[ContactData]):
       torch.zeros_like(state.current_contact_time),
     )
 
+  def _update_latch(self) -> None:
+    """Accumulate contact events over the current control step.
+
+    ``found_any`` ORs the per-substep match counts; the peak fields capture
+    the values of the substep with the largest force magnitude (deepest
+    penetration when force is not requested).
+    """
+    assert self._latch_state is not None
+
+    data = self._extract_sensor_data()
+    state = self._latch_state
+
+    if data.found is not None:
+      state["found_any"] |= data.found > 0
+
+    if data.force is not None:
+      mag = data.force.norm(dim=-1)
+    elif data.dist is not None:
+      mag = -data.dist
+    elif data.found is not None:
+      mag = data.found.float()
+    else:
+      return
+
+    update = mag > state["peak_mag"]
+    state["peak_mag"] = torch.where(update, mag, state["peak_mag"])
+    if "force_peak" in state and data.force is not None:
+      state["force_peak"] = torch.where(
+        update[..., None], data.force, state["force_peak"]
+      )
+    if "dist_at_peak" in state and data.dist is not None:
+      state["dist_at_peak"] = torch.where(update, data.dist, state["dist_at_peak"])
+    if "pos_at_peak" in state and data.pos is not None:
+      state["pos_at_peak"] = torch.where(
+        update[..., None], data.pos, state["pos_at_peak"]
+      )
+
   def _update_history(self) -> None:
-    """Roll history buffer and insert current contact data at index 0."""
+    """Roll history buffers and insert current contact data at index 0."""
     assert self._history_state is not None
 
     contact_data = self._extract_sensor_data()
 
-    if "force" in self._history_state and contact_data.force is not None:
-      self._history_state["force"] = self._history_state["force"].roll(1, dims=2)
-      self._history_state["force"][:, :, 0, :] = contact_data.force
-
-    if "torque" in self._history_state and contact_data.torque is not None:
-      self._history_state["torque"] = self._history_state["torque"].roll(1, dims=2)
-      self._history_state["torque"][:, :, 0, :] = contact_data.torque
-
-    if "dist" in self._history_state and contact_data.dist is not None:
-      self._history_state["dist"] = self._history_state["dist"].roll(1, dims=2)
-      self._history_state["dist"][:, :, 0] = contact_data.dist
+    for field, buf in self._history_state.items():
+      values = getattr(contact_data, field)
+      if values is None:
+        continue
+      rolled = buf.roll(1, dims=2)
+      if field in _HISTORY_SCALAR_FIELDS:
+        rolled[:, :, 0] = values
+      else:
+        rolled[:, :, 0, :] = values
+      self._history_state[field] = rolled
 
   def _resolve_primary_names(
     self, entities: dict[str, Entity], match: ContactMatch

--- a/src/mjlab/sensor/sensor.py
+++ b/src/mjlab/sensor/sensor.py
@@ -126,6 +126,23 @@ class Sensor(ABC, Generic[T]):
     """Invalidate the cached data, forcing recomputation on next access."""
     self._cache_valid = False
 
+  def invalidate_cache(self) -> None:
+    """Public wrapper around ``_invalidate_cache``.
+
+    Allows container objects (e.g. scenes) to drop stale cached data without
+    reaching into private state.
+    """
+    self._invalidate_cache()
+
+  def begin_control_step(self) -> None:
+    """Mark the start of a new control (policy) step.
+
+    Called by the environment once before its physics substep loop. Sensors
+    that accumulate state across substeps (e.g. the contact sensor's
+    substep-collision latch) override this to clear their per-control-step
+    accumulators. The base implementation does nothing.
+    """
+
   def reset(self, env_ids: torch.Tensor | slice | None = None) -> None:
     """Reset sensor state for specified environments.
 

--- a/tests/test_contact_sensor.py
+++ b/tests/test_contact_sensor.py
@@ -1180,3 +1180,486 @@ def test_global_frame_maxforce_rotation(device):
   assert torch.all(sensor_force[:, 2].abs() > 1.0), (
     f"sensor_force z-component should be non-trivial, got {sensor_force[:, 2].tolist()}"
   )
+
+
+##
+# History extension tests (found/pos/normal/tangent).
+##
+
+
+def _place_box_on_ground(sim: Simulation, scene: Scene, z: float = 0.11):
+  """Place the falling-box entity at rest just above the ground plane."""
+  root_state = torch.zeros((2, 13), device=sim.device)
+  root_state[:, 2] = z
+  root_state[:, 3] = 1.0
+  scene["box"].write_root_state_to_sim(root_state)
+
+
+def test_found_history_shape_and_disabled(device):
+  """found_history has shape [B, N, H] when enabled and is None otherwise."""
+  history_len = 4
+  sensor_cfg = ContactSensorCfg(
+    name="box_contact",
+    primary=ContactMatch(mode="geom", pattern="box_geom", entity="box"),
+    secondary=None,
+    fields=("found",),
+    history_length=history_len,
+  )
+
+  scene, sim = create_scene_with_sensor(FALLING_BOX_XML, "box", sensor_cfg, device)
+
+  _place_box_on_ground(sim, scene)
+  for _ in range(100):
+    sim.step()
+    scene.update(dt=sim.cfg.mujoco.timestep)
+
+  data = scene["box_contact"].data
+  assert data.found_history is not None
+  assert data.found_history.shape == (2, 1, history_len)
+
+  # While the box rests on the ground every buffered substep saw contact.
+  assert torch.all(data.found_history > 0)
+
+
+def test_found_history_disabled_by_default(device):
+  """found_history stays None when history_length=0."""
+  sensor_cfg = ContactSensorCfg(
+    name="box_contact",
+    primary=ContactMatch(mode="geom", pattern="box_geom", entity="box"),
+    secondary=None,
+    fields=("found",),
+  )
+
+  scene, _ = create_scene_with_sensor(FALLING_BOX_XML, "box", sensor_cfg, device)
+
+  assert scene["box_contact"].data.found_history is None
+
+
+def test_history_rolls_found(device):
+  """index 0 holds the newest substep: lifting the box writes 0 to slot 0 only."""
+  history_len = 3
+  sensor_cfg = ContactSensorCfg(
+    name="box_contact",
+    primary=ContactMatch(mode="geom", pattern="box_geom", entity="box"),
+    secondary=None,
+    fields=("found",),
+    history_length=history_len,
+  )
+
+  scene, sim = create_scene_with_sensor(FALLING_BOX_XML, "box", sensor_cfg, device)
+
+  sensor = scene["box_contact"]
+
+  # Box resting on ground: every substep in contact.
+  _place_box_on_ground(sim, scene)
+  for _ in range(100):
+    sim.step()
+    scene.update(dt=sim.cfg.mujoco.timestep)
+
+  # Teleport the box far above the ground: the next substep has no contact.
+  _place_box_on_ground(sim, scene, z=1.0)
+  sim.step()
+  scene.update(dt=sim.cfg.mujoco.timestep)
+
+  found_history = sensor.data.found_history
+  assert found_history is not None
+  assert torch.all(found_history[:, :, 0] == 0), (
+    f"index 0 should hold the airborne substep, got {found_history}"
+  )
+  assert torch.all(found_history[:, :, 1] > 0), (
+    f"index 1 should hold the resting substep, got {found_history}"
+  )
+
+
+def test_vector_field_history_shapes(device):
+  """pos/normal/tangent history buffers are allocated and populated."""
+  history_len = 3
+  sensor_cfg = ContactSensorCfg(
+    name="box_contact",
+    primary=ContactMatch(mode="geom", pattern="box_geom", entity="box"),
+    secondary=None,
+    fields=("found", "force", "dist", "pos", "normal", "tangent"),
+    history_length=history_len,
+  )
+
+  scene, sim = create_scene_with_sensor(FALLING_BOX_XML, "box", sensor_cfg, device)
+
+  _place_box_on_ground(sim, scene)
+  for _ in range(100):
+    sim.step()
+    scene.update(dt=sim.cfg.mujoco.timestep)
+
+  data = scene["box_contact"].data
+  for name in ("pos_history", "normal_history", "tangent_history"):
+    values = getattr(data, name)
+    assert values is not None
+    assert values.shape == (2, 1, history_len, 3)
+  # With history_length=1 the newest entry equals the current read exactly.
+  torch.testing.assert_close(data.pos_history[:, :, 0, :], data.pos)
+  torch.testing.assert_close(data.normal_history[:, :, 0, :], data.normal)
+  torch.testing.assert_close(data.tangent_history[:, :, 0, :], data.tangent)
+  torch.testing.assert_close(data.found_history[:, :, 0], data.found)
+  torch.testing.assert_close(data.dist_history[:, :, 0], data.dist)
+
+
+def test_found_history_reset(device):
+  """reset(env_ids) zeroes found_history only for the given envs."""
+  history_len = 3
+  sensor_cfg = ContactSensorCfg(
+    name="box_contact",
+    primary=ContactMatch(mode="geom", pattern="box_geom", entity="box"),
+    secondary=None,
+    fields=("found",),
+    history_length=history_len,
+  )
+
+  scene, _ = create_scene_with_sensor(FALLING_BOX_XML, "box", sensor_cfg, device)
+
+  sensor = scene["box_contact"]
+  sensor._history_state["found"][:] = 1.0
+
+  sensor.reset(torch.tensor([0], device=device))
+
+  data = sensor.data
+  assert data.found_history is not None
+  assert torch.all(data.found_history[0] == 0)
+  assert torch.all(data.found_history[1] == 1.0)
+
+
+##
+# Substep contact latch tests (catch_substep_contacts).
+##
+
+
+# Stiff, highly elastic contact so a dropped ball impacts and separates
+# within a single control step (mirrors scripts/demos/contact_sensor_decimation.py).
+BOUNCY_BALL_XML = """
+<mujoco>
+  <worldbody>
+    <body name="ground" pos="0 0 0">
+      <geom name="ground_geom" type="plane" size="5 5 0.1"/>
+    </body>
+    <body name="ball" pos="0 0 1">
+      <freejoint/>
+      <geom name="ball_geom" type="sphere" size="0.05" mass="0.1"
+            solref="-1000 0"/>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+
+def test_latch_disabled_outputs_are_none(device):
+  """Latch outputs stay None when catch_substep_contacts=False (default)."""
+  sensor_cfg = ContactSensorCfg(
+    name="box_contact",
+    primary=ContactMatch(mode="geom", pattern="box_geom", entity="box"),
+    secondary=None,
+    fields=("found", "force"),
+  )
+
+  scene, _ = create_scene_with_sensor(FALLING_BOX_XML, "box", sensor_cfg, device)
+
+  data = scene["box_contact"].data
+  assert data.found_any is None
+  assert data.force_peak is None
+  assert data.dist_at_peak is None
+  assert data.pos_at_peak is None
+
+
+def test_latch_requires_found_field(device):
+  """catch_substep_contacts without the found field raises."""
+  sensor_cfg = ContactSensorCfg(
+    name="box_contact",
+    primary=ContactMatch(mode="geom", pattern="box_geom", entity="box"),
+    secondary=None,
+    fields=("force",),
+    catch_substep_contacts=True,
+  )
+
+  with pytest.raises(ValueError, match="requires 'found'"):
+    ContactSensorCfg.build(sensor_cfg)
+
+
+def test_latch_found_any_or_semantics(device):
+  """found_any stays True after contact resolves within the control step."""
+  sensor_cfg = ContactSensorCfg(
+    name="box_contact",
+    primary=ContactMatch(mode="geom", pattern="box_geom", entity="box"),
+    secondary=None,
+    fields=("found", "force"),
+    catch_substep_contacts=True,
+  )
+
+  scene, sim = create_scene_with_sensor(FALLING_BOX_XML, "box", sensor_cfg, device)
+
+  sensor = scene["box_contact"]
+
+  # Settle the box on the ground, then latch three resting substeps followed
+  # by one airborne substep.
+  _place_box_on_ground(sim, scene)
+  for _ in range(100):
+    sim.step()
+    scene.update(dt=sim.cfg.mujoco.timestep)
+
+  sensor.begin_control_step()
+  for _ in range(3):
+    sim.step()
+    scene.update(dt=sim.cfg.mujoco.timestep)
+  _place_box_on_ground(sim, scene, z=1.0)
+  sim.step()
+  scene.update(dt=sim.cfg.mujoco.timestep)
+
+  data = sensor.data
+  assert data.found is not None
+  assert torch.all(data.found == 0), "box should be airborne on the last substep"
+  assert data.found_any is not None
+  assert torch.all(data.found_any), (
+    "found_any should latch the earlier resting substeps"
+  )
+
+
+def test_latch_force_peak_matches_substep_maximum(device):
+  """force_peak/dist_at_peak equal the largest-magnitude substep values."""
+  history_len = 8
+  sensor_cfg = ContactSensorCfg(
+    name="box_contact",
+    primary=ContactMatch(mode="geom", pattern="box_geom", entity="box"),
+    secondary=None,
+    fields=("found", "force", "dist"),
+    history_length=history_len,
+    catch_substep_contacts=True,
+  )
+
+  scene, sim = create_scene_with_sensor(FALLING_BOX_XML, "box", sensor_cfg, device)
+
+  sensor = scene["box_contact"]
+
+  # Drop the box and wait for first ground contact, then capture one
+  # control-step window of the settling impact where forces vary per substep.
+  root_state = torch.zeros((2, 13), device=sim.device)
+  root_state[:, 2] = 0.5
+  root_state[:, 3] = 1.0
+  scene["box"].write_root_state_to_sim(root_state)
+
+  landed = False
+  for _ in range(300):
+    sim.step()
+    scene.update(dt=sim.cfg.mujoco.timestep)
+    if torch.all(sensor.data.found > 0):
+      landed = True
+      break
+  assert landed, "box should have reached the ground"
+
+  sensor.begin_control_step()
+  forces = []
+  dists = []
+  for _ in range(history_len):
+    sim.step()
+    scene.update(dt=sim.cfg.mujoco.timestep)
+    forces.append(sensor.data.force.clone())
+    dists.append(sensor.data.dist.clone())
+
+  force_sequence = torch.stack(forces, dim=2)  # [B, N, H, 3]
+  mag = force_sequence.norm(dim=-1)  # [B, N, H]
+  peak_idx = mag.argmax(dim=2)  # [B, N]
+
+  data = sensor.data
+  assert data.found_any is not None
+  assert torch.any(data.found_any), "impact should have latched a contact"
+  assert data.force_peak is not None
+  for b in range(2):
+    for n in range(1):
+      torch.testing.assert_close(
+        data.force_peak[b, n], force_sequence[b, n, peak_idx[b, n]]
+      )
+      torch.testing.assert_close(data.dist_at_peak[b, n], dists[peak_idx[b, n]][b, n])
+
+
+def test_latch_begin_control_step_clears(device):
+  """begin_control_step resets found_any and peak trackers."""
+  sensor_cfg = ContactSensorCfg(
+    name="box_contact",
+    primary=ContactMatch(mode="geom", pattern="box_geom", entity="box"),
+    secondary=None,
+    fields=("found", "force", "pos"),
+    catch_substep_contacts=True,
+  )
+
+  scene, _ = create_scene_with_sensor(FALLING_BOX_XML, "box", sensor_cfg, device)
+
+  sensor = scene["box_contact"]
+  sensor._latch_state["found_any"][:] = True
+  sensor._latch_state["peak_mag"][:] = 5.0
+  sensor._latch_state["force_peak"][:] = 9.0
+  sensor._latch_state["pos_at_peak"][:] = 9.0
+
+  sensor.begin_control_step()
+
+  data = sensor.data
+  assert data.found_any is not None
+  assert torch.all(~data.found_any)
+  assert data.force_peak is not None
+  assert torch.all(data.force_peak == 0)
+  assert data.pos_at_peak is not None
+  assert torch.all(data.pos_at_peak == 0)
+
+
+def test_latch_reset_scoped(device):
+  """reset(env_ids) clears the latch only for the listed envs."""
+  sensor_cfg = ContactSensorCfg(
+    name="box_contact",
+    primary=ContactMatch(mode="geom", pattern="box_geom", entity="box"),
+    secondary=None,
+    fields=("found", "force"),
+    catch_substep_contacts=True,
+  )
+
+  scene, _ = create_scene_with_sensor(FALLING_BOX_XML, "box", sensor_cfg, device)
+
+  sensor = scene["box_contact"]
+  sensor._latch_state["found_any"][:] = True
+  sensor._latch_state["peak_mag"][:] = 5.0
+  sensor._latch_state["force_peak"][:] = 9.0
+
+  sensor.reset(torch.tensor([0], device=device))
+
+  data = sensor.data
+  assert data.found_any is not None
+  assert not data.found_any[0].any()
+  assert data.found_any[1].all()
+  assert data.force_peak is not None
+  assert torch.all(data.force_peak[0] == 0)
+  assert torch.all(data.force_peak[1] == 9.0)
+
+
+def test_latch_catches_impact_missed_by_final_substep(device):
+  """Integration: a bouncing ball's brief impact latches even though the
+  final substep of the control step reports no contact."""
+  decimation = 20
+  sensor_cfg = ContactSensorCfg(
+    name="ball_contact",
+    primary=ContactMatch(mode="geom", pattern="ball_geom", entity="ball"),
+    secondary=None,
+    fields=("found", "force"),
+    catch_substep_contacts=True,
+  )
+
+  scene, sim = create_scene_with_sensor(BOUNCY_BALL_XML, "ball", sensor_cfg, device)
+
+  sensor = scene["ball_contact"]
+
+  # Drop the ball from 0.5 m and scan control-step windows around the bounces.
+  root_state = torch.zeros((2, 13), device=sim.device)
+  root_state[:, 2] = 0.5
+  root_state[:, 3] = 1.0
+  scene["ball"].write_root_state_to_sim(root_state)
+
+  latched_only = 0
+  for _ in range(40):
+    sensor.begin_control_step()
+    for _ in range(decimation):
+      sim.step()
+      scene.update(dt=sim.cfg.mujoco.timestep)
+    data = sensor.data
+    instant = data.found[:, 0] > 0
+    latched = data.found_any[:, 0]
+    assert torch.all(latched | ~instant), (
+      "found_any must be a superset of the instantaneous read"
+    )
+    latched_only += int(torch.sum(latched & ~instant).item())
+
+  assert latched_only > 0, (
+    "expected at least one control step where the impact was latched but the "
+    "final-substep snapshot reported no contact"
+  )
+
+
+##
+# Fast-ball crossing regression test.
+##
+
+
+# Ball and paddle live in one entity so both geoms resolve in the same scope.
+# The paddle is a jointless (static) thin box; the ball is launched fast
+# enough to enter and leave the paddle's contact zone within a single
+# control step of decimation substeps. Stiff near-elastic contact makes the
+# ball rebound off the paddle rather than tunnel through it.
+FAST_BALL_PADDLE_XML = """
+<mujoco>
+  <worldbody>
+    <body name="paddle" pos="0 0 0.15">
+      <geom name="paddle_geom" type="box" size="0.01 0.15 0.15" mass="100"/>
+    </body>
+    <body name="ball" pos="-0.25 0 0.15">
+      <freejoint/>
+      <geom name="ball_geom" type="sphere" size="0.033" mass="0.058"
+            solref="-100000 0"/>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+
+def test_fast_ball_crossing_latched_but_missed_by_snapshot(device):
+  """Regression: a fast ball hitting a thin paddle mid-control-step.
+
+  At 10 m/s and a 2 ms physics timestep the ball crosses the paddle's
+  contact zone in ~4 of the 20 substeps of one control step. The
+  final-substep ``found`` snapshot is 0 (the ball is already past the
+  paddle), which is exactly the tennis-style collision that motivated
+  ``catch_substep_contacts`` and the history extension.
+  """
+  decimation = 20
+  sensor_cfg = ContactSensorCfg(
+    name="ball_contact",
+    primary=ContactMatch(mode="geom", pattern="ball_geom", entity="ball"),
+    secondary=ContactMatch(mode="geom", pattern="paddle_geom", entity="ball"),
+    fields=("found", "force", "dist", "pos"),
+    history_length=decimation,
+    catch_substep_contacts=True,
+  )
+
+  scene, sim = create_scene_with_sensor(
+    FAST_BALL_PADDLE_XML, "ball", sensor_cfg, device
+  )
+
+  sensor = scene["ball_contact"]
+
+  # Launch the ball at +10 m/s from 0.25 m before the paddle plane.
+  root_state = torch.zeros((2, 13), device=sim.device)
+  root_state[:, 0] = -0.25
+  root_state[:, 2] = 0.15
+  root_state[:, 3] = 1.0
+  root_state[:, 7] = 10.0
+  scene["ball"].write_root_state_to_sim(root_state)
+
+  sensor.begin_control_step()
+  for _ in range(decimation):
+    sim.step()
+    scene.update(dt=sim.cfg.mujoco.timestep)
+
+  data = sensor.data
+
+  # The final-substep snapshot missed the collision entirely: the ball is
+  # already past the paddle.
+  assert torch.all(data.found == 0), (
+    "ball should have left the contact zone before the final substep; "
+    "tune the launch speed so the crossing fits inside one control step"
+  )
+
+  # The latch caught it.
+  assert data.found_any is not None
+  assert torch.all(data.found_any), "latch must record the mid-step collision"
+  assert data.force_peak is not None
+  assert torch.all(data.force_peak.norm(dim=-1) > 0), "impact must carry force"
+  assert data.pos_at_peak is not None
+  assert torch.all(data.pos_at_peak[..., 0].abs() < 0.1), (
+    f"impact should sit near the paddle plane, got {data.pos_at_peak[..., 0]}"
+  )
+
+  # The extended history caught it too.
+  assert data.found_history is not None
+  assert torch.all((data.found_history > 0).any(dim=-1)), (
+    "found_history must contain at least one contact substep"
+  )

--- a/tests/test_env_sensor_wiring.py
+++ b/tests/test_env_sensor_wiring.py
@@ -1,0 +1,201 @@
+"""Tests for control-step sensor wiring in the env loop.
+
+Covers the Scene forwarding hooks (begin_control_step, invalidate_sensor_caches)
+and their invocation from ManagerBasedRlEnv.step/reset.
+"""
+
+import pytest
+import torch
+from conftest import get_test_device
+from test_contact_sensor import FALLING_BOX_XML, create_scene_with_sensor
+
+from mjlab.envs import ManagerBasedRlEnv
+from mjlab.sensor.contact_sensor import ContactMatch, ContactSensorCfg
+from mjlab.sensor.sensor import Sensor
+from mjlab.tasks.cartpole.cartpole_env_cfg import cartpole_balance_env_cfg
+
+
+@pytest.fixture(scope="module")
+def device():
+  return get_test_device()
+
+
+##
+# Stub sensors.
+##
+
+
+class _RecordingSensor(Sensor):
+  """Minimal sensor that counts begin_control_step calls."""
+
+  def __init__(self, name: str):
+    super().__init__()
+    self.name = name
+    self.begin_calls = 0
+
+  def edit_spec(self, scene_spec, entities):
+    del scene_spec, entities
+
+  def initialize(self, mj_model, model, data, device):
+    del mj_model, model, data, device
+
+  def _compute_data(self):
+    return None
+
+  def begin_control_step(self):
+    self.begin_calls += 1
+
+
+##
+# Unit tests.
+##
+
+
+def test_sensor_base_begin_control_step_is_noop():
+  """The base Sensor.begin_control_step is a callable no-op."""
+  sensor = _RecordingSensor("base")
+  sensor.begin_control_step()  # Must not raise (base would, stub overrides).
+  assert sensor.begin_calls == 1
+
+
+def test_scene_begin_control_step_forwards_to_all_sensors(device):
+  """Scene.begin_control_step invokes the hook on every registered sensor."""
+  sensor_cfg = ContactSensorCfg(
+    name="box_contact",
+    primary=ContactMatch(mode="geom", pattern="box_geom", entity="box"),
+    secondary=None,
+    fields=("found",),
+  )
+  scene, _ = create_scene_with_sensor(FALLING_BOX_XML, "box", sensor_cfg, device)
+
+  stub_a = _RecordingSensor("stub_a")
+  stub_b = _RecordingSensor("stub_b")
+  scene._sensors["stub_a"] = stub_a
+  scene._sensors["stub_b"] = stub_b
+
+  scene.begin_control_step()
+
+  assert stub_a.begin_calls == 1
+  assert stub_b.begin_calls == 1
+
+
+def test_scene_invalidate_sensor_caches(device):
+  """Scene.invalidate_sensor_caches drops cached data on every sensor."""
+  sensor_cfg = ContactSensorCfg(
+    name="box_contact",
+    primary=ContactMatch(mode="geom", pattern="box_geom", entity="box"),
+    secondary=None,
+    fields=("found",),
+  )
+  scene, sim = create_scene_with_sensor(FALLING_BOX_XML, "box", sensor_cfg, device)
+
+  _ = scene["box_contact"].data  # Populate the cache.
+  sensor = scene["box_contact"]
+  assert sensor._cache_valid
+
+  scene.invalidate_sensor_caches()
+  assert not sensor._cache_valid
+
+
+##
+# Integration tests (real ManagerBasedRlEnv).
+##
+
+
+def _make_cfg():
+  cfg = cartpole_balance_env_cfg()
+  cfg.episode_length_s = 0.5
+  cfg.scene.num_envs = 4
+  # Cart and floor never touch in this scene, so the latch stays clear
+  # after begin_control_step unless the env fails to call it.
+  cfg.scene.sensors = (
+    ContactSensorCfg(
+      name="cart_floor_contact",
+      primary=ContactMatch(mode="geom", pattern="cart", entity="cartpole"),
+      secondary=ContactMatch(mode="geom", pattern="floor", entity="cartpole"),
+      fields=("found",),
+      catch_substep_contacts=True,
+    ),
+  )
+  return cfg
+
+
+def test_env_clears_latch_every_control_step(device):
+  """The contact latch set before env.step is cleared by the step boundary."""
+  env = ManagerBasedRlEnv(cfg=_make_cfg(), device=device)
+  env.reset()
+  sensor = env.scene["cart_floor_contact"]
+
+  sensor._latch_state["found_any"][:] = True
+  obs, _, _, _, _ = env.step(torch.zeros((env.num_envs, 1), device=device))
+
+  assert obs is not None
+  data = sensor.data
+  assert data.found_any is not None
+  assert torch.all(~data.found_any), (
+    "latch must be cleared at the control-step boundary"
+  )
+  env.close()
+
+
+def test_env_calls_control_step_and_cache_hooks(device, monkeypatch):
+  """env.step calls begin_control_step once and invalidates caches after forward."""
+  env = ManagerBasedRlEnv(cfg=_make_cfg(), device=device)
+  env.reset()
+
+  scene = env.scene
+  begin_calls = []
+  invalidate_calls = []
+  orig_begin = scene.begin_control_step
+  orig_invalidate = scene.invalidate_sensor_caches
+
+  monkeypatch.setattr(
+    scene,
+    "begin_control_step",
+    lambda: (begin_calls.append(1), orig_begin()),
+  )
+  monkeypatch.setattr(
+    scene,
+    "invalidate_sensor_caches",
+    lambda: (invalidate_calls.append(1), orig_invalidate()),
+  )
+
+  action = torch.zeros((env.num_envs, 1), device=device)
+  env.step(action)
+  assert len(begin_calls) == 1
+  assert len(invalidate_calls) >= 1
+
+  env.reset()
+  assert len(invalidate_calls) >= 2
+  env.close()
+
+
+def test_env_latch_covers_only_latest_control_step(device):
+  """The latch read during rewards reflects exactly the latest control step.
+
+  With decimation substeps the latch must accumulate across substeps within
+  one env.step (found_any stays False here because the cart never touches the
+  floor, but the field must be present and per-step fresh).
+  """
+  cfg = _make_cfg()
+  cfg.scene.sensors = (
+    ContactSensorCfg(
+      name="cart_floor_contact",
+      primary=ContactMatch(mode="geom", pattern="cart", entity="cartpole"),
+      secondary=ContactMatch(mode="geom", pattern="floor", entity="cartpole"),
+      fields=("found", "force"),
+      catch_substep_contacts=True,
+    ),
+  )
+  env = ManagerBasedRlEnv(cfg=cfg, device=device)
+  env.reset()
+
+  for _ in range(3):
+    obs, _, _, _, _ = env.step(torch.zeros((env.num_envs, 1), device=device))
+    sensor = env.scene["cart_floor_contact"]
+    data = sensor.data
+    assert data.found_any is not None
+    assert data.force_peak is not None
+    assert torch.all(~data.found_any)
+    assert torch.all(data.force_peak == 0)
+  env.close()


### PR DESCRIPTION
## Summary

PR #699 made built-in contact sensors decimation-safe by reading
`force_history` with a force threshold, so brief collisions that appear and
resolve within the substep loop of a control step are no longer missed. That
approach has two blind spots: it only covers the `force`/`torque`/`dist`
history fields, and it reports nothing when contact produces no force above
the threshold (or when no force field is requested at all).

This PR extends that work with three changes:

1. **History extension** — `ContactSensor` rolling history buffers (`history_length`)
   now cover every requested per-contact field (`found`, `pos`, `normal`,
   `tangent`) in addition to `force`/`torque`/`dist`.
2. **Opt-in control-step latch** — new `ContactSensorCfg.catch_substep_contacts`
   flag accumulates contacts across the substeps of each control step and exposes
   them directly on `ContactData`:
   - `found_any` `[B, N]` — contact in *any* substep since the last boundary,
     with no force threshold involved;
   - `force_peak`, `dist_at_peak`, `pos_at_peak` — the values at the
     largest-magnitude substep (deepest penetration when force is not requested).
   The env clears the latch at each control-step boundary via the new
   `Scene.begin_control_step()` hook; `reset(env_ids)` also clears it per env.
3. **Sensor cache refresh** — `ManagerBasedRlEnv` now invalidates sensor caches
   after the post-decimation `forward()`, so observation-time reads return
   post-forward sensordata instead of the stale reward-stage snapshot.

Everything is opt-in: with no config changes, all new `ContactData` fields stay
`None` and existing behavior is bit-for-bit unchanged. See
**Relation to PR #699** below for a field-by-field comparison.

## Relation to PR #699

PR #699 ("Use contact sensor history to catch collisions across decimation
substeps") added `history_length = decimation` to the built-in task sensors and
rewrote their rewards/terminations to threshold `norm(force_history)`. This PR
keeps that mechanism and builds on it:

### Added beyond #699

| capability                    | PR #699                                   | this PR                                              |
| ----------------------------- | ----------------------------------------- | ---------------------------------------------------- |
| history fields                | `force`, `torque`, `dist`                 | + `found`, `pos`, `normal`, `tangent`                |
| any-contact check             | `norm(force_history) > threshold`          | `found_any` latch, no threshold, no force field needed |
| impact location/orientation   | -                                         | `pos_at_peak` (and `normal_history`/`tangent_history`) |
| peak impact force/depth       | implicit in the history window            | `force_peak`, `dist_at_peak` — one field, no reduction code |
| control-step boundary         | implicit (history is a plain window)      | explicit `Scene.begin_control_step()` lifecycle hook |
| fast-ball demo                | bouncing-ball demo                        | `fast_ball_contact.py` rally demo (complements it)   |

### Fixed

- **Zero-force contact misses.** Thresholding `norm(force_history)` reports a
  miss when a contact registers no force above the threshold or when the sensor
  does not request `force` at all. `found_any` derives from the `found` field,
  so it latches the event in both cases.
- **Stale snapshot between reward and observation stages.** Sensor data cached
  during the reward/termination stage survived the post-decimation `forward()`,
  so observations could read an older contact snapshot than rewards (or vice
  versa, depending on which term touched the sensor first). Caches are now
  invalidated after `forward()`, so observations always reflect the
  post-decimation state — untouched by #699.

## Usage

```python
ContactSensorCfg(
  name="racket_ball",
  primary=ContactMatch(mode="geom", pattern="racket", entity="robot"),
  secondary=ContactMatch(mode="geom", pattern="ball", entity="ball"),
  fields=("found", "force", "pos"),
  catch_substep_contacts=True,   # new
)

# In a reward/termination function:
data = sensor.data
data.found_any       # [B, N] bool: hit happened anywhere in this control step
data.force_peak      # [B, N, 3] impact force at the peak-magnitude substep
data.pos_at_peak     # [B, N, 3] impact position
```

`history_length` keeps working exactly as before and composes with the latch
(`found_history` is now also available for custom windowed logic).

## Demo

`scripts/demos/fast_ball_contact.py` (modeled on `contact_sensor_decimation.py`
from PR #699) rallies a 10 m/s ball between two paddles at decimation 20.
<img width="2107" height="1136" alt="fast_ball_contact_view" src="https://github.com/user-attachments/assets/4f5acc6b-0c89-4e8d-947a-2d7f759625df" />

Over 60 control steps the ball lands 47 hits:

| detection mode                | hits found |
| ----------------------------- | ---------- |
| instantaneous `found`         | 9          |
| `force_history` reduction (#699 style) | 47 |
| `found_any` latch (this PR)   | 47         |

i.e. 38 of 47 hits (81%) are invisible to a snapshot read. The remaining
`force_history`-style detection still needs a force field and a threshold;
the latch answers "did it touch" from `found` alone. Run it with:

```
uv run python scripts/demos/fast_ball_contact.py
uv run python scripts/demos/fast_ball_contact.py --viewer
```

## Test plan

- 19 new tests:
  - `tests/test_contact_sensor.py`: history shape/ordering/reset for the new
    fields, latch OR semantics, peak selection vs. a cloned per-substep
    sequence, boundary/reset clearing, a "found is None / found_any is None"
    compatibility check, cfg validation, and a bouncing-ball integration test
    where an impact that resolves mid-window is latched while the final-substep
    snapshot is empty.
  - `tests/test_env_sensor_wiring.py`: `Scene.begin_control_step` forwarding,
    `Scene.invalidate_sensor_caches`, and real `ManagerBasedRlEnv` integration
    (latch cleared once per control step; caches dropped after `forward()` in
    both `step()` and `reset()` paths).
  - A fast-ball/thin-paddle regression test: at 10 m/s and 2 ms timestep the
    ball crosses the paddle's contact zone in ~4 of 20 substeps; the test
    asserts `found == 0` while `found_any` latches the hit and
    `found_history` captures it.
- All new tests pass on CUDA (RTX 3050) and CPU (`FORCE_CPU=1`).
- `make test-all` passes: `ruff format`, `ruff check`, `ty check`, `pyright`
  (0 errors), and the full suite (1101 passed).

## Checklist

- [x] Changelog entries added under "Upcoming version" (`docs/source/changelog.rst`),
      framed as an extension of the #699 detection.
- [x] `ContactSensorCfg` / `ContactData` docstrings updated for the new option
      and fields.
- [x] Formatting, type checking, and tests pass (`make test-all`).
- [x] No default-behavior change: latch outputs are `None` unless

